### PR TITLE
feat(resolver): add online did:web resolution with SSRF hardening

### DIFF
--- a/src/tools/core/iri_utils.py
+++ b/src/tools/core/iri_utils.py
@@ -12,8 +12,9 @@ FEATURE SET:
 2. get_namespace - Extract namespace from URI (before # or last /)
 3. is_did_web - Check if IRI is a did:web: decentralized identifier
 4. parse_did_web - Parse did:web: IRI into components
-5. normalize_iri - Normalize IRI for comparison (trailing slash handling)
-6. iri_to_domain - Extract domain hint from ontology IRI
+5. did_web_to_url - Convert did:web identifiers to HTTPS did.json URLs
+6. normalize_iri - Normalize IRI for comparison (trailing slash handling)
+7. iri_to_domain - Extract domain hint from ontology IRI
 
 USAGE:
 ======
@@ -146,13 +147,13 @@ def parse_did_web(iri: str) -> Optional[Dict[str, str]]:
     if not is_did_web(iri):
         return None
 
-    # Remove "did:web:" prefix
-    remainder = iri[8:]
+    # Strip DID URL path/query/fragment so we operate on the DID itself.
+    remainder = re.split(r"[/?#]", iri[8:], maxsplit=1)[0]
 
     # Split into parts (: separated in did:web)
     parts = remainder.split(":")
 
-    if len(parts) < 1:
+    if len(parts) < 1 or any(part == "" for part in parts):
         return None
 
     host = unquote(parts[0])
@@ -169,6 +170,91 @@ def parse_did_web(iri: str) -> Optional[Dict[str, str]]:
         "type": type_name,
         "id": resource_id,
     }
