### PR TITLE
fix(validation): add graceful error handling for unresolvable @context

### DIFF
--- a/src/tools/utils/graph_loader.py
+++ b/src/tools/utils/graph_loader.py
@@ -221,12 +221,22 @@ def load_jsonld_files(
                 graph.parse(str(json_file), format="json-ld")
         except Exception as e:
             logger.error("Failed to load %s: %s", rel_path, e)
-            if "HTTP Error" in str(e) or "urlopen error" in str(e):
+            err_str = str(e)
+            if "HTTP Error" in err_str or "urlopen error" in err_str:
                 raise RuntimeError(
                     f"Failed to load {rel_path}: could not fetch remote @context URL.\n"
                     f"  Cause: {e}\n"
                     f"  Hint: Ensure all @context URLs are mapped to local files via "
                     f"--artifacts, or check that the URL is published and reachable."
+                ) from e
+            if "Invalid IRI" in err_str or isinstance(e, ValueError):
+                raise RuntimeError(
+                    f"Failed to load {rel_path}: invalid IRI encountered during "
+                    f"JSON-LD parsing.\n"
+                    f"  Cause: {e}\n"
+                    f"  Hint: Check that all @context URLs are mapped to local files "
+                    f"via --artifacts. A missing context mapping can cause bare terms "
+                    f"to produce invalid IRIs."
                 ) from e
             raise
 

--- a/src/tools/validators/validation_suite.py
+++ b/src/tools/validators/validation_suite.py
@@ -270,7 +270,7 @@ def validate_data_conformance_all(
         # Use catalog-based validation method
         try:
             result = validator.validate_from_catalog(domain, test_type="valid")
-        except RuntimeError as e:
+        except (RuntimeError, ValueError) as e:
             print(f"\n\u274c {e}", file=sys.stderr, flush=True)
             return 1
 


### PR DESCRIPTION
fix(validation): add graceful error handling for unresolvable @context URLs
* Wrap HTTP/URL fetch failures in RuntimeError with actionable hint message in graph_loader.py
* Catch RuntimeError in validation_suite.py for clean error output instead of raw tracebacks
* Improve error handling for invalid IRIs