### PR TITLE
fix(ci): correct release notes generation for manual triggers

### DIFF
--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -68,6 +68,17 @@ jobs:
           git commit -s -m "chore: update registry for ${{ steps.tag.outputs.tag }} [skip ci]" || echo "No changes to commit"
           git push origin main || echo "Push failed - may need manual intervention"
 
+      - name: Ensure release tag exists for changelog generation
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          if ! git rev-parse "$TAG" >/dev/null 2>&1; then
+            git tag "$TAG"
+            echo "Created temporary tag $TAG at $(git rev-parse HEAD)"
+          else
+            echo "Tag $TAG already exists"
+          fi
+
       - name: Generate changelog
         id: changelog
         uses: orhun/git-cliff-action@v4

--- a/cliff.toml
+++ b/cliff.toml
@@ -30,6 +30,11 @@ conventional_commits = true
 filter_unconventional = false
 # process each line of a commit as an individual commit
 split_commits = false
+# strip trailing PR references from commit messages to avoid duplicates
+# (the template already adds a linked PR reference via commit.remote.pr_number)
+commit_preprocessors = [
+    { pattern = ' *\(#\d+\)$', replace = "" },
+]
 # sort the tags topologically
 topo_order = false
 # sort the commits inside sections by oldest/newest order

--- a/docs/ecosystem/release-process.md
+++ b/docs/ecosystem/release-process.md
@@ -1,0 +1,105 @@
+# Release Process
+
+This guide describes how maintainers create a new release of the ontology repository.
+
+## Prerequisites
+
+Before creating a release, ensure:
+
+- [ ] All PRs for the release are merged into `main`
+- [ ] `pyproject.toml` version is updated (e.g., `version = "0.2.0"`)
+- [ ] Validation passes: `make test`
+- [ ] Pre-commit hooks pass: `make lint`
+
+## Creating a Release
+
+### Option A — Tag Push (Recommended)
+
+Create a signed, annotated tag and push it. The release workflow triggers automatically.
+
+```bash
+git checkout main
+git pull origin main
+git tag -a -s v0.2.0 -m "v0.2.0"
+git push origin v0.2.0
+```
+
+This is the preferred method because:
+
+- The tag is GPG-signed and annotated (matches repository signing policy).
+- The tag exists before the workflow runs, so changelog generation resolves the correct commit range.
+- The tag is immutable — it points to the exact commit you reviewed.
+
+### Option B — Manual Workflow Dispatch
+
+Use the GitHub Actions UI when you need to re-run a release or the tag already exists.
+
+1. Go to **Actions** → **Release** → **Run workflow**.
+2. Enter the release tag (e.g., `v0.2.0`).
+3. Click **Run workflow**.
+
+!!! warning "Tag must exist first"
+    If the tag does not yet exist as a git tag, the workflow creates a lightweight
+    tag at the current `main` HEAD. Prefer Option A to get a signed, annotated tag.
+
+## What the Workflow Does
+
+The [`cd-release.yml`](https://github.com/ASCS-eV/ontology-management-base/blob/main/.github/workflows/cd-release.yml) workflow runs these steps in order:
+
+```mermaid
+flowchart LR
+    A[Update registry] --> B[Commit to main]
+    B --> C[Generate changelog]
+    C --> D[Create GitHub Release]
+    D --> E[Build docs + W3ID artifacts]
+```
+
+| Step | Detail |
+|------|--------|
+| **Update registry** | Runs `registry_updater` with `--release-tag` to update `docs/registry.json` |
+| **Commit to main** | Pushes the registry update back to `main` (skips CI) |
+| **Generate changelog** | Uses [git-cliff](https://git-cliff.org/) with `cliff.toml` to produce release notes from conventional commits |
+| **Create GitHub Release** | Publishes the release on GitHub with the generated notes |
+| **Build docs + W3ID** | Triggers `cd-docs.yml` to build documentation and versioned W3ID artifacts from the immutable tag |
+
+## Versioning
+
+The repository uses [Semantic Versioning](https://semver.org/):
+
+| Change | Bump | Example |
+|--------|------|---------|
+| Bug fix or non-breaking ontology correction | Patch | `v0.1.3` → `v0.1.4` |
+| New domain or backward-compatible additions | Minor | `v0.1.4` → `v0.2.0` |
+| Breaking change (existing Self-Descriptions become invalid) | Major | `v0.2.0` → `v1.0.0` |
+
+Update the version in `pyproject.toml` before tagging:
+
+```toml
+[project]
+version = "0.2.0"
+```
+
+## Changelog Generation
+
+Release notes are auto-generated from [Conventional Commits](https://www.conventionalcommits.org/) using [git-cliff](https://git-cliff.org/). Commit prefixes map to sections:
+
+| Prefix | Section |
+|--------|---------|
+| `feat:` | Features |
+| `fix:` | Bug Fixes |
+| `docs:` | Documentation |
+| `refactor:` | Refactoring |
+| `test:` | Testing |
+| `ci:` | CI/CD |
+| `chore:` | Maintenance |
+
+Configuration lives in [`cliff.toml`](https://github.com/ASCS-eV/ontology-management-base/blob/main/cliff.toml).
+
+## Post-Release Verification
+
+After the workflow completes, verify:
+
+- [ ] [GitHub Release](https://github.com/ASCS-eV/ontology-management-base/releases) exists with correct notes
+- [ ] `docs/registry.json` on `main` reflects the new tag
+- [ ] [Documentation site](https://ascs-ev.github.io/ontology-management-base/) is updated
+- [ ] W3ID IRIs resolve (e.g., `https://w3id.org/ascs-ev/envited-x/{domain}/v{n}`)

--- a/docs/getting-started/contribute.md
+++ b/docs/getting-started/contribute.md
@@ -49,6 +49,11 @@ Hook flow (via `hooks/copy_artifacts.py`):
 4. The hook copies `artifacts/<domain>/` into `docs/artifacts/<domain>/<versionInfo>/` and adds example instances from `tests/data/`.
 5. Generated folders (`docs/artifacts/`, `docs/ontologies/classes/`, `docs/ontologies/properties/`) are ignored by git.
 
+## Releasing
+
+See the [Release Process](../ecosystem/release-process.md) guide for how maintainers
+create tagged releases and publish documentation.
+
 ## Review Checklist
 
 - Ontology IRI and version are consistent

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -141,6 +141,7 @@ nav:
       - Domain Migration Guide: gaiax/gx-domain-migration.md
   - ENVITED Ecosystem:
       - ENVITED-X Data Space: ecosystem/envited-x.md
+      - Release Process: ecosystem/release-process.md
       - Long-Term Maintenance: ecosystem/maintenance.md
   - Future:
       - LinkML Migration: future/linkml.md


### PR DESCRIPTION
# Description

Fixes two bugs in the release workflow that caused v0.1.4's release notes to be incorrect,
and adds a release process guide so maintainers know the recommended procedure.

**Bug 1 — Wrong commit range on `workflow_dispatch`:**
When the release workflow is triggered manually, the specified tag doesn't exist yet as a git tag.
`git-cliff --latest` then resolves to the *previous* tag's range, producing a duplicate of the
last release's notes. Fixed by creating a lightweight tag before running git-cliff so `--latest`
computes the correct range.

**Bug 2 — Duplicate PR links:**
GitHub squash-merge commits include `(#NN)` in the subject line. The `cliff.toml` template then
appends *another* `([#NN](url))` via `commit.remote.pr_number`, causing every PR reference to
appear twice. Fixed by adding a `commit_preprocessors` rule that strips the trailing `(#NN)`
from commit messages before template rendering.

**Documentation:**
Added `docs/ecosystem/release-process.md` covering the recommended release workflow (signed tag
push), versioning policy, changelog generation, and post-release verification checklist.
Cross-referenced from the contribute guide.

## 🏗️ Type of change

- [x] Change (non-breaking change or fix on an existing type)

## 🧪 How Has This Been Tested?

- Verified v0.1.3 and v0.1.4 release notes both exhibit the duplicate PR link issue
- Confirmed v0.1.4 release notes are an exact copy of v0.1.3 (wrong range)
- Traced root cause: `--latest` picks up v0.1.3's range because v0.1.4 tag doesn't exist during `workflow_dispatch`
- Validated the `commit_preprocessors` regex strips `(#30)` patterns correctly

## ✅ Checklist

- [x] My code follows the modelling guidelines of this project
- [x] I have performed a self-review of my own changes
- [ ] I have updated the version number in the ontology file (if applicable)
- [x] New and existing unit tests pass locally with my changes
