### PR TITLE
fix: use python instead of python3 in pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,21 +28,21 @@ repos:
 
       - id: jsonld-lint
         name: JSON-LD Parser
-        entry: python3 -m src.tools.validators.syntax_validator --json
+        entry: python -m src.tools.validators.syntax_validator --json
         language: system
         types: [json]
         files: \.(json|jsonld)$
 
       - id: turtle-lint
         name: Turtle Parser
-        entry: python3 -m src.tools.validators.syntax_validator --turtle
+        entry: python -m src.tools.validators.syntax_validator --turtle
         language: system
         types: [text]
         files: \.(ttl)$
 
       - id: update-context
         name: Update JSON-LD Contexts
-        entry: python3 -m src.tools.utils.context_generator --all
+        entry: python -m src.tools.utils.context_generator --all
         language: system
         pass_filenames: false
         files: ^artifacts/.*\.(owl\.ttl|shacl\.ttl)$
@@ -50,7 +50,7 @@ repos:
 
       - id: update-registry
         name: Update Ontology Registry and Catalog
-        entry: python3 -m src.tools.utils.registry_updater
+        entry: python -m src.tools.utils.registry_updater
         language: system
         pass_filenames: false
         files: ^artifacts/.*\.(owl\.ttl|shacl\.ttl|context\.jsonld)$
@@ -58,7 +58,7 @@ repos:
 
       - id: update-properties
         name: Update Properties Documentation
-        entry: python3 -m src.tools.utils.properties_updater
+        entry: python -m src.tools.utils.properties_updater
         language: system
         pass_filenames: false
         files: ^artifacts/.*\.(owl\.ttl|shacl\.ttl|context\.jsonld)$
@@ -66,7 +66,7 @@ repos:
 
       - id: update-readme
         name: Update README Catalog Table
-        entry: python3 -m src.tools.utils.readme_updater
+        entry: python -m src.tools.utils.readme_updater
         language: system
         pass_filenames: false
         files: ^artifacts/.*\.(owl\.ttl|shacl\.ttl|context\.jsonld)$


### PR DESCRIPTION
## Summary

Use `python` instead of `python3` in pre-commit hook entries to fix cross-platform compatibility.

## Problem

Windows Python venvs only create `python.exe` — not `python3.exe`. The pre-commit hooks using `language: system` with `entry: python3 -m ...` fail on Windows with:

\\\
Executable \python3\ not found
\\\

## Fix

Changed all 6 hook entries from `python3` to `python`. Both Linux and Windows venvs always have `python` pointing to the correct interpreter.

## Changes

- `.pre-commit-config.yaml`: `python3` → `python` in all 6 local hook entries (jsonld-lint, turtle-lint, update-context, update-registry, update-properties, update-readme)

## Testing

- [x] All pre-commit hooks pass on Windows (`pre-commit run --all-files`)
- [x] No behavioral change on Linux (`python` and `python3` are equivalent in a venv)

## Checklist

- [x] My code follows the modelling guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] New and existing unit tests pass locally with my changes