### PR TITLE
fix(ci): replace broken gh-pages W3ID persistence with cache branch

### DIFF
--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -40,7 +40,7 @@ on:
 
 # Sets permissions of the GITHUB_TOKEN
 permissions:
-  contents: read
+  contents: write   # Required to persist W3ID artifacts to w3id-content branch
   pages: write
   id-token: write
 
@@ -170,24 +170,22 @@ jobs:
               shutil.copy2(version_dir / "context.jsonld", latest_dir / "context.jsonld")
           PY
 
-      - name: Fetch existing W3ID artifacts (gh-pages)
+      - name: Fetch cached W3ID artifacts
         uses: actions/checkout@v4
         with:
-          ref: gh-pages
-          path: gh-pages
+          ref: w3id-content
+          path: w3id-cache
           fetch-depth: 1
         continue-on-error: true
 
       - name: Preserve W3ID artifacts
         run: |
-          if [ -d gh-pages/w3id ]; then
-            # Restore all previously-published W3ID artifacts from gh-pages.
-            # During releases (build_w3id=true): fresh build takes precedence
-            # for the newly released version; old versions are preserved.
-            # During main pushes (build_w3id=false): no fresh w3id artifacts
-            # exist, so everything is restored from gh-pages unchanged.
-            find gh-pages/w3id -type f | while read -r src; do
-              rel="${src#gh-pages/w3id/}"
+          # Merge cached W3ID artifacts into the site.
+          # Previously-published versions that are NOT in the fresh build
+          # are preserved; freshly-built versions take precedence.
+          if [ -d w3id-cache ] && [ ! -f w3id-cache/.empty ]; then
+            find w3id-cache -type f -not -path '*/\.git/*' | while read -r src; do
+              rel="${src#w3id-cache/}"
               dest="site/w3id/$rel"
               if [ ! -f "$dest" ]; then
                 mkdir -p "$(dirname "$dest")"
@@ -200,6 +198,27 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./site
+
+      - name: Persist W3ID artifacts to cache branch
+        run: |
+          # Push the merged W3ID directory to the w3id-content branch so
+          # future deploys can restore all previously-released versions.
+          if [ ! -d site/w3id ] || [ -z "$(find site/w3id -type f -print -quit 2>/dev/null)" ]; then
+            echo "No W3ID artifacts to persist — skipping."
+            exit 0
+          fi
+          TMPDIR=$(mktemp -d)
+          cp -r site/w3id/* "$TMPDIR/"
+          cd "$TMPDIR"
+          git init -b w3id-content
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "chore: update W3ID artifacts cache [skip ci]"
+          git remote add origin \
+            "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git"
+          git push --force origin w3id-content
+          rm -rf "$TMPDIR"
 
   deploy:
     name: 🚀 Deploy to GitHub Pages

--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -111,6 +111,6 @@ jobs:
       ref: ${{ needs.release.outputs.tag }}
       build_w3id: true
     permissions:
-      contents: read
+      contents: write  # Required for W3ID artifact cache branch
       pages: write
       id-token: write


### PR DESCRIPTION
## Problem

The Documentation workflow preserved W3ID artifacts (ontology.ttl, shapes.ttl, context.jsonld) between deployments by checking out a `gh-pages` branch. However, `deploy-pages@v4` uses **artifact-based deployment** and never creates a `gh-pages` branch.

Every `git fetch gh-pages` failed silently (`continue-on-error: true`), so the Preserve step found nothing. Each successful docs deploy then replaced GitHub Pages **without** W3ID artifacts, wiping all previously-released ontology/shapes/context files served via w3id.org content negotiation.

## Root Cause

```
Fetch existing W3ID artifacts (gh-pages)
  → git fetch gh-pages   ❌ branch does not exist (3 retries, all fail)
  → continue-on-error: true   (silently swallowed)

Preserve W3ID artifacts
  → if [ -d gh-pages/w3id ]   ❌ directory empty
  → nothing preserved

Upload & Deploy
  → site deployed WITHOUT /w3id/ directory
  → all w3id.org → GitHub Pages redirects return 404
```

## Fix

- Replace `gh-pages` checkout with a dedicated **`w3id-content`** cache branch
- After building the site artifact, persist the merged W3ID directory to `w3id-content` via force-push
- On **push-to-main** (`build_w3id=false`): no fresh w3id artifacts built, but everything restored from cache → **self-healing**
- On **release** (`build_w3id=true`): fresh build for the new version, old versions preserved from cache
- Upgrade `permissions.contents` from `read` to `write` in both `cd-docs.yml` and `cd-release.yml`

## Post-merge: seed the cache

After merging, trigger **Documentation** `workflow_dispatch` with `build_w3id: true` for these tags **in order**:

| Order | Ref | Publishes |
|-------|-----|-----------|
| 1 | `v0.1.2` | Gen 1: hdmap/v5, ositrace/v5, scenario/v5, leakage-test/v2, simulation-model/v2, + all unchanged domains |
| 2 | `v0.1.4` | Gen 2: hdmap/v6, ositrace/v6, scenario/v6, leakage-test/v3, simulation-model/v3 (preserves gen 1 from cache) |

Tags v0.1.0/v0.1.1 are skipped (identical versionIRIs to v0.1.2). Tag v0.1.3 is skipped (identical versionIRIs to v0.1.4).

Domains **without** w3id.org IRIs (`gx`, `openlabel` v1) are correctly excluded by the `w3id_path()` filter.