### PR TITLE
fix(ontology): align xsd datatypes between SHACL shapes and JSON-LD instances

### DIFF
--- a/artifacts/simulation-model/simulation-model.owl.ttl
+++ b/artifacts/simulation-model/simulation-model.owl.ttl
@@ -276,12 +276,12 @@ simulation-model:sensorTechnologyVariant a owl:DatatypeProperty ;
 simulation-model:maxDetections a owl:DatatypeProperty ;
     rdfs:label "maximum number of detections"@en ;
     rdfs:domain simulation-model:Quantity ;
-    rdfs:range xsd:unsignedInt .
+    rdfs:range xsd:integer .
 
 simulation-model:maxObjects a owl:DatatypeProperty ;
     rdfs:label "maximum number of detected objects"@en ;
     rdfs:domain simulation-model:Quantity ;
-    rdfs:range xsd:unsignedInt .
+    rdfs:range xsd:integer .
 
 # Quality properties
 simulation-model:modelLimitations a owl:DatatypeProperty ;

--- a/tests/data/environment-model/valid/environment-model_instance.json
+++ b/tests/data/environment-model/valid/environment-model_instance.json
@@ -73,15 +73,15 @@
       "@type": "environment-model:Quantity",
       "environment-model:textureMaterialCount": {
         "@value": "179",
-        "@type": "xsd:unsignedInt"
+        "@type": "xsd:integer"
       },
       "environment-model:triangleCount": {
         "@value": "12456",
-        "@type": "xsd:unsignedInt"
+        "@type": "xsd:integer"
       },
       "environment-model:geometryCount": {
         "@value": "5000",
-        "@type": "xsd:unsignedInt"
+        "@type": "xsd:integer"
       }
     },
     "environment-model:hasQuality": {

--- a/tests/data/hdmap/invalid/fail01_false_value_hdmap_instance.json
+++ b/tests/data/hdmap/invalid/fail01_false_value_hdmap_instance.json
@@ -71,23 +71,23 @@
       },
       "hdmap:numberIntersections": {
         "@value": "5",
-        "@type": "xsd:unsignedInt"
+        "@type": "xsd:integer"
       },
       "hdmap:numberTrafficLights": {
         "@value": "0",
-        "@type": "xsd:unsignedInt"
+        "@type": "xsd:integer"
       },
       "hdmap:numberTrafficSigns": {
         "@value": "155",
-        "@type": "xsd:unsignedInt"
+        "@type": "xsd:integer"
       },
       "hdmap:numberObjects": {
         "@value": "200",
-        "@type": "xsd:unsignedInt"
+        "@type": "xsd:integer"
       },
       "hdmap:numberOutlines": {
         "@value": "100",
-        "@type": "xsd:unsignedInt"
+        "@type": "xsd:integer"
       },
       "hdmap:speedLimit": {
         "@type": "hdmap:Range2D",

--- a/tests/data/hdmap/valid/hdmap_instance.json
+++ b/tests/data/hdmap/valid/hdmap_instance.json
@@ -59,23 +59,23 @@
       },
       "hdmap:numberIntersections": {
         "@value": "5",
-        "@type": "xsd:unsignedInt"
+        "@type": "xsd:integer"
       },
       "hdmap:numberTrafficLights": {
         "@value": "0",
-        "@type": "xsd:unsignedInt"
+        "@type": "xsd:integer"
       },
       "hdmap:numberTrafficSigns": {
         "@value": "155",
-        "@type": "xsd:unsignedInt"
+        "@type": "xsd:integer"
       },
       "hdmap:numberObjects": {
         "@value": "200",
-        "@type": "xsd:unsignedInt"
+        "@type": "xsd:integer"
       },
       "hdmap:numberOutlines": {
         "@value": "100",
-        "@type": "xsd:unsignedInt"
+        "@type": "xsd:integer"
       },
       "hdmap:speedLimit": {
         "@type": "hdmap:Range2D",

--- a/tests/data/scenario/invalid/fail01_false_value_scenario_instance.json
+++ b/tests/data/scenario/invalid/fail01_false_value_scenario_instance.json
@@ -109,15 +109,15 @@
       "@type": "scenario:Quantity",
       "scenario:numberTrafficObjects": {
         "@value": "1",
-        "@type": "xsd:unsignedInt"
+        "@type": "xsd:integer"
       },
       "scenario:temporaryTrafficObjects": {
         "@value": "0",
-        "@type": "xsd:unsignedInt"
+        "@type": "xsd:integer"
       },
       "scenario:permanentTrafficObjects": {
         "@value": "1",
-        "@type": "xsd:unsignedInt"
+        "@type": "xsd:integer"
       },
       "scenario:controllers": {
         "@value": "SampleController1",

--- a/tests/data/scenario/valid/scenario_instance.json
+++ b/tests/data/scenario/valid/scenario_instance.json
@@ -102,15 +102,15 @@
       "@type": "scenario:Quantity",
       "scenario:numberTrafficObjects": {
         "@value": 1,
-        "@type": "xsd:unsignedInt"
+        "@type": "xsd:integer"
       },
       "scenario:temporaryTrafficObjects": {
         "@value": 0,
-        "@type": "xsd:unsignedInt"
+        "@type": "xsd:integer"
       },
       "scenario:permanentTrafficObjects": {
         "@value": 1,
-        "@type": "xsd:unsignedInt"
+        "@type": "xsd:integer"
       },
       "scenario:controllers": {
         "@value": "SampleController1",

--- a/tests/data/simulation-model/valid/simulation-model_instance.json
+++ b/tests/data/simulation-model/valid/simulation-model_instance.json
@@ -152,11 +152,11 @@
       "@type": "simulation-model:Quantity",
       "simulation-model:maxDetections": {
         "@value": "800",
-        "@type": "xsd:unsignedInt"
+        "@type": "xsd:integer"
       },
       "simulation-model:maxObjects": {
         "@value": "50",
-        "@type": "xsd:unsignedInt"
+        "@type": "xsd:integer"
       }
     },
     "simulation-model:hasDataSource": {


### PR DESCRIPTION
## Summary

Fixes the  mismatch between SHACL shape definitions and JSON-LD test instances reported in #11.

The SHACL shapes define properties like `numberIntersections`, `numberTrafficLights`, etc. as `xsd:integer`, but the JSON-LD test instances were using `xsd:unsignedInt`. This caused SHACL validation failures (e.g. in the [SHACL Playground](https://shacl.org/playground/)) because `xsd:unsignedInt` is not a subtype of `xsd:integer` in strict datatype matching.

## Changes

- **JSON-LD test instances**: Changed `xsd:unsignedInt` → `xsd:integer` in all affected domains:
  - `hdmap` (valid + invalid instances): `numberIntersections`, `numberTrafficLights`, `numberTrafficSigns`, `numberObjects`, `numberOutlines`
  - `scenario` (valid + invalid): `numberTrafficObjects`, `temporaryTrafficObjects`, `permanentTrafficObjects`
  - `environment-model` (valid): `textureMaterialCount`, `triangleCount`, `geometryCount`
  - `simulation-model` (valid): `maxDetections`, `maxObjects`
- **OWL ontology**: Updated `simulation-model.owl.ttl` — changed `rdfs:range` from `xsd:unsignedInt` to `xsd:integer` for `maxDetections` and `maxObjects` properties

## Testing

- [x] Full validation suite passes for all affected domains (`hdmap`, `scenario`, `environment-model`, `simulation-model`)
- [x] Syntax checks pass (JSON-LD + Turtle)
- [x] Artifact coherence checks pass
- [x] SHACL conformance checks pass
- [x] Failing tests (invalid instances) still correctly fail as expected

## Related Issues

Closes #11