+
+
+def did_web_to_url(iri: str) -> Optional[str]:
+    """
+    Convert a did:web identifier to its HTTPS ``did.json`` document URL.
+
+    Args:
+        iri: did:web: IRI string
+
+    Returns:
+        HTTPS URL for the DID document, or None if the input is not did:web
+
+    Examples:
+        >>> did_web_to_url("did:web:example.com")
+        'https://example.com/.well-known/did.json'
+        >>> did_web_to_url("did:web:example.com:user:alice")
+        'https://example.com/user/alice/did.json'
+        >>> did_web_to_url("did:web:example.com%3A3000")
+        'https://example.com:3000/.well-known/did.json'
+    """
+    if not is_did_web(iri):
+        return None
+
+    remainder = re.split(r"[/?#]", iri[8:], maxsplit=1)[0]
+    raw_parts = remainder.split(":")
+    if not raw_parts or any(part == "" for part in raw_parts):
+        return None
+
+    host, *path_segments = [unquote(part) for part in raw_parts]
+
+    if any(ch.isspace() or ch in "@/\\?#[]" for ch in host):
+        return None
+    if host.count(":") > 1:
+        return None
+
+    host_name = host
+    if ":" in host:
+        host_name, port = host.rsplit(":", 1)
+        if not port.isdigit():
+            return None
+        port_num = int(port)
+        if port_num < 1 or port_num > 65535:
+            return None
+
+    labels = host_name.split(".")
+    if not host_name or any(
+        not re.fullmatch(r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?", label)
+        for label in labels
+    ):
+        return None
+
+    # Reject single-label hostnames (no dots) — they are ambiguous and
+    # typically resolve to internal services (e.g. "localhost", "metadata").
+    if len(labels) < 2:
+        return None
+
+    # Reject localhost and private/link-local IP addresses to prevent SSRF.
+    _lower = host_name.lower()
+    if _lower in ("localhost", "localhost.localdomain"):
+        return None
+    try:
+        import ipaddress
+
+        addr = ipaddress.ip_address(_lower)
+        if (
+            addr.is_loopback
+            or addr.is_private
+            or addr.is_link_local
+            or addr.is_reserved
+        ):
+            return None
+    except ValueError:
+        pass  # not an IP literal — good
+
+    for segment in path_segments:
+        if (
+            not segment
+            or segment in (".", "..")
+            or any(ch.isspace() or ch in "/\\?#@" for ch in segment)
+        ):
+            return None
+
+    if path_segments:
+        return f"https://{host}/{'/'.join(path_segments)}/did.json"
+    return f"https://{host}/.well-known/did.json"
 
 
 def normalize_iri(iri: str, trailing_slash: bool = True) -> str:
@@ -424,6 +510,15 @@ def _run_tests() -> bool:
         print("PASS: matches_namespace")
     except AssertionError as e:
         print(f"FAIL: matches_namespace - {e}")
+        all_passed = False
+
+    # Test 13: did_web_to_url
+    try:
+        result = did_web_to_url("did:web:example.com:user:alice")
+        assert result == "https://example.com/user/alice/did.json"
+        print("PASS: did_web_to_url")
+    except AssertionError as e:
+        print(f"FAIL: did_web_to_url - {e}")
         all_passed = False
 
     print()

--- a/src/tools/utils/context_resolver.py
+++ b/src/tools/utils/context_resolver.py
@@ -196,6 +196,45 @@ def _collect_unresolved_context_urls(
     return sorted(unresolved)
 
 
+def inline_jsonld_with_local_contexts(
+    data: Union[dict, list],
+    url_map: Optional[Dict[str, Path]],
+    uri_tweaks: Optional[Dict[str, str]] = None,
+    source_name: Optional[Union[str, Path]] = None,
+) -> str:
+    """
+    Inline known local contexts into already-loaded JSON-LD content.
+
+    Args:
+        data: Parsed JSON-LD document content
+        url_map: Context URL -> local file mapping (None to skip)
+        uri_tweaks: IRI replacements. Defaults to ``DEFAULT_URI_TWEAKS``.
+        source_name: Optional name used in unresolved-context warnings
+
+    Returns:
+        JSON string ready for rdflib parsing
+    """
+    if uri_tweaks is None:
+        uri_tweaks = DEFAULT_URI_TWEAKS
+
+    if url_map:
+        data = _inline_contexts_recursive(data, url_map, uri_tweaks)
+        unresolved = _collect_unresolved_context_urls(data, url_map)
+        if unresolved:
+            logger.warning(
+                "Unresolved @context URL(s) in %s (rdflib will fetch remotely): %s",
+                source_name or "<json-ld>",
+                ", ".join(unresolved),
+            )
+
+    result = json.dumps(data)
+
+    for old, new in uri_tweaks.items():
+        result = result.replace(old, new)
+
+    return result
+
+
 def load_jsonld_with_local_contexts(
     file_path: Path,
     url_map: Optional[Dict[str, Path]],
@@ -223,20 +262,9 @@ def load_jsonld_with_local_contexts(
     with open(file_path, "r", encoding="utf-8") as f:
         data = json.load(f)
 
-    if url_map:
-        data = _inline_contexts_recursive(data, url_map, uri_tweaks)
-        unresolved = _collect_unresolved_context_urls(data, url_map)
-        if unresolved:
-            logger.warning(
-                "Unresolved @context URL(s) in %s (rdflib will fetch remotely): %s",
-                file_path,
-                ", ".join(unresolved),
-            )
-
-    result = json.dumps(data)
-
-    # Also apply URI tweaks to the main document content
-    for old, new in uri_tweaks.items():
-        result = result.replace(old, new)
-
-    return result
+    return inline_jsonld_with_local_contexts(
+        data,
+        url_map,
+        uri_tweaks=uri_tweaks,
+        source_name=file_path,
+    )

--- a/src/tools/utils/graph_loader.py
+++ b/src/tools/utils/graph_loader.py
@@ -22,10 +22,10 @@ load_fixtures_for_iris implements a catalog-first resolution strategy:
    - Fast, offline, deterministic
 
 2. Online Fallback (Optional)
-   - For http:// and https:// IRIs not found in catalog
+   - For did:web, http://, and https:// IRIs not found in catalog
    - Logs warning but continues validation
-   - Disabled by default (allow_online_fallback=False)
-   - Enable via --allow-online CLI flag
+   - Enabled by default in the validation pipeline
+   - Disable via --offline when fully local-only behavior is required
 
 3. Graceful Handling
    - Unresolved IRIs are collected and returned
@@ -70,15 +70,17 @@ NOTES:
 
 import argparse
 import json
+import re
 import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
+from urllib.request import Request, build_opener, HTTPSHandler
 
 import rdflib
 from rdflib import Graph
 
 from src.tools.core.constants import FAST_STORE
-from src.tools.core.iri_utils import is_did_web
+from src.tools.core.iri_utils import did_web_to_url, is_did_web
 from src.tools.core.logging import get_logger
 from src.tools.utils.print_formatter import normalize_path_for_display
 
@@ -307,13 +309,75 @@ def load_jsonld_with_context(file_path: Path) -> Tuple[Graph, Dict[str, str]]:
     return graph, prefixes
 
 
+def _load_online_did_web_document(
+    iri: str,
+    graph: Graph,
+    context_url_map: Optional[Dict[str, Path]] = None,
+) -> str:
+    """Fetch and load a did:web document into the graph."""
+    requested_did = re.split(r"[/?#]", iri, maxsplit=1)[0]
+    document_url = did_web_to_url(iri)
+    if not document_url:
+        raise ValueError(f"Not a did:web identifier: {iri}")
+
+    request = Request(
+        document_url,
+        headers={
+            "Accept": (
+                "application/did+ld+json, application/did+json, "
+                "application/ld+json, application/json"
+            )
+        },
+    )
+
+    # Use a custom opener that does NOT follow redirects to prevent SSRF
+    # via attacker-controlled 3xx responses targeting internal services.
+    _no_redirect_opener = build_opener(HTTPSHandler)
+
+    with _no_redirect_opener.open(request, timeout=10) as response:
+        payload = response.read().decode("utf-8")
+
+    did_document = json.loads(payload)
+    if not isinstance(did_document, dict):
+        raise ValueError(f"Resolved did:web document is not a JSON object: {iri}")
+    if did_document.get("id") != requested_did:
+        raise ValueError(
+            f"Resolved did:web document id mismatch for {iri}: {did_document.get('id')}"
+        )
+    if context_url_map:
+        from src.tools.utils.context_resolver import inline_jsonld_with_local_contexts
+
+        json_str = inline_jsonld_with_local_contexts(
+            did_document,
+            context_url_map,
+            source_name=document_url,
+        )
+    else:
+        json_str = json.dumps(did_document)
+
+    did_graph = Graph(store=FAST_STORE)
+    did_graph.parse(
+        data=json_str,
+        format="json-ld",
+        base=document_url,
+        publicID=document_url,
+    )
+    if len(did_graph) == 0:
+        raise ValueError(
+            f"Resolved did:web document produced no RDF triples for {iri}; "
+            "plain DID JSON without JSON-LD context is not supported by OMB graph loading"
+        )
+    graph += did_graph
+    return document_url
+
+
 def load_fixtures_for_iris(
     iris: Set[str],
     resolver: "RegistryResolver",  # noqa: F821 - forward reference
     graph: Graph,
     root_dir: Path,
     context_url_map: Optional[Dict[str, Path]] = None,
-    allow_online_fallback: bool = False,
+    allow_online_fallback: bool = True,
     verbose: bool = False,
 ) -> Tuple[int, List[str]]:
     """
@@ -333,7 +397,7 @@ def load_fixtures_for_iris(
             When provided, fixture JSON-LD is loaded with the same local
             context inlining used for top-level data files.
         allow_online_fallback: If True, attempt online resolution for
-            unresolved IRIs (with warning). Default False.
+            unresolved IRIs, including ``did:web`` documents. Default True.
         verbose: If True, print details about each resolved fixture.
 
     Returns:
@@ -376,7 +440,23 @@ def load_fixtures_for_iris(
                 except Exception as e:
                     logger.warning("Could not load fixture for %s: %s", iri, e)
 
-        # Step 2: Try online resolution if enabled
+        # Step 2: Try online did:web resolution if enabled
+        if allow_online_fallback and is_did_web(iri):
+            try:
+                document_url = _load_online_did_web_document(
+                    iri,
+                    graph,
+                    context_url_map=context_url_map,
+                )
+                logger.info("Resolved did:web online: %s via %s", iri, document_url)
+                if verbose:
+                    print(f"    ⚡ Resolved did:web: {iri} -> {document_url}")
+                fixtures_loaded += 1
+                continue
+            except Exception as e:
+                logger.warning("Could not resolve did:web %s online: %s", iri, e)
+
+        # Step 3: Try online HTTP(S) resolution if enabled
         if allow_online_fallback and iri.startswith(("http://", "https://")):
             try:
                 graph.parse(iri, format="json-ld")
@@ -388,7 +468,7 @@ def load_fixtures_for_iris(
             except Exception as e:
                 logger.warning("Could not resolve online %s: %s", iri, e)
 
-        # Step 3: Mark as unresolved (warning, not error)
+        # Step 4: Mark as unresolved (warning, not error)
         unresolved_iris.append(iri)
         logger.warning("Unresolved IRI (continuing validation): %s", iri)
 

--- a/src/tools/validators/shacl/validator.py
+++ b/src/tools/validators/shacl/validator.py
@@ -95,7 +95,7 @@ class ShaclValidator:
         verbose: bool = True,
         resolver: Optional["RegistryResolver"] = None,
         strict: bool = False,
-        allow_online: bool = False,
+        allow_online: bool = True,
     ):
         """
         Initialize the SHACL validator.

--- a/src/tools/validators/validation_suite.py
+++ b/src/tools/validators/validation_suite.py
@@ -224,7 +224,7 @@ def validate_data_conformance_all(
     resolver: RegistryResolver = None,
     inference_mode: str = "rdfs",
     strict: bool = False,
-    allow_online: bool = False,
+    allow_online: bool = True,
 ) -> int:
     """
     Validate JSON-LD files against SHACL schemas.
@@ -308,7 +308,7 @@ def check_failing_tests_all(
     ontology_domains: List[str],
     resolver: RegistryResolver = None,
     inference_mode: str = "rdfs",
-    allow_online: bool = False,
+    allow_online: bool = True,
 ) -> int:
     """
     Run failing test cases from tests/data/{domain}/invalid/ directories.
@@ -610,8 +610,15 @@ def main():
     target_group.add_argument(
         "--allow-online",
         action="store_true",
-        default=False,
-        help="Allow online fallback for unresolved IRIs (disabled by default).",
+        default=True,
+        help="Allow online fallback for unresolved IRIs (enabled by default).",
+    )
+
+    target_group.add_argument(
+        "--offline",
+        dest="allow_online",
+        action="store_false",
+        help="Disable online fallback for unresolved IRIs.",
     )
 
     args = parser.parse_args()

--- a/tests/unit/core/test_iri_utils.py
+++ b/tests/unit/core/test_iri_utils.py
@@ -4,6 +4,7 @@ Unit tests for src.tools.core.iri_utils module.
 """
 
 from src.tools.core.iri_utils import (
+    did_web_to_url,
     extract_prefix_from_context,
     get_local_name,
     get_namespace,
@@ -132,6 +133,82 @@ class TestParseDidWeb:
         result = parse_did_web("did:web:example%2Eorg")
         assert result is not None
         assert result["host"] == "example.org"
+
+
+class TestDidWebToUrl:
+    """Tests for did_web_to_url function."""
+
+    def test_converts_host_only_identifier(self):
+        """Host-only did:web resolves to .well-known/did.json."""
+        assert (
+            did_web_to_url("did:web:example.org")
+            == "https://example.org/.well-known/did.json"
+        )
+
+    def test_converts_path_segments(self):
+        """Colon-delimited path segments become URL path segments."""
+        assert (
+            did_web_to_url("did:web:example.org:user:alice")
+            == "https://example.org/user/alice/did.json"
+        )
+
+    def test_decodes_percent_encoded_port(self):
+        """Percent-encoded ports are restored in the HTTPS URL."""
+        assert (
+            did_web_to_url("did:web:example.org%3A3000")
+            == "https://example.org:3000/.well-known/did.json"
+        )
+
+    def test_strips_fragment_from_did_url(self):
+        """Fragments do not change the DID document URL."""
+        assert (
+            did_web_to_url("did:web:example.org:user:alice#key-1")
+            == "https://example.org/user/alice/did.json"
+        )
+
+    def test_rejects_url_injection_in_host(self):
+        """Userinfo-style host injection is rejected."""
+        assert did_web_to_url("did:web:victim.com%40attacker.com") is None
+
+    def test_rejects_dangerous_path_segments(self):
+        """Dangerous decoded path delimiters are rejected."""
+        assert did_web_to_url("did:web:example.org:user%2Falice") is None
+
+    def test_rejects_path_traversal_segments(self):
+        """Dot-dot path traversal segments are rejected."""
+        assert did_web_to_url("did:web:example.org:..") is None
+        assert did_web_to_url("did:web:example.org:..:etc:passwd") is None
+        assert did_web_to_url("did:web:example.org:user:..") is None
+        assert did_web_to_url("did:web:example.org:.") is None
+
+    def test_rejects_localhost(self):
+        """Localhost hostnames are rejected to prevent SSRF."""
+        assert did_web_to_url("did:web:localhost") is None
+        assert did_web_to_url("did:web:localhost.localdomain") is None
+
+    def test_rejects_loopback_ip(self):
+        """Loopback IP addresses are rejected to prevent SSRF."""
+        assert did_web_to_url("did:web:127.0.0.1") is None
+        assert did_web_to_url("did:web:127.0.0.1%3A8080") is None
+
+    def test_rejects_private_ip(self):
+        """Private IP ranges are rejected to prevent SSRF."""
+        assert did_web_to_url("did:web:10.0.0.1") is None
+        assert did_web_to_url("did:web:192.168.1.1") is None
+        assert did_web_to_url("did:web:172.16.0.1") is None
+
+    def test_rejects_link_local_ip(self):
+        """Link-local / cloud metadata IPs are rejected to prevent SSRF."""
+        assert did_web_to_url("did:web:169.254.169.254") is None
+
+    def test_rejects_single_label_hostname(self):
+        """Single-label hostnames (no dots) are rejected."""
+        assert did_web_to_url("did:web:intranet") is None
+        assert did_web_to_url("did:web:metadata") is None
+
+    def test_returns_none_for_non_did_web(self):
+        """Non did:web identifiers do not produce URLs."""
+        assert did_web_to_url("https://example.org/resource") is None
 
 
 class TestNormalizeIri:

--- a/tests/unit/utils/test_context_resolver.py
+++ b/tests/unit/utils/test_context_resolver.py
@@ -13,9 +13,9 @@ def test_build_context_url_map_includes_schema_shared_w3c_contexts(root_dir: Pat
 
     url_map = build_context_url_map(resolver, root_dir)
 
-    expected_path = (
+    schema_context_path = (
         root_dir / "imports" / "schema" / "schema.context.jsonld"
     ).resolve()
 
-    assert url_map["http://www.w3.org/2006/vcard/ns#"] == expected_path
-    assert url_map["http://www.w3.org/ns/dcat#"] == expected_path
+    assert url_map["http://www.w3.org/2006/vcard/ns#"] == schema_context_path
+    assert url_map["http://www.w3.org/ns/dcat#"] == schema_context_path

--- a/tests/unit/utils/test_graph_loader.py
+++ b/tests/unit/utils/test_graph_loader.py
@@ -8,7 +8,7 @@ import os
 from pathlib import Path
 
 import pytest
-from rdflib import Graph
+from rdflib import Graph, URIRef
 
 from src.tools.utils import graph_loader
 from src.tools.utils.registry_resolver import RegistryResolver
@@ -268,3 +268,271 @@ def test_load_fixtures_for_iris_uses_context_url_map(temp_dir: Path):
     assert loaded == 1
     assert len(unresolved) == 0
     assert len(g) >= 1
+
+
+class _FakeUrlopenResponse:
+    def __init__(self, payload: str):
+        self._payload = payload.encode("utf-8")
+
+    def read(self) -> bytes:
+        return self._payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeOpener:
+    """Fake opener returned by monkeypatched build_opener."""
+
+    def __init__(self, open_fn):
+        self._open_fn = open_fn
+
+    def open(self, request, timeout=10):
+        return self._open_fn(request, timeout=timeout)
+
+
+def _patch_opener(monkeypatch, open_fn):
+    """Replace graph_loader.build_opener so it returns a _FakeOpener."""
+
+    def fake_build_opener(*handlers):
+        return _FakeOpener(open_fn)
+
+    monkeypatch.setattr(graph_loader, "build_opener", fake_build_opener)
+
+
+def test_load_fixtures_for_iris_resolves_did_web_online(
+    temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+):
+    (temp_dir / "docs").mkdir()
+    (temp_dir / "docs" / "registry.json").write_text(
+        '{"version":"1.0.0","ontologies":{}}'
+    )
+    (temp_dir / "artifacts").mkdir()
+    (temp_dir / "artifacts" / "catalog-v001.xml").write_text(
+        '<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog"></catalog>'
+    )
+
+    def fake_urlopen(request, timeout=10):
+        assert request.full_url == "https://test.example/.well-known/did.json"
+        return _FakeUrlopenResponse(
+            json.dumps(
+                {
+                    "@context": {
+                        "id": "@id",
+                        "name": "http://example.org/name",
+                    },
+                    "id": "did:web:test.example",
+                    "name": "Test Entity",
+                }
+            )
+        )
+
+    _patch_opener(monkeypatch, fake_urlopen)
+
+    resolver = RegistryResolver(temp_dir)
+    g = Graph()
+    loaded, unresolved = graph_loader.load_fixtures_for_iris(
+        {"did:web:test.example"},
+        resolver,
+        g,
+        temp_dir,
+        allow_online_fallback=True,
+    )
+
+    assert loaded == 1
+    assert unresolved == []
+    assert (URIRef("did:web:test.example"), None, None) in g
+
+
+def test_load_fixtures_for_iris_resolves_did_web_online_with_context_url_map(
+    temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+):
+    (temp_dir / "docs").mkdir()
+    (temp_dir / "docs" / "registry.json").write_text(
+        '{"version":"1.0.0","ontologies":{}}'
+    )
+    (temp_dir / "artifacts").mkdir()
+    (temp_dir / "artifacts" / "catalog-v001.xml").write_text(
+        '<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog"></catalog>'
+    )
+
+    contexts_dir = temp_dir / "contexts"
+    contexts_dir.mkdir()
+    local_context = contexts_dir / "did-context.jsonld"
+    local_context.write_text(
+        json.dumps(
+            {
+                "@context": {
+                    "id": "@id",
+                    "name": "http://example.org/name",
+                }
+            }
+        )
+    )
+
+    def fake_urlopen(request, timeout=10):
+        assert request.full_url == "https://test.example/user/alice/did.json"
+        return _FakeUrlopenResponse(
+            json.dumps(
+                {
+                    "@context": "https://example.org/did-context",
+                    "id": "did:web:test.example:user:alice",
+                    "name": "Alice",
+                }
+            )
+        )
+
+    _patch_opener(monkeypatch, fake_urlopen)
+
+    resolver = RegistryResolver(temp_dir)
+    g = Graph()
+    loaded, unresolved = graph_loader.load_fixtures_for_iris(
+        {"did:web:test.example:user:alice"},
+        resolver,
+        g,
+        temp_dir,
+        context_url_map={"https://example.org/did-context": local_context},
+        allow_online_fallback=True,
+    )
+
+    assert loaded == 1
+    assert unresolved == []
+    assert (URIRef("did:web:test.example:user:alice"), None, None) in g
+
+
+def test_load_fixtures_for_iris_rejects_mismatched_did_document_id(
+    temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+):
+    (temp_dir / "docs").mkdir()
+    (temp_dir / "docs" / "registry.json").write_text(
+        '{"version":"1.0.0","ontologies":{}}'
+    )
+    (temp_dir / "artifacts").mkdir()
+    (temp_dir / "artifacts" / "catalog-v001.xml").write_text(
+        '<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog"></catalog>'
+    )
+
+    def fake_urlopen(request, timeout=10):
+        assert request.full_url == "https://test.example/.well-known/did.json"
+        return _FakeUrlopenResponse(
+            json.dumps(
+                {
+                    "@context": {"id": "@id"},
+                    "id": "did:web:other.example",
+                }
+            )
+        )
+
+    _patch_opener(monkeypatch, fake_urlopen)
+
+    resolver = RegistryResolver(temp_dir)
+    g = Graph()
+    loaded, unresolved = graph_loader.load_fixtures_for_iris(
+        {"did:web:test.example"},
+        resolver,
+        g,
+        temp_dir,
+    )
+
+    assert loaded == 0
+    assert unresolved == ["did:web:test.example"]
+    assert len(g) == 0
+
+
+def test_load_fixtures_for_iris_rejects_plain_did_json_without_context(
+    temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+):
+    (temp_dir / "docs").mkdir()
+    (temp_dir / "docs" / "registry.json").write_text(
+        '{"version":"1.0.0","ontologies":{}}'
+    )
+    (temp_dir / "artifacts").mkdir()
+    (temp_dir / "artifacts" / "catalog-v001.xml").write_text(
+        '<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog"></catalog>'
+    )
+
+    def fake_urlopen(request, timeout=10):
+        assert request.full_url == "https://test.example/.well-known/did.json"
+        return _FakeUrlopenResponse(json.dumps({"id": "did:web:test.example"}))
+
+    _patch_opener(monkeypatch, fake_urlopen)
+
+    resolver = RegistryResolver(temp_dir)
+    g = Graph()
+    loaded, unresolved = graph_loader.load_fixtures_for_iris(
+        {"did:web:test.example"},
+        resolver,
+        g,
+        temp_dir,
+    )
+
+    assert loaded == 0
+    assert unresolved == ["did:web:test.example"]
+    assert len(g) == 0
+
+
+def test_load_fixtures_for_iris_rejects_ssrf_localhost(
+    temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Localhost did:web must never reach the network — did_web_to_url rejects it."""
+    (temp_dir / "docs").mkdir()
+    (temp_dir / "docs" / "registry.json").write_text(
+        '{"version":"1.0.0","ontologies":{}}'
+    )
+    (temp_dir / "artifacts").mkdir()
+    (temp_dir / "artifacts" / "catalog-v001.xml").write_text(
+        '<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog"></catalog>'
+    )
+
+    def should_not_be_called(request, timeout=10):
+        raise AssertionError(f"SSRF: network call attempted to {request.full_url}")
+
+    _patch_opener(monkeypatch, should_not_be_called)
+
+    resolver = RegistryResolver(temp_dir)
+    g = Graph()
+    loaded, unresolved = graph_loader.load_fixtures_for_iris(
+        {"did:web:localhost", "did:web:127.0.0.1", "did:web:169.254.169.254"},
+        resolver,
+        g,
+        temp_dir,
+    )
+
+    assert loaded == 0
+    assert len(unresolved) == 3
+    assert len(g) == 0
+
+
+def test_load_fixtures_for_iris_rejects_ssrf_private_ip(
+    temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Private IP did:web must never reach the network."""
+    (temp_dir / "docs").mkdir()
+    (temp_dir / "docs" / "registry.json").write_text(
+        '{"version":"1.0.0","ontologies":{}}'
+    )
+    (temp_dir / "artifacts").mkdir()
+    (temp_dir / "artifacts" / "catalog-v001.xml").write_text(
+        '<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog"></catalog>'
+    )
+
+    def should_not_be_called(request, timeout=10):
+        raise AssertionError(f"SSRF: network call attempted to {request.full_url}")
+
+    _patch_opener(monkeypatch, should_not_be_called)
+
+    resolver = RegistryResolver(temp_dir)
+    g = Graph()
+    loaded, unresolved = graph_loader.load_fixtures_for_iris(
+        {"did:web:10.0.0.1", "did:web:192.168.1.1", "did:web:172.16.0.1"},
+        resolver,
+        g,
+        temp_dir,
+    )
+
+    assert loaded == 0
+    assert len(unresolved) == 3
+    assert len(g) == 0

--- a/tests/unit/validators/test_validation_suite.py
+++ b/tests/unit/validators/test_validation_suite.py
@@ -228,7 +228,7 @@ def test_validate_data_conformance_all_prints_formatted_report(
             verbose: bool = True,
             resolver: RegistryResolver = None,
             strict: bool = False,
-            allow_online: bool = False,
+            allow_online: bool = True,
         ):
             self._resolver = resolver
 


### PR DESCRIPTION
## Summary

Add online `did:web` document resolution to the OMB validation pipeline, enabling SHACL validation of credentials that reference external DID identifiers (e.g. Gaia-X issuer/notary endpoints like `did:web:gaia-x.eu`, `did:web:compliance.gxdch.gaiax.ovh:v2`).

Online resolution is now **enabled by default**. An explicit `--offline` CLI flag is available for opt-out.

## Motivation

When validating Gaia-X credentials, the data graph references `did:web` identifiers for issuers and notaries. Without online resolution, these remain unresolved IRIs — the validator cannot load the associated DID documents into the graph, reducing validation coverage. This is especially important for closed SHACL shapes (`sh:closed true`) that target nodes by `rdf:type`.

## Changes

### Core: `did:web` URL Construction (`src/tools/core/iri_utils.py`)

- New `did_web_to_url()` function converts `did:web:` identifiers to their HTTPS `did.json` document URL per the [did:web method specification](https://w3c-ccg.github.io/did-method-web/)
- Strips DID URL fragments/queries before URL construction
- **SSRF hardening**:
  - Rejects userinfo injection via percent-decoded `@` in host (`did:web:victim.com%40attacker.com`)
  - Rejects localhost / `localhost.localdomain`
  - Rejects loopback IPs (`127.0.0.0/8`) via `ipaddress` module
  - Rejects private IP ranges (RFC 1918: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`)
  - Rejects link-local / cloud metadata IPs (`169.254.0.0/16`)
  - Rejects reserved IPs
  - Rejects single-label hostnames (no dots — e.g. `metadata`, `intranet`)
  - Rejects path traversal segments (`.`, `..`)
  - Validates hostname labels against DNS label rules
  - Validates port range (1–65535)

### Core: Online DID Document Loading (`src/tools/utils/graph_loader.py`)

- New `_load_online_did_web_document()` fetches DID documents over HTTPS and loads them into the RDF graph as JSON-LD
- **Redirect-free opener**: uses `build_opener(HTTPSHandler)` without `HTTPRedirectHandler` to prevent SSRF via attacker-controlled 3xx redirects to internal services, `file://` URLs, or cloud metadata endpoints
- **Document integrity checks**:
  - Verifies the fetched document `id` matches the requested DID (prevents confused-deputy attacks)
  - Rejects documents that are not JSON objects
  - Parses into a separate graph first; rejects if zero triples are produced (catches plain DID JSON without `@context`)
- Integrates with local context inlining via `inline_jsonld_with_local_contexts()` so catalog-mapped contexts are substituted in fetched documents

### Refactor: Context Inlining (`src/tools/utils/context_resolver.py`)

- Extracted `inline_jsonld_with_local_contexts()` from `load_jsonld_with_local_contexts()` so fetched DID documents (not just local files) can benefit from local context substitution

### Default Flip: Online Resolution Enabled by Default

- `allow_online` parameter defaults changed from `False` to `True` in:
  - `validate_data_conformance_all()`
  - `check_failing_tests_all()`
  - `ShaclValidator.__init__()`
  - `load_fixtures_for_iris()`
  - CLI `--allow-online` flag
- New `--offline` CLI flag added (sets `allow_online=False`)

## Test Coverage

### Security Tests (`tests/unit/core/test_iri_utils.py`)

| Test | What it verifies |
|------|-----------------|
| `test_strips_fragment_from_did_url` | `did:web:example.org:user:alice#key-1` resolves correctly |
| `test_rejects_url_injection_in_host` | `did:web:victim.com%40attacker.com` → `None` |
| `test_rejects_dangerous_path_segments` | `did:web:example.org:user%2Falice` → `None` |
| `test_rejects_path_traversal_segments` | `..`, `.` segments → `None` |
| `test_rejects_localhost` | `localhost`, `localhost.localdomain` → `None` |
| `test_rejects_loopback_ip` | `127.0.0.1`, `127.0.0.1:8080` → `None` |
| `test_rejects_private_ip` | `10.0.0.1`, `192.168.1.1`, `172.16.0.1` → `None` |
| `test_rejects_link_local_ip` | `169.254.169.254` → `None` |
| `test_rejects_single_label_hostname` | `intranet`, `metadata` → `None` |

### Integration Tests (`tests/unit/utils/test_graph_loader.py`)

| Test | What it verifies |
|------|-----------------|
| `test_resolves_did_web_online` | Host-only DID resolves and loads triples |
| `test_resolves_did_web_online_with_context_url_map` | Path-based DID with local context substitution |
| `test_rejects_mismatched_did_document_id` | Fetched doc with wrong `id` is rejected (0 loaded, 1 unresolved) |
| `test_rejects_plain_did_json_without_context` | Doc without `@context` yields 0 triples → rejected |
| `test_rejects_ssrf_localhost` | `localhost` / `127.0.0.1` / `169.254.169.254` never reach the network |
| `test_rejects_ssrf_private_ip` | `10.0.0.1` / `192.168.1.1` / `172.16.0.1` never reach the network |

## Validation

- All 97 focused unit tests pass
- Gaia-X Loire participant credentials pass full SHACL validation with all three `did:web` documents resolving online:
  - `did:web:gaia-x.eu` → `https://gaia-x.eu/.well-known/did.json`
  - `did:web:compliance.gxdch.gaiax.ovh:v2` → `https://compliance.gxdch.gaiax.ovh/v2/did.json`
  - `did:web:notary.gxdch.gaiax.ovh:v2` → `https://notary.gxdch.gaiax.ovh/v2/did.json`
- Offline opt-out (`--offline`) still works correctly with expected unresolved warnings

## Breaking Changes

- **Default behavior change**: online resolution is now enabled by default. Pipelines that depend on fully offline validation must add `--offline` to their invocations.