### PR TITLE
feat: add HTTP artifact resolution for pip-only installations

### DIFF
--- a/src/tools/utils/graph_loader.py
+++ b/src/tools/utils/graph_loader.py
@@ -222,11 +222,18 @@ def load_jsonld_files(
                 )
 
                 json_str = load_jsonld_with_local_contexts(json_file, context_url_map)
+                try:
+                    file_uri = json_file.resolve().as_uri()
+                except OSError:
+                    # On Windows, resolve() may call os.getcwd() even for
+                    # absolute paths.  Fall back to as_uri() when cwd is
+                    # unavailable (e.g. deleted working directory).
+                    file_uri = json_file.absolute().as_uri()
                 graph.parse(
                     data=json_str,
                     format="json-ld",
-                    base=json_file.resolve().as_uri(),
-                    publicID=json_file.resolve().as_uri(),
+                    base=file_uri,
+                    publicID=file_uri,
                 )
             else:
                 graph.parse(str(json_file), format="json-ld")

--- a/src/tools/utils/http_artifact_resolver.py
+++ b/src/tools/utils/http_artifact_resolver.py
@@ -1,12 +1,20 @@
 #!/usr/bin/env python3
 """
-HTTP-based artifact resolution for pip-only OMB installations.
+HTTP Artifact Resolver - Remote ontology artifact fetching and caching.
 
 When OMB is installed via ``pip install`` (without the full repository clone),
 the local ``artifacts/``, ``imports/``, and ``tests/`` directories are absent.
 This module fetches ontology artifacts from the published GitHub Pages site and
 raw GitHub content, caching them locally so the existing catalog-driven
 validation pipeline works unchanged.
+
+FEATURE SET:
+============
+1. HttpArtifactResolver - Fetches and caches OMB ontology artifacts from HTTP
+2. _http_get - Unified HTTP GET with optional content-negotiation
+3. _validate_response_host - SSRF prevention via host allowlist
+4. _safe_cache_path - Path traversal prevention for cache writes
+5. _get_default_cache_dir - Platform-appropriate cache directory
 
 DESIGN:
 =======
@@ -49,6 +57,27 @@ USAGE:
 
     # Or fetch only domains needed for specific IRIs:
     cache_dir = resolver.ensure_cache_for_iris(iris_set)
+
+STANDALONE TESTING:
+==================
+    python3 -m src.tools.utils.http_artifact_resolver --test
+
+    Options:
+      --test         Run self-tests (no network required)
+      --clear-cache  Remove all cached artifacts
+      --cache-dir    Override default cache directory
+      --verbose      Verbose output
+
+DEPENDENCIES:
+=============
+- urllib: HTTP fetching (stdlib, no external dependencies)
+- xml.etree.ElementTree: XML catalog parsing
+
+NOTES:
+======
+- Uses urllib.request (not ``requests``) for consistency with graph_loader.py
+- SSRF prevention via ALLOWED_HOSTS post-redirect validation
+- Path traversal prevention via _safe_cache_path on all cache writes
 """
 
 import json
@@ -58,7 +87,6 @@ import shutil
 import time
 import xml.etree.ElementTree as ET
 from pathlib import Path
-from typing import Dict, List, Optional, Set
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
@@ -108,6 +136,37 @@ ALLOWED_HOSTS = frozenset(
 # Cache TTL: re-validate after this many seconds (24 hours).
 CACHE_TTL_SECONDS = 86400
 
+# Stale build sentinel timeout in seconds (10 minutes).
+# If a `.cache-building` marker is older than this, it's treated as stale
+# (crashed process) and ignored.
+STALE_BUILD_TIMEOUT_SECONDS = 600
+
+
+def _safe_cache_path(cache_dir: Path, *segments: str) -> Path:
+    """Resolve a path within cache_dir, rejecting traversal attempts.
+
+    All cache-write operations must call this **before** any ``mkdir()`` to
+    prevent directory creation outside the cache boundary.
+
+    Args:
+        cache_dir: Root cache directory (must already exist or be the target
+                   for creation).
+        *segments: Path segments to join (e.g., ``"imports"``, ``"rdf/rdf.owl.ttl"``).
+
+    Returns:
+        Resolved absolute path guaranteed to be under *cache_dir*.
+
+    Raises:
+        ValueError: If the resolved path escapes *cache_dir*.
+    """
+    dest = (cache_dir.resolve() / Path(*segments)).resolve()
+    if not dest.is_relative_to(cache_dir.resolve()):
+        raise ValueError(
+            f"Path traversal blocked: {'/'.join(segments)} "
+            f"resolves outside cache {cache_dir}"
+        )
+    return dest
+
 
 def _get_default_cache_dir() -> Path:
     """Return platform-appropriate cache directory for OMB artifacts."""
@@ -136,12 +195,15 @@ def _validate_response_host(response_url: str) -> None:
         )
 
 
-def _http_get(url: str, timeout: int = HTTP_TIMEOUT) -> bytes:
+def _http_get(
+    url: str, timeout: int = HTTP_TIMEOUT, accept: str | None = None
+) -> bytes:
     """Fetch URL content with a simple GET request.
 
     Args:
         url: URL to fetch
         timeout: Request timeout in seconds
+        accept: Optional Accept header for content-negotiation
 
     Returns:
         Response body as bytes
@@ -150,33 +212,10 @@ def _http_get(url: str, timeout: int = HTTP_TIMEOUT) -> bytes:
         URLError: On network failure or untrusted redirect
         HTTPError: On non-2xx response
     """
-    request = Request(url, headers={"User-Agent": "ontology-management-base"})
-    with urlopen(request, timeout=timeout) as response:
-        _validate_response_host(response.url)
-        return response.read()
-
-
-def _http_get_with_accept(url: str, accept: str, timeout: int = HTTP_TIMEOUT) -> bytes:
-    """Fetch URL with a specific Accept header (content-negotiation).
-
-    Args:
-        url: URL to fetch
-        accept: Accept header value (e.g., "text/turtle")
-        timeout: Request timeout in seconds
-
-    Returns:
-        Response body as bytes
-
-    Raises:
-        URLError: On network failure or untrusted redirect
-    """
-    request = Request(
-        url,
-        headers={
-            "User-Agent": "ontology-management-base",
-            "Accept": accept,
-        },
-    )
+    headers: dict[str, str] = {"User-Agent": "ontology-management-base"}
+    if accept:
+        headers["Accept"] = accept
+    request = Request(url, headers=headers)
     with urlopen(request, timeout=timeout) as response:
         _validate_response_host(response.url)
         return response.read()
@@ -194,7 +233,7 @@ class HttpArtifactResolver:
 
     def __init__(
         self,
-        cache_dir: Optional[Path] = None,
+        cache_dir: Path | None = None,
         gh_pages_base: str = GH_PAGES_BASE,
         raw_github_base: str = RAW_GITHUB_BASE,
         registry_url: str = REGISTRY_URL,
@@ -214,13 +253,13 @@ class HttpArtifactResolver:
         self.raw_github_base = raw_github_base.rstrip("/")
         self.registry_url = registry_url
         self.timeout = timeout
-        self._registry: Optional[Dict] = None
+        self._registry: dict | None = None
 
     # =========================================================================
     # Registry Discovery
     # =========================================================================
 
-    def fetch_registry(self) -> Dict:
+    def fetch_registry(self) -> dict:
         """Fetch and parse docs/registry.json from GitHub Pages.
 
         Returns:
@@ -252,7 +291,7 @@ class HttpArtifactResolver:
         registry = self.fetch_registry()
         return registry.get("latestRelease", "unknown")
 
-    def get_domain_info(self) -> Dict[str, Dict]:
+    def get_domain_info(self) -> dict[str, dict]:
         """Get domain→metadata mapping from the registry.
 
         Returns:
@@ -266,7 +305,7 @@ class HttpArtifactResolver:
     # Cache Management
     # =========================================================================
 
-    def _versioned_cache_dir(self, version: Optional[str] = None) -> Path:
+    def _versioned_cache_dir(self, version: str | None = None) -> Path:
         """Get the versioned cache directory.
 
         Args:
@@ -279,8 +318,12 @@ class HttpArtifactResolver:
             version = self.get_registry_version()
         return self.cache_base / version
 
-    def is_cache_valid(self, cache_dir: Optional[Path] = None) -> bool:
+    def is_cache_valid(self, cache_dir: Path | None = None) -> bool:
         """Check if the cache is present and not stale.
+
+        Returns False when a ``.cache-building`` sentinel exists (build in
+        progress or crashed).  Stale sentinels older than
+        ``STALE_BUILD_TIMEOUT_SECONDS`` are cleaned up automatically.
 
         Args:
             cache_dir: Explicit cache directory, or auto-detect.
@@ -292,6 +335,25 @@ class HttpArtifactResolver:
             try:
                 cache_dir = self._versioned_cache_dir()
             except RuntimeError:
+                return False
+
+        building_marker = cache_dir / ".cache-building"
+        if building_marker.exists():
+            try:
+                ts = float(building_marker.read_text().strip())
+                if (time.time() - ts) > STALE_BUILD_TIMEOUT_SECONDS:
+                    logger.warning(
+                        "Removing stale build marker (>%d s old): %s",
+                        STALE_BUILD_TIMEOUT_SECONDS,
+                        building_marker,
+                    )
+                    building_marker.unlink(missing_ok=True)
+                else:
+                    logger.debug("Cache build in progress: %s", building_marker)
+                    return False
+            except (ValueError, OSError):
+                # Corrupt marker — remove and treat as invalid
+                building_marker.unlink(missing_ok=True)
                 return False
 
         marker = cache_dir / ".cache-timestamp"
@@ -324,7 +386,7 @@ class HttpArtifactResolver:
             Absolute path to the cached catalog file
         """
         url = f"{self.raw_github_base}/{catalog_rel_path}"
-        dest = cache_dir / catalog_rel_path
+        dest = _safe_cache_path(cache_dir, catalog_rel_path)
         dest.parent.mkdir(parents=True, exist_ok=True)
 
         logger.info("Fetching catalog: %s", catalog_rel_path)
@@ -361,14 +423,14 @@ class HttpArtifactResolver:
         registry = self.fetch_registry()
         dest = cache_dir / "docs" / "registry.json"
         dest.parent.mkdir(parents=True, exist_ok=True)
-        dest.write_text(json.dumps(registry, indent=3), encoding="utf-8")
+        dest.write_text(json.dumps(registry, indent=2), encoding="utf-8")
         return dest
 
     # =========================================================================
     # Fetching: Domain Artifacts (via w3id.org / GH Pages)
     # =========================================================================
 
-    def _build_w3id_url(self, domain_info: Dict) -> Optional[str]:
+    def _build_w3id_url(self, domain_info: dict) -> str | None:
         """Build the w3id.org base URL for a domain's artifacts.
 
         Args:
@@ -382,7 +444,7 @@ class HttpArtifactResolver:
             return None
         return iri.rstrip("#/")
 
-    def _build_gh_pages_url(self, domain_info: Dict) -> Optional[str]:
+    def _build_gh_pages_url(self, domain_info: dict) -> str | None:
         """Build the GitHub Pages URL for a domain's artifacts.
 
         GH Pages URL pattern:
@@ -404,7 +466,7 @@ class HttpArtifactResolver:
     def fetch_domain_artifacts(
         self,
         domain: str,
-        domain_info: Dict,
+        domain_info: dict,
         cache_dir: Path,
     ) -> bool:
         """Fetch OWL, SHACL, and context files for a domain.
@@ -420,7 +482,7 @@ class HttpArtifactResolver:
         Returns:
             True if at least the ontology was fetched successfully
         """
-        domain_dir = cache_dir / "artifacts" / domain
+        domain_dir = _safe_cache_path(cache_dir, "artifacts", domain)
         domain_dir.mkdir(parents=True, exist_ok=True)
 
         gh_url = self._build_gh_pages_url(domain_info)
@@ -465,9 +527,7 @@ class HttpArtifactResolver:
                 else:
                     conneg_url = w3id_url
                 try:
-                    data = _http_get_with_accept(
-                        conneg_url, accept_header, self.timeout
-                    )
+                    data = _http_get(conneg_url, self.timeout, accept=accept_header)
                     dest.write_bytes(data)
                     logger.info("Fetched %s/%s via w3id.org conneg", domain, local_name)
                     fetched = True
@@ -513,7 +573,7 @@ class HttpArtifactResolver:
 
         fetched = 0
         cached = 0
-        seen_paths: Set[str] = set()
+        seen_paths: set[str] = set()
 
         for elem in uri_elems:
             rel_path = elem.get("uri")
@@ -521,7 +581,11 @@ class HttpArtifactResolver:
                 continue
             seen_paths.add(rel_path)
 
-            dest = cache_dir / "imports" / rel_path
+            try:
+                dest = _safe_cache_path(cache_dir, "imports", rel_path)
+            except ValueError:
+                logger.warning("Skipping import with path traversal: %s", rel_path)
+                continue
             if dest.exists():
                 cached += 1
                 continue
@@ -568,7 +632,7 @@ class HttpArtifactResolver:
 
         fetched = 0
         cached = 0
-        seen_paths: Set[str] = set()
+        seen_paths: set[str] = set()
 
         for elem in uri_elems:
             rel_path = elem.get("uri")
@@ -576,7 +640,13 @@ class HttpArtifactResolver:
                 continue
             seen_paths.add(rel_path)
 
-            dest = cache_dir / "artifacts" / rel_path
+            try:
+                dest = _safe_cache_path(cache_dir, "artifacts", rel_path)
+            except ValueError:
+                logger.warning(
+                    "Skipping catalog artifact with path traversal: %s", rel_path
+                )
+                continue
             if dest.exists():
                 cached += 1
                 continue
@@ -604,7 +674,7 @@ class HttpArtifactResolver:
 
     def ensure_cache(
         self,
-        domains: Optional[List[str]] = None,
+        domains: list[str] | None = None,
         force: bool = False,
     ) -> Path:
         """Ensure all required artifacts are cached locally.
@@ -631,45 +701,50 @@ class HttpArtifactResolver:
         logger.info("Building artifact cache at %s", cache_dir)
         cache_dir.mkdir(parents=True, exist_ok=True)
 
-        # Step 1: Fetch registry
-        self.fetch_registry_to_cache(cache_dir)
+        building_marker = cache_dir / ".cache-building"
+        building_marker.write_text(str(time.time()))
+        try:
+            # Step 1: Fetch registry
+            self.fetch_registry_to_cache(cache_dir)
 
-        # Step 2: Fetch catalogs
-        self.fetch_all_catalogs(cache_dir)
+            # Step 2: Fetch catalogs
+            self.fetch_all_catalogs(cache_dir)
 
-        # Step 3: Fetch domain artifacts
-        domain_info = self.get_domain_info()
-        if domains is None:
-            domains = list(domain_info.keys())
+            # Step 3: Fetch domain artifacts
+            domain_info = self.get_domain_info()
+            if domains is None:
+                domains = list(domain_info.keys())
 
-        fetched_domains = []
-        for domain_name in domains:
-            info = domain_info.get(domain_name)
-            if not info:
-                logger.warning("Domain '%s' not found in registry", domain_name)
-                continue
-            if self.fetch_domain_artifacts(domain_name, info, cache_dir):
-                fetched_domains.append(domain_name)
+            fetched_domains = []
+            for domain_name in domains:
+                info = domain_info.get(domain_name)
+                if not info:
+                    logger.warning("Domain '%s' not found in registry", domain_name)
+                    continue
+                if self.fetch_domain_artifacts(domain_name, info, cache_dir):
+                    fetched_domains.append(domain_name)
 
-        logger.info(
-            "Fetched artifacts for %d/%d domains",
-            len(fetched_domains),
-            len(domains),
-        )
+            logger.info(
+                "Fetched artifacts for %d/%d domains",
+                len(fetched_domains),
+                len(domains),
+            )
 
-        # Step 4: Fetch import ontologies
-        self.fetch_import_files(cache_dir)
+            # Step 4: Fetch import ontologies
+            self.fetch_import_files(cache_dir)
 
-        # Step 5: Fetch any remaining artifacts from catalog
-        # (covers domains like gx that are in catalog but not registry.json)
-        self.fetch_artifacts_from_catalog(cache_dir)
+            # Step 5: Fetch any remaining artifacts from catalog
+            # (covers domains like gx that are in catalog but not registry.json)
+            self.fetch_artifacts_from_catalog(cache_dir)
 
-        # Step 6: Write cache marker
-        self._write_cache_marker(cache_dir)
+            # Step 6: Write cache marker (only on success)
+            self._write_cache_marker(cache_dir)
+        finally:
+            building_marker.unlink(missing_ok=True)
 
         return cache_dir
 
-    def ensure_cache_for_iris(self, iris: Set[str]) -> Path:
+    def ensure_cache_for_iris(self, iris: set[str]) -> Path:
         """Ensure artifacts are cached for domains matching the given IRIs.
 
         Discovers which domains are needed based on the IRI prefixes in the
@@ -682,7 +757,7 @@ class HttpArtifactResolver:
             Path to the versioned cache directory.
         """
         domain_info = self.get_domain_info()
-        needed_domains: Set[str] = set()
+        needed_domains: set[str] = set()
 
         for iri in iris:
             for domain_name, info in domain_info.items():
@@ -713,7 +788,7 @@ class HttpArtifactResolver:
         )
         return self.ensure_cache(domains=list(needed_domains))
 
-    def clear_cache(self, version: Optional[str] = None) -> None:
+    def clear_cache(self, version: str | None = None) -> None:
         """Remove cached artifacts.
 
         Args:
@@ -738,3 +813,148 @@ class HttpArtifactResolver:
         if target.exists():
             shutil.rmtree(target)
             logger.info("Cleared cache: %s", target)
+
+
+# =========================================================================
+# Standalone self-tests
+# =========================================================================
+
+
+def _run_tests() -> bool:
+    """Run self-tests for the module.
+
+    Tests core utilities (cache dir, host validation, safe paths, URL builders)
+    without making real HTTP requests.
+    """
+    import tempfile
+
+    print("Running http_artifact_resolver self-tests...")
+    all_passed = True
+
+    # Test 1: _get_default_cache_dir returns an omb-suffixed path
+    cache_dir = _get_default_cache_dir()
+    if cache_dir.name != "omb":
+        print(f"FAIL: Expected cache dir name 'omb', got '{cache_dir.name}'")
+        all_passed = False
+    else:
+        print(f"PASS: Default cache dir: {cache_dir}")
+
+    # Test 2: _validate_response_host accepts trusted hosts
+    try:
+        _validate_response_host("https://ascs-ev.github.io/test")
+        print("PASS: Trusted host accepted")
+    except URLError:
+        print("FAIL: Trusted host rejected")
+        all_passed = False
+
+    # Test 3: _validate_response_host rejects untrusted hosts
+    try:
+        _validate_response_host("https://evil.example.com/payload")
+        print("FAIL: Untrusted host accepted")
+        all_passed = False
+    except URLError:
+        print("PASS: Untrusted host rejected")
+
+    # Test 4: _safe_cache_path rejects path traversal
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        try:
+            _safe_cache_path(tmp, "imports", "../../etc/passwd")
+            print("FAIL: Path traversal not rejected")
+            all_passed = False
+        except ValueError:
+            print("PASS: Path traversal rejected")
+
+        # Test 5: _safe_cache_path allows normal paths
+        result = _safe_cache_path(tmp, "artifacts", "hdmap/hdmap.owl.ttl")
+        if result.is_relative_to(tmp.resolve()):
+            print("PASS: Normal path allowed")
+        else:
+            print("FAIL: Normal path rejected")
+            all_passed = False
+
+    # Test 6: URL builders
+    resolver = HttpArtifactResolver(cache_dir=Path(tempfile.mkdtemp()))
+    info_ascs = {"iri": "https://w3id.org/ascs-ev/envited-x/hdmap/v6"}
+    gh_url = resolver._build_gh_pages_url(info_ascs)
+    if gh_url and "w3id/ascs-ev/envited-x/hdmap/v6" in gh_url:
+        print("PASS: GH Pages URL built correctly")
+    else:
+        print(f"FAIL: GH Pages URL: {gh_url}")
+        all_passed = False
+
+    w3id_url = resolver._build_w3id_url(info_ascs)
+    if w3id_url == "https://w3id.org/ascs-ev/envited-x/hdmap/v6":
+        print("PASS: w3id URL built correctly")
+    else:
+        print(f"FAIL: w3id URL: {w3id_url}")
+        all_passed = False
+
+    # Test 7: Missing IRI returns None
+    if resolver._build_w3id_url({}) is None:
+        print("PASS: Missing IRI returns None")
+    else:
+        print("FAIL: Missing IRI did not return None")
+        all_passed = False
+
+    # Cleanup
+    shutil.rmtree(resolver.cache_base, ignore_errors=True)
+
+    print(f"\n{'All tests passed!' if all_passed else 'Some tests FAILED!'}")
+    return all_passed
+
+
+def main():
+    """CLI entry point for http_artifact_resolver."""
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(
+        description="HTTP-based artifact resolution for OMB"
+    )
+    parser.add_argument(
+        "--test",
+        action="store_true",
+        help="Run self-tests",
+    )
+    parser.add_argument(
+        "--clear-cache",
+        action="store_true",
+        help="Clear all cached artifacts",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        help="Override cache directory",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Verbose output",
+    )
+
+    args = parser.parse_args()
+
+    if args.test:
+        success = _run_tests()
+        sys.exit(0 if success else 1)
+
+    resolver = HttpArtifactResolver(cache_dir=args.cache_dir)
+
+    if args.clear_cache:
+        resolver.clear_cache()
+        print("Cache cleared.")
+        sys.exit(0)
+
+    # Default: show cache info
+    cache_dir = _get_default_cache_dir()
+    print(f"Cache directory: {cache_dir}")
+    if cache_dir.exists():
+        versions = [d.name for d in cache_dir.iterdir() if d.is_dir()]
+        print(f"Cached versions: {versions or '(none)'}")
+    else:
+        print("No cache present.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tools/utils/http_artifact_resolver.py
+++ b/src/tools/utils/http_artifact_resolver.py
@@ -56,12 +56,18 @@ import os
 import platform
 import shutil
 import time
+import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
 from src.tools.core.logging import get_logger
+
+# NOTE: This module uses urllib.request (not the ``requests`` library) for
+# consistency with ``graph_loader.py`` which also uses urllib for HTTPS
+# fetching.  Both modules share the same trust boundary and timeout semantics.
 
 logger = get_logger(__name__)
 
@@ -78,13 +84,26 @@ REGISTRY_URL = f"{GH_PAGES_BASE}/registry.json"
 
 # W3ID artifact file names served by GitHub Pages.
 W3ID_ARTIFACTS = {
-    "ontology": "ontology.ttl",
-    "shapes": "shapes.ttl",
-    "context": "context.jsonld",
+    "ontology": ("ontology.ttl", "text/turtle"),
+    "shapes": ("shapes.ttl", "text/turtle"),
+    "context": ("context.jsonld", "application/ld+json"),
 }
+
+# Standard catalog filename used across the repository.
+CATALOG_FILENAME = "catalog-v001.xml"
 
 # Default HTTP timeout in seconds.
 HTTP_TIMEOUT = 30
+
+# Trusted hosts for HTTP fetching.  Response URLs are validated against this
+# set after following redirects to prevent SSRF via malicious redirect targets.
+ALLOWED_HOSTS = frozenset(
+    {
+        "ascs-ev.github.io",
+        "raw.githubusercontent.com",
+        "w3id.org",
+    }
+)
 
 # Cache TTL: re-validate after this many seconds (24 hours).
 CACHE_TTL_SECONDS = 86400
@@ -99,6 +118,24 @@ def _get_default_cache_dir() -> Path:
     return base / "omb"
 
 
+def _validate_response_host(response_url: str) -> None:
+    """Validate that the response URL host is in the trusted allowlist.
+
+    Prevents SSRF via attacker-controlled redirect targets.  Fails closed:
+    missing or unrecognised hosts are rejected.
+
+    Raises:
+        URLError: If the response host is not in ALLOWED_HOSTS.
+    """
+    host = urlparse(response_url).hostname
+    if not host:
+        raise URLError(f"Invalid response URL (missing host): {response_url}")
+    if host not in ALLOWED_HOSTS:
+        raise URLError(
+            f"Response redirected to untrusted host: {host} (URL: {response_url})"
+        )
+
+
 def _http_get(url: str, timeout: int = HTTP_TIMEOUT) -> bytes:
     """Fetch URL content with a simple GET request.
 
@@ -110,11 +147,12 @@ def _http_get(url: str, timeout: int = HTTP_TIMEOUT) -> bytes:
         Response body as bytes
 
     Raises:
-        URLError: On network failure
+        URLError: On network failure or untrusted redirect
         HTTPError: On non-2xx response
     """
     request = Request(url, headers={"User-Agent": "ontology-management-base"})
     with urlopen(request, timeout=timeout) as response:
+        _validate_response_host(response.url)
         return response.read()
 
 
@@ -128,6 +166,9 @@ def _http_get_with_accept(url: str, accept: str, timeout: int = HTTP_TIMEOUT) ->
 
     Returns:
         Response body as bytes
+
+    Raises:
+        URLError: On network failure or untrusted redirect
     """
     request = Request(
         url,
@@ -137,6 +178,7 @@ def _http_get_with_accept(url: str, accept: str, timeout: int = HTTP_TIMEOUT) ->
         },
     )
     with urlopen(request, timeout=timeout) as response:
+        _validate_response_host(response.url)
         return response.read()
 
 
@@ -144,7 +186,7 @@ class HttpArtifactResolver:
     """Fetches and caches OMB ontology artifacts from HTTP sources.
 
     Attributes:
-        cache_dir: Root cache directory (versioned subdirs created inside)
+        cache_base: Root cache directory (versioned subdirs created inside)
         gh_pages_base: GitHub Pages base URL
         raw_github_base: Raw GitHub content base URL
         registry_url: URL for docs/registry.json
@@ -298,9 +340,9 @@ class HttpArtifactResolver:
     def fetch_all_catalogs(self, cache_dir: Path) -> None:
         """Fetch all 3 XML catalogs to the cache directory."""
         for rel_path in [
-            "artifacts/catalog-v001.xml",
-            "imports/catalog-v001.xml",
-            "tests/catalog-v001.xml",
+            f"artifacts/{CATALOG_FILENAME}",
+            f"imports/{CATALOG_FILENAME}",
+            f"tests/{CATALOG_FILENAME}",
         ]:
             try:
                 self.fetch_catalog(rel_path, cache_dir)
@@ -329,21 +371,15 @@ class HttpArtifactResolver:
     def _build_w3id_url(self, domain_info: Dict) -> Optional[str]:
         """Build the w3id.org base URL for a domain's artifacts.
 
-        The w3id URL pattern depends on the namespace:
-        - ascs-ev: https://w3id.org/ascs-ev/envited-x/{domain}/{version}
-        - gaia-x4plcaad: https://w3id.org/gaia-x4plcaad/ontologies/{domain}/{version}
-        - gaia-x development: special case (# fragment IRI)
-
         Args:
             domain_info: Domain metadata from registry.json
 
         Returns:
-            Base w3id.org URL, or None if cannot be determined.
+            Base w3id.org URL, or None if IRI is missing.
         """
         iri = domain_info.get("iri")
         if not iri:
             return None
-        # The IRI itself is the w3id.org URL (minus any trailing # or /)
         return iri.rstrip("#/")
 
     def _build_gh_pages_url(self, domain_info: Dict) -> Optional[str]:
@@ -359,15 +395,11 @@ class HttpArtifactResolver:
             GH Pages base URL for the domain's w3id artifacts.
         """
         iri = domain_info.get("iri", "")
-        if not iri:
+        if not iri or "w3id.org/" not in iri:
             return None
 
-        # Extract the path after w3id.org/
-        if "w3id.org/" in iri:
-            path = iri.split("w3id.org/", 1)[1].rstrip("#/")
-            return f"{self.gh_pages_base}/w3id/{path}"
-
-        return None
+        path = iri.split("w3id.org/", 1)[1].rstrip("#/")
+        return f"{self.gh_pages_base}/w3id/{path}"
 
     def fetch_domain_artifacts(
         self,
@@ -395,10 +427,11 @@ class HttpArtifactResolver:
         w3id_url = self._build_w3id_url(domain_info)
 
         # Map of local filename → (GH Pages artifact name, w3id accept header)
+        # derived from W3ID_ARTIFACTS constant.
         file_map = {
-            f"{domain}.owl.ttl": ("ontology.ttl", "text/turtle"),
-            f"{domain}.shacl.ttl": ("shapes.ttl", "text/turtle"),
-            f"{domain}.context.jsonld": ("context.jsonld", "application/ld+json"),
+            f"{domain}.owl.ttl": W3ID_ARTIFACTS["ontology"],
+            f"{domain}.shacl.ttl": W3ID_ARTIFACTS["shapes"],
+            f"{domain}.context.jsonld": W3ID_ARTIFACTS["context"],
         }
 
         ontology_fetched = False
@@ -464,16 +497,14 @@ class HttpArtifactResolver:
             cache_dir: Cache root directory
 
         Returns:
-            Number of files successfully fetched
+            Number of files successfully fetched (excluding cache hits)
         """
-        import xml.etree.ElementTree as ET
-
-        catalog_path = cache_dir / "imports" / "catalog-v001.xml"
+        catalog_path = cache_dir / "imports" / CATALOG_FILENAME
         if not catalog_path.exists():
             logger.warning("Imports catalog not cached, cannot fetch import files")
             return 0
 
-        tree = ET.parse(catalog_path)
+        tree = ET.parse(catalog_path)  # noqa: S314 — trusted source (raw GitHub)
         root = tree.getroot()
         ns = {"cat": "urn:oasis:names:tc:entity:xmlns:xml:catalog"}
         uri_elems = root.findall("cat:uri", ns)
@@ -481,6 +512,7 @@ class HttpArtifactResolver:
             uri_elems = root.findall("uri")
 
         fetched = 0
+        cached = 0
         seen_paths: Set[str] = set()
 
         for elem in uri_elems:
@@ -491,7 +523,7 @@ class HttpArtifactResolver:
 
             dest = cache_dir / "imports" / rel_path
             if dest.exists():
-                fetched += 1
+                cached += 1
                 continue
 
             url = f"{self.raw_github_base}/imports/{rel_path}"
@@ -505,7 +537,7 @@ class HttpArtifactResolver:
             except (HTTPError, URLError) as e:
                 logger.warning("Failed to fetch import %s: %s", rel_path, e)
 
-        logger.info("Fetched %d import files", fetched)
+        logger.info("Import files: %d fetched, %d already cached", fetched, cached)
         return fetched
 
     def fetch_artifacts_from_catalog(self, cache_dir: Path) -> int:
@@ -520,16 +552,14 @@ class HttpArtifactResolver:
             cache_dir: Cache root directory
 
         Returns:
-            Number of files successfully fetched
+            Number of files successfully fetched (excluding cache hits)
         """
-        import xml.etree.ElementTree as ET
-
-        catalog_path = cache_dir / "artifacts" / "catalog-v001.xml"
+        catalog_path = cache_dir / "artifacts" / CATALOG_FILENAME
         if not catalog_path.exists():
             logger.warning("Artifacts catalog not cached, skipping catalog fetch")
             return 0
 
-        tree = ET.parse(catalog_path)
+        tree = ET.parse(catalog_path)  # noqa: S314 — trusted source (raw GitHub)
         root = tree.getroot()
         ns = {"cat": "urn:oasis:names:tc:entity:xmlns:xml:catalog"}
         uri_elems = root.findall("cat:uri", ns)
@@ -537,6 +567,7 @@ class HttpArtifactResolver:
             uri_elems = root.findall("uri")
 
         fetched = 0
+        cached = 0
         seen_paths: Set[str] = set()
 
         for elem in uri_elems:
@@ -547,6 +578,7 @@ class HttpArtifactResolver:
 
             dest = cache_dir / "artifacts" / rel_path
             if dest.exists():
+                cached += 1
                 continue
 
             url = f"{self.raw_github_base}/artifacts/{rel_path}"
@@ -561,7 +593,9 @@ class HttpArtifactResolver:
                 logger.warning("Failed to fetch artifact %s: %s", rel_path, e)
 
         if fetched:
-            logger.info("Fetched %d additional artifact files from catalog", fetched)
+            logger.info(
+                "Catalog artifacts: %d fetched, %d already cached", fetched, cached
+            )
         return fetched
 
     # =========================================================================
@@ -661,8 +695,12 @@ class HttpArtifactResolver:
                     break
 
         if not needed_domains:
-            logger.warning(
-                "No matching domains found for %d IRIs, fetching all",
+            # Non-registry domains (e.g., gx/gaia-x) are only discoverable
+            # via the artifacts catalog, not registry.json.  Fall back to a
+            # full cache build which includes catalog-based fetching.
+            logger.info(
+                "No registry-based domain match for %d IRI(s); "
+                "fetching all domains (includes catalog-only domains like gx)",
                 len(iris),
             )
             return self.ensure_cache()
@@ -680,11 +718,22 @@ class HttpArtifactResolver:
 
         Args:
             version: Specific version to clear. If None, clears entire cache.
+
+        Raises:
+            ValueError: If the resolved target is not under cache_base.
         """
         if version:
             target = self.cache_base / version
         else:
             target = self.cache_base
+
+        # Safety: ensure target is under the expected cache hierarchy.
+        try:
+            target.resolve().relative_to(self.cache_base.resolve())
+        except ValueError:
+            raise ValueError(
+                f"Refusing to delete {target}: not under cache base {self.cache_base}"
+            ) from None
 
         if target.exists():
             shutil.rmtree(target)

--- a/src/tools/utils/http_artifact_resolver.py
+++ b/src/tools/utils/http_artifact_resolver.py
@@ -1,0 +1,691 @@
+#!/usr/bin/env python3
+"""
+HTTP-based artifact resolution for pip-only OMB installations.
+
+When OMB is installed via ``pip install`` (without the full repository clone),
+the local ``artifacts/``, ``imports/``, and ``tests/`` directories are absent.
+This module fetches ontology artifacts from the published GitHub Pages site and
+raw GitHub content, caching them locally so the existing catalog-driven
+validation pipeline works unchanged.
+
+DESIGN:
+=======
+1. Fetch ``docs/registry.json`` from GitHub Pages — contains all domain→IRI→files
+2. Fetch the 3 XML catalogs (artifacts, imports, tests) from raw GitHub
+3. For each needed domain, fetch OWL/SHACL/context files from w3id.org or GH Pages
+4. Store everything in a cache directory that mirrors the repository structure
+5. ``RegistryResolver`` uses the cache dir as ``root_dir``
+
+CACHE STRUCTURE:
+================
+::
+
+    ~/.cache/omb/{version}/
+    ├── artifacts/
+    │   ├── catalog-v001.xml
+    │   └── {domain}/
+    │       ├── {domain}.owl.ttl
+    │       ├── {domain}.shacl.ttl
+    │       └── {domain}.context.jsonld
+    ├── imports/
+    │   ├── catalog-v001.xml
+    │   └── {module}/
+    │       ├── {module}.owl.ttl
+    │       └── {module}.context.jsonld
+    ├── tests/
+    │   └── catalog-v001.xml
+    └── docs/
+        └── registry.json
+
+USAGE:
+======
+::
+
+    from src.tools.utils.http_artifact_resolver import HttpArtifactResolver
+
+    resolver = HttpArtifactResolver()
+    cache_dir = resolver.ensure_cache()  # fetch everything needed
+    # Then use: RegistryResolver(root_dir=cache_dir)
+
+    # Or fetch only domains needed for specific IRIs:
+    cache_dir = resolver.ensure_cache_for_iris(iris_set)
+"""
+
+import json
+import os
+import platform
+import shutil
+import time
+from pathlib import Path
+from typing import Dict, List, Optional, Set
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from src.tools.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+# GitHub Pages base URL for published ontology artifacts.
+GH_PAGES_BASE = "https://ascs-ev.github.io/ontology-management-base"
+
+# Raw GitHub content for files not published to Pages (catalogs, imports).
+RAW_GITHUB_BASE = (
+    "https://raw.githubusercontent.com/ASCS-eV/ontology-management-base/main"
+)
+
+# Registry JSON URL (published via GH Pages docs workflow).
+REGISTRY_URL = f"{GH_PAGES_BASE}/registry.json"
+
+# W3ID artifact file names served by GitHub Pages.
+W3ID_ARTIFACTS = {
+    "ontology": "ontology.ttl",
+    "shapes": "shapes.ttl",
+    "context": "context.jsonld",
+}
+
+# Default HTTP timeout in seconds.
+HTTP_TIMEOUT = 30
+
+# Cache TTL: re-validate after this many seconds (24 hours).
+CACHE_TTL_SECONDS = 86400
+
+
+def _get_default_cache_dir() -> Path:
+    """Return platform-appropriate cache directory for OMB artifacts."""
+    if platform.system() == "Windows":
+        base = Path(os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local"))
+    else:
+        base = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
+    return base / "omb"
+
+
+def _http_get(url: str, timeout: int = HTTP_TIMEOUT) -> bytes:
+    """Fetch URL content with a simple GET request.
+
+    Args:
+        url: URL to fetch
+        timeout: Request timeout in seconds
+
+    Returns:
+        Response body as bytes
+
+    Raises:
+        URLError: On network failure
+        HTTPError: On non-2xx response
+    """
+    request = Request(url, headers={"User-Agent": "ontology-management-base"})
+    with urlopen(request, timeout=timeout) as response:
+        return response.read()
+
+
+def _http_get_with_accept(url: str, accept: str, timeout: int = HTTP_TIMEOUT) -> bytes:
+    """Fetch URL with a specific Accept header (content-negotiation).
+
+    Args:
+        url: URL to fetch
+        accept: Accept header value (e.g., "text/turtle")
+        timeout: Request timeout in seconds
+
+    Returns:
+        Response body as bytes
+    """
+    request = Request(
+        url,
+        headers={
+            "User-Agent": "ontology-management-base",
+            "Accept": accept,
+        },
+    )
+    with urlopen(request, timeout=timeout) as response:
+        return response.read()
+
+
+class HttpArtifactResolver:
+    """Fetches and caches OMB ontology artifacts from HTTP sources.
+
+    Attributes:
+        cache_dir: Root cache directory (versioned subdirs created inside)
+        gh_pages_base: GitHub Pages base URL
+        raw_github_base: Raw GitHub content base URL
+        registry_url: URL for docs/registry.json
+    """
+
+    def __init__(
+        self,
+        cache_dir: Optional[Path] = None,
+        gh_pages_base: str = GH_PAGES_BASE,
+        raw_github_base: str = RAW_GITHUB_BASE,
+        registry_url: str = REGISTRY_URL,
+        timeout: int = HTTP_TIMEOUT,
+    ):
+        """Initialize the HTTP artifact resolver.
+
+        Args:
+            cache_dir: Override default cache directory.
+            gh_pages_base: GitHub Pages base URL for w3id artifacts.
+            raw_github_base: Raw GitHub content base URL for catalogs/imports.
+            registry_url: URL for the domain registry JSON.
+            timeout: HTTP request timeout in seconds.
+        """
+        self.cache_base = cache_dir or _get_default_cache_dir()
+        self.gh_pages_base = gh_pages_base.rstrip("/")
+        self.raw_github_base = raw_github_base.rstrip("/")
+        self.registry_url = registry_url
+        self.timeout = timeout
+        self._registry: Optional[Dict] = None
+
+    # =========================================================================
+    # Registry Discovery
+    # =========================================================================
+
+    def fetch_registry(self) -> Dict:
+        """Fetch and parse docs/registry.json from GitHub Pages.
+
+        Returns:
+            Parsed registry dictionary with domain metadata.
+
+        Raises:
+            RuntimeError: If registry cannot be fetched or parsed.
+        """
+        if self._registry is not None:
+            return self._registry
+
+        logger.info("Fetching registry from %s", self.registry_url)
+        try:
+            data = _http_get(self.registry_url, self.timeout)
+            self._registry = json.loads(data.decode("utf-8"))
+            logger.info(
+                "Registry loaded: version=%s, domains=%d",
+                self._registry.get("version", "?"),
+                len(self._registry.get("ontologies", {})),
+            )
+            return self._registry
+        except (HTTPError, URLError, json.JSONDecodeError) as e:
+            raise RuntimeError(
+                f"Failed to fetch registry from {self.registry_url}: {e}"
+            ) from e
+
+    def get_registry_version(self) -> str:
+        """Get the latest release tag from the registry."""
+        registry = self.fetch_registry()
+        return registry.get("latestRelease", "unknown")
+
+    def get_domain_info(self) -> Dict[str, Dict]:
+        """Get domain→metadata mapping from the registry.
+
+        Returns:
+            Dict mapping domain name to its registry metadata
+            (namespace, iri, latest version, file paths).
+        """
+        registry = self.fetch_registry()
+        return registry.get("ontologies", {})
+
+    # =========================================================================
+    # Cache Management
+    # =========================================================================
+
+    def _versioned_cache_dir(self, version: Optional[str] = None) -> Path:
+        """Get the versioned cache directory.
+
+        Args:
+            version: Explicit version string, or auto-detect from registry.
+
+        Returns:
+            Path to versioned cache directory.
+        """
+        if version is None:
+            version = self.get_registry_version()
+        return self.cache_base / version
+
+    def is_cache_valid(self, cache_dir: Optional[Path] = None) -> bool:
+        """Check if the cache is present and not stale.
+
+        Args:
+            cache_dir: Explicit cache directory, or auto-detect.
+
+        Returns:
+            True if cache exists and is fresh enough to use.
+        """
+        if cache_dir is None:
+            try:
+                cache_dir = self._versioned_cache_dir()
+            except RuntimeError:
+                return False
+
+        marker = cache_dir / ".cache-timestamp"
+        if not marker.exists():
+            return False
+
+        try:
+            ts = float(marker.read_text().strip())
+            return (time.time() - ts) < CACHE_TTL_SECONDS
+        except (ValueError, OSError):
+            return False
+
+    def _write_cache_marker(self, cache_dir: Path) -> None:
+        """Write a timestamp marker for cache freshness tracking."""
+        marker = cache_dir / ".cache-timestamp"
+        marker.write_text(str(time.time()))
+
+    # =========================================================================
+    # Fetching: Catalogs
+    # =========================================================================
+
+    def fetch_catalog(self, catalog_rel_path: str, cache_dir: Path) -> Path:
+        """Fetch an XML catalog from raw GitHub and save to cache.
+
+        Args:
+            catalog_rel_path: Repo-relative path (e.g., "artifacts/catalog-v001.xml")
+            cache_dir: Cache root directory
+
+        Returns:
+            Absolute path to the cached catalog file
+        """
+        url = f"{self.raw_github_base}/{catalog_rel_path}"
+        dest = cache_dir / catalog_rel_path
+        dest.parent.mkdir(parents=True, exist_ok=True)
+
+        logger.info("Fetching catalog: %s", catalog_rel_path)
+        try:
+            data = _http_get(url, self.timeout)
+            dest.write_bytes(data)
+            logger.debug("Cached catalog: %s (%d bytes)", dest, len(data))
+            return dest
+        except (HTTPError, URLError) as e:
+            logger.warning("Failed to fetch catalog %s: %s", url, e)
+            raise
+
+    def fetch_all_catalogs(self, cache_dir: Path) -> None:
+        """Fetch all 3 XML catalogs to the cache directory."""
+        for rel_path in [
+            "artifacts/catalog-v001.xml",
+            "imports/catalog-v001.xml",
+            "tests/catalog-v001.xml",
+        ]:
+            try:
+                self.fetch_catalog(rel_path, cache_dir)
+            except (HTTPError, URLError):
+                if "tests/" in rel_path:
+                    logger.info("Tests catalog not required for remote mode")
+                else:
+                    raise
+
+    # =========================================================================
+    # Fetching: Registry JSON
+    # =========================================================================
+
+    def fetch_registry_to_cache(self, cache_dir: Path) -> Path:
+        """Fetch and cache docs/registry.json."""
+        registry = self.fetch_registry()
+        dest = cache_dir / "docs" / "registry.json"
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(json.dumps(registry, indent=3), encoding="utf-8")
+        return dest
+
+    # =========================================================================
+    # Fetching: Domain Artifacts (via w3id.org / GH Pages)
+    # =========================================================================
+
+    def _build_w3id_url(self, domain_info: Dict) -> Optional[str]:
+        """Build the w3id.org base URL for a domain's artifacts.
+
+        The w3id URL pattern depends on the namespace:
+        - ascs-ev: https://w3id.org/ascs-ev/envited-x/{domain}/{version}
+        - gaia-x4plcaad: https://w3id.org/gaia-x4plcaad/ontologies/{domain}/{version}
+        - gaia-x development: special case (# fragment IRI)
+
+        Args:
+            domain_info: Domain metadata from registry.json
+
+        Returns:
+            Base w3id.org URL, or None if cannot be determined.
+        """
+        iri = domain_info.get("iri")
+        if not iri:
+            return None
+        # The IRI itself is the w3id.org URL (minus any trailing # or /)
+        return iri.rstrip("#/")
+
+    def _build_gh_pages_url(self, domain_info: Dict) -> Optional[str]:
+        """Build the GitHub Pages URL for a domain's artifacts.
+
+        GH Pages URL pattern:
+        ``{GH_PAGES_BASE}/w3id/{namespace_path}/{version}/``
+
+        Args:
+            domain_info: Domain metadata from registry.json
+
+        Returns:
+            GH Pages base URL for the domain's w3id artifacts.
+        """
+        iri = domain_info.get("iri", "")
+        if not iri:
+            return None
+
+        # Extract the path after w3id.org/
+        if "w3id.org/" in iri:
+            path = iri.split("w3id.org/", 1)[1].rstrip("#/")
+            return f"{self.gh_pages_base}/w3id/{path}"
+
+        return None
+
+    def fetch_domain_artifacts(
+        self,
+        domain: str,
+        domain_info: Dict,
+        cache_dir: Path,
+    ) -> bool:
+        """Fetch OWL, SHACL, and context files for a domain.
+
+        Tries GitHub Pages first (direct URL), falls back to w3id.org
+        content-negotiation.
+
+        Args:
+            domain: Domain name (e.g., "hdmap")
+            domain_info: Domain metadata from registry.json
+            cache_dir: Cache root directory
+
+        Returns:
+            True if at least the ontology was fetched successfully
+        """
+        domain_dir = cache_dir / "artifacts" / domain
+        domain_dir.mkdir(parents=True, exist_ok=True)
+
+        gh_url = self._build_gh_pages_url(domain_info)
+        w3id_url = self._build_w3id_url(domain_info)
+
+        # Map of local filename → (GH Pages artifact name, w3id accept header)
+        file_map = {
+            f"{domain}.owl.ttl": ("ontology.ttl", "text/turtle"),
+            f"{domain}.shacl.ttl": ("shapes.ttl", "text/turtle"),
+            f"{domain}.context.jsonld": ("context.jsonld", "application/ld+json"),
+        }
+
+        ontology_fetched = False
+
+        for local_name, (gh_artifact, accept_header) in file_map.items():
+            dest = domain_dir / local_name
+            if dest.exists():
+                logger.debug("Already cached: %s", dest)
+                if local_name.endswith(".owl.ttl"):
+                    ontology_fetched = True
+                continue
+
+            fetched = False
+
+            # Strategy 1: GitHub Pages direct URL
+            if gh_url:
+                artifact_url = f"{gh_url}/{gh_artifact}"
+                try:
+                    data = _http_get(artifact_url, self.timeout)
+                    dest.write_bytes(data)
+                    logger.info("Fetched %s/%s from GH Pages", domain, local_name)
+                    fetched = True
+                except (HTTPError, URLError) as e:
+                    logger.debug("GH Pages fetch failed for %s: %s", artifact_url, e)
+
+            # Strategy 2: w3id.org content-negotiation
+            if not fetched and w3id_url:
+                # For shapes, use the /shapes path
+                if "shacl" in local_name:
+                    conneg_url = f"{w3id_url}/shapes"
+                else:
+                    conneg_url = w3id_url
+                try:
+                    data = _http_get_with_accept(
+                        conneg_url, accept_header, self.timeout
+                    )
+                    dest.write_bytes(data)
+                    logger.info("Fetched %s/%s via w3id.org conneg", domain, local_name)
+                    fetched = True
+                except (HTTPError, URLError) as e:
+                    logger.debug("w3id.org conneg failed for %s: %s", conneg_url, e)
+
+            if not fetched:
+                logger.warning(
+                    "Could not fetch %s/%s from any source", domain, local_name
+                )
+            elif local_name.endswith(".owl.ttl"):
+                ontology_fetched = True
+
+        return ontology_fetched
+
+    # =========================================================================
+    # Fetching: Import Ontologies (from raw GitHub)
+    # =========================================================================
+
+    def fetch_import_files(self, cache_dir: Path) -> int:
+        """Fetch all base ontology files listed in imports/catalog-v001.xml.
+
+        Reads the cached imports catalog to discover which files are needed,
+        then fetches each from raw GitHub.
+
+        Args:
+            cache_dir: Cache root directory
+
+        Returns:
+            Number of files successfully fetched
+        """
+        import xml.etree.ElementTree as ET
+
+        catalog_path = cache_dir / "imports" / "catalog-v001.xml"
+        if not catalog_path.exists():
+            logger.warning("Imports catalog not cached, cannot fetch import files")
+            return 0
+
+        tree = ET.parse(catalog_path)
+        root = tree.getroot()
+        ns = {"cat": "urn:oasis:names:tc:entity:xmlns:xml:catalog"}
+        uri_elems = root.findall("cat:uri", ns)
+        if not uri_elems:
+            uri_elems = root.findall("uri")
+
+        fetched = 0
+        seen_paths: Set[str] = set()
+
+        for elem in uri_elems:
+            rel_path = elem.get("uri")
+            if not rel_path or rel_path in seen_paths:
+                continue
+            seen_paths.add(rel_path)
+
+            dest = cache_dir / "imports" / rel_path
+            if dest.exists():
+                fetched += 1
+                continue
+
+            url = f"{self.raw_github_base}/imports/{rel_path}"
+            dest.parent.mkdir(parents=True, exist_ok=True)
+
+            try:
+                data = _http_get(url, self.timeout)
+                dest.write_bytes(data)
+                logger.debug("Fetched import: %s", rel_path)
+                fetched += 1
+            except (HTTPError, URLError) as e:
+                logger.warning("Failed to fetch import %s: %s", rel_path, e)
+
+        logger.info("Fetched %d import files", fetched)
+        return fetched
+
+    def fetch_artifacts_from_catalog(self, cache_dir: Path) -> int:
+        """Fetch artifact files referenced in artifacts/catalog-v001.xml.
+
+        This is the fallback for domains NOT in registry.json (e.g., the
+        ``gx`` domain with IRI ``https://w3id.org/gaia-x/development#``).
+        Parses the cached artifacts catalog and fetches any referenced files
+        that are not yet present in the cache.
+
+        Args:
+            cache_dir: Cache root directory
+
+        Returns:
+            Number of files successfully fetched
+        """
+        import xml.etree.ElementTree as ET
+
+        catalog_path = cache_dir / "artifacts" / "catalog-v001.xml"
+        if not catalog_path.exists():
+            logger.warning("Artifacts catalog not cached, skipping catalog fetch")
+            return 0
+
+        tree = ET.parse(catalog_path)
+        root = tree.getroot()
+        ns = {"cat": "urn:oasis:names:tc:entity:xmlns:xml:catalog"}
+        uri_elems = root.findall("cat:uri", ns)
+        if not uri_elems:
+            uri_elems = root.findall("uri")
+
+        fetched = 0
+        seen_paths: Set[str] = set()
+
+        for elem in uri_elems:
+            rel_path = elem.get("uri")
+            if not rel_path or rel_path in seen_paths:
+                continue
+            seen_paths.add(rel_path)
+
+            dest = cache_dir / "artifacts" / rel_path
+            if dest.exists():
+                continue
+
+            url = f"{self.raw_github_base}/artifacts/{rel_path}"
+            dest.parent.mkdir(parents=True, exist_ok=True)
+
+            try:
+                data = _http_get(url, self.timeout)
+                dest.write_bytes(data)
+                logger.debug("Fetched artifact from catalog: %s", rel_path)
+                fetched += 1
+            except (HTTPError, URLError) as e:
+                logger.warning("Failed to fetch artifact %s: %s", rel_path, e)
+
+        if fetched:
+            logger.info("Fetched %d additional artifact files from catalog", fetched)
+        return fetched
+
+    # =========================================================================
+    # High-Level API
+    # =========================================================================
+
+    def ensure_cache(
+        self,
+        domains: Optional[List[str]] = None,
+        force: bool = False,
+    ) -> Path:
+        """Ensure all required artifacts are cached locally.
+
+        Fetches registry, catalogs, domain artifacts, and import files.
+        Returns the cache directory that can be used as ``root_dir`` for
+        ``RegistryResolver``.
+
+        Args:
+            domains: Optional list of specific domains to fetch.
+                     If None, fetches all domains from the registry.
+            force: If True, re-fetch even if cache is valid.
+
+        Returns:
+            Path to the versioned cache directory (use as root_dir).
+        """
+        version = self.get_registry_version()
+        cache_dir = self._versioned_cache_dir(version)
+
+        if not force and self.is_cache_valid(cache_dir):
+            logger.info("Using valid cache at %s", cache_dir)
+            return cache_dir
+
+        logger.info("Building artifact cache at %s", cache_dir)
+        cache_dir.mkdir(parents=True, exist_ok=True)
+
+        # Step 1: Fetch registry
+        self.fetch_registry_to_cache(cache_dir)
+
+        # Step 2: Fetch catalogs
+        self.fetch_all_catalogs(cache_dir)
+
+        # Step 3: Fetch domain artifacts
+        domain_info = self.get_domain_info()
+        if domains is None:
+            domains = list(domain_info.keys())
+
+        fetched_domains = []
+        for domain_name in domains:
+            info = domain_info.get(domain_name)
+            if not info:
+                logger.warning("Domain '%s' not found in registry", domain_name)
+                continue
+            if self.fetch_domain_artifacts(domain_name, info, cache_dir):
+                fetched_domains.append(domain_name)
+
+        logger.info(
+            "Fetched artifacts for %d/%d domains",
+            len(fetched_domains),
+            len(domains),
+        )
+
+        # Step 4: Fetch import ontologies
+        self.fetch_import_files(cache_dir)
+
+        # Step 5: Fetch any remaining artifacts from catalog
+        # (covers domains like gx that are in catalog but not registry.json)
+        self.fetch_artifacts_from_catalog(cache_dir)
+
+        # Step 6: Write cache marker
+        self._write_cache_marker(cache_dir)
+
+        return cache_dir
+
+    def ensure_cache_for_iris(self, iris: Set[str]) -> Path:
+        """Ensure artifacts are cached for domains matching the given IRIs.
+
+        Discovers which domains are needed based on the IRI prefixes in the
+        data, and fetches only those domains.
+
+        Args:
+            iris: Set of RDF type or predicate IRIs from data being validated.
+
+        Returns:
+            Path to the versioned cache directory.
+        """
+        domain_info = self.get_domain_info()
+        needed_domains: Set[str] = set()
+
+        for iri in iris:
+            for domain_name, info in domain_info.items():
+                domain_iri = info.get("iri", "")
+                if not domain_iri:
+                    continue
+                base = domain_iri.rstrip("#/")
+                if iri.startswith(base + "/") or iri.startswith(base + "#"):
+                    needed_domains.add(domain_name)
+                    break
+
+        if not needed_domains:
+            logger.warning(
+                "No matching domains found for %d IRIs, fetching all",
+                len(iris),
+            )
+            return self.ensure_cache()
+
+        logger.info(
+            "Resolved %d IRIs to %d domains: %s",
+            len(iris),
+            len(needed_domains),
+            sorted(needed_domains),
+        )
+        return self.ensure_cache(domains=list(needed_domains))
+
+    def clear_cache(self, version: Optional[str] = None) -> None:
+        """Remove cached artifacts.
+
+        Args:
+            version: Specific version to clear. If None, clears entire cache.
+        """
+        if version:
+            target = self.cache_base / version
+        else:
+            target = self.cache_base
+
+        if target.exists():
+            shutil.rmtree(target)
+            logger.info("Cleared cache: %s", target)

--- a/src/tools/utils/registry_resolver.py
+++ b/src/tools/utils/registry_resolver.py
@@ -69,12 +69,14 @@ class RegistryResolver:
         domains = resolver.list_domains()
     """
 
-    def __init__(self, root_dir: Path = None):
+    def __init__(self, root_dir: Path = None, enable_http: bool = False):
         """
         Initialize the registry resolver.
 
         Args:
             root_dir: Root directory of the repository. Defaults to current directory.
+            enable_http: If True and local catalogs are missing, bootstrap
+                artifacts from HTTP using HttpArtifactResolver.
         """
         self.root_dir = Path(root_dir or Path.cwd()).resolve()
         self._registry: Dict = {}
@@ -86,11 +88,30 @@ class RegistryResolver:
         self._imports_catalog_entries: Optional[Dict[str, str]] = None
         self._imports_context_entries: Optional[Dict[str, str]] = None
         self._imports_shacl_entries: Optional[Dict[str, List[str]]] = None
+        self._http_enabled: bool = False
+
+        if enable_http and not self._has_local_catalogs():
+            self._bootstrap_from_http()
 
         self._load_registry()
-        self._load_catalog()  # Replaces _load_fixtures_catalog
+        self._load_catalog()
         self._load_artifacts_catalog()
         self._build_iri_index()
+
+    def _has_local_catalogs(self) -> bool:
+        """Check whether the essential XML catalogs exist locally."""
+        artifacts_cat = self.root_dir / "artifacts" / "catalog-v001.xml"
+        imports_cat = self.root_dir / "imports" / "catalog-v001.xml"
+        return artifacts_cat.exists() and imports_cat.exists()
+
+    def _bootstrap_from_http(self) -> None:
+        """Fetch artifacts via HTTP and point root_dir at the cache."""
+        from src.tools.utils.http_artifact_resolver import HttpArtifactResolver
+
+        http_resolver = HttpArtifactResolver()
+        cache_dir = http_resolver.ensure_cache()
+        self.root_dir = cache_dir
+        self._http_enabled = True
 
     def _load_registry(self) -> None:
         """Load docs/registry.json."""

--- a/src/tools/utils/registry_resolver.py
+++ b/src/tools/utils/registry_resolver.py
@@ -80,7 +80,6 @@ class RegistryResolver:
                 replaces ``root_dir`` with the HTTP cache directory.
         """
         self.root_dir = Path(root_dir or Path.cwd()).resolve()
-        self._original_root_dir = self.root_dir
         self._registry: Dict = {}
         self._catalog: Dict[str, Dict] = {}  # Full catalog (test-data + fixtures)
         self._fixtures_catalog: Dict[str, str] = {}  # Fixture IRIs only
@@ -99,6 +98,11 @@ class RegistryResolver:
         self._load_catalog()
         self._load_artifacts_catalog()
         self._build_iri_index()
+
+    @property
+    def is_http_bootstrapped(self) -> bool:
+        """Whether this resolver was bootstrapped from HTTP cache."""
+        return self._http_enabled
 
     def _has_local_catalogs(self) -> bool:
         """Check whether the essential XML catalogs exist locally."""

--- a/src/tools/utils/registry_resolver.py
+++ b/src/tools/utils/registry_resolver.py
@@ -76,9 +76,11 @@ class RegistryResolver:
         Args:
             root_dir: Root directory of the repository. Defaults to current directory.
             enable_http: If True and local catalogs are missing, bootstrap
-                artifacts from HTTP using HttpArtifactResolver.
+                artifacts from HTTP using HttpArtifactResolver.  Note: this
+                replaces ``root_dir`` with the HTTP cache directory.
         """
         self.root_dir = Path(root_dir or Path.cwd()).resolve()
+        self._original_root_dir = self.root_dir
         self._registry: Dict = {}
         self._catalog: Dict[str, Dict] = {}  # Full catalog (test-data + fixtures)
         self._fixtures_catalog: Dict[str, str] = {}  # Fixture IRIs only
@@ -100,8 +102,9 @@ class RegistryResolver:
 
     def _has_local_catalogs(self) -> bool:
         """Check whether the essential XML catalogs exist locally."""
-        artifacts_cat = self.root_dir / "artifacts" / "catalog-v001.xml"
-        imports_cat = self.root_dir / "imports" / "catalog-v001.xml"
+        catalog_name = "catalog-v001.xml"
+        artifacts_cat = self.root_dir / "artifacts" / catalog_name
+        imports_cat = self.root_dir / "imports" / catalog_name
         return artifacts_cat.exists() and imports_cat.exists()
 
     def _bootstrap_from_http(self) -> None:
@@ -110,6 +113,11 @@ class RegistryResolver:
 
         http_resolver = HttpArtifactResolver()
         cache_dir = http_resolver.ensure_cache()
+        logger.info(
+            "HTTP bootstrap: root_dir changed from %s to cache at %s",
+            self.root_dir,
+            cache_dir,
+        )
         self.root_dir = cache_dir
         self._http_enabled = True
 

--- a/src/tools/validators/shacl/validator.py
+++ b/src/tools/validators/shacl/validator.py
@@ -96,6 +96,7 @@ class ShaclValidator:
         resolver: Optional["RegistryResolver"] = None,
         strict: bool = False,
         allow_online: bool = True,
+        enable_http: bool = False,
     ):
         """
         Initialize the SHACL validator.
@@ -109,9 +110,12 @@ class ShaclValidator:
                 registered on the resolver before passing.
             strict: If True, unresolved IRIs cause validation failure.
             allow_online: If True, attempt HTTP resolution for unresolved IRIs.
+            enable_http: If True and no local catalogs, bootstrap via HTTP.
         """
         self.root_dir = Path(root_dir).resolve()
-        self.resolver = resolver if resolver else RegistryResolver(root_dir)
+        self.resolver = resolver if resolver else RegistryResolver(
+            root_dir, enable_http=enable_http
+        )
         self.inference_mode = inference_mode
         self.verbose = verbose
         self.strict = strict

--- a/src/tools/validators/shacl/validator.py
+++ b/src/tools/validators/shacl/validator.py
@@ -113,8 +113,15 @@ class ShaclValidator:
             enable_http: If True and no local catalogs, bootstrap via HTTP.
         """
         self.root_dir = Path(root_dir).resolve()
-        self.resolver = resolver if resolver else RegistryResolver(
-            root_dir, enable_http=enable_http
+        if resolver and enable_http:
+            logger.warning(
+                "Both 'resolver' and 'enable_http' provided to ShaclValidator; "
+                "'enable_http' is ignored when a pre-built resolver is supplied"
+            )
+        self.resolver = (
+            resolver
+            if resolver
+            else RegistryResolver(root_dir, enable_http=enable_http)
         )
         self.inference_mode = inference_mode
         self.verbose = verbose

--- a/src/tools/validators/validation_suite.py
+++ b/src/tools/validators/validation_suite.py
@@ -261,6 +261,9 @@ def validate_data_conformance_all(
     print("📋 Using catalog-based test discovery\n", flush=True)
 
     # Create validator with shared resolver
+    # Note: enable_http is not passed here because catalog_resolver is already
+    # HTTP-bootstrapped when --remote is used.  ShaclValidator uses the
+    # pre-built resolver directly.
     validator = ShaclValidator(
         root_dir,
         inference_mode=inference_mode,
@@ -343,7 +346,7 @@ def check_failing_tests_all(
 
     print("📋 Using catalog-based test discovery\n", flush=True)
 
-    # Create validator with shared resolver
+    # Create validator with shared resolver (already HTTP-bootstrapped if --remote)
     validator = ShaclValidator(
         root_dir,
         inference_mode=inference_mode,

--- a/src/tools/validators/validation_suite.py
+++ b/src/tools/validators/validation_suite.py
@@ -621,7 +621,16 @@ def main():
         help="Disable online fallback for unresolved IRIs.",
     )
 
+    target_group.add_argument(
+        "--remote",
+        action="store_true",
+        default=False,
+        help="Enable HTTP artifact resolution for pip-only installations "
+        "(fetches ontology schemas from GitHub Pages when local catalogs are missing).",
+    )
+
     args = parser.parse_args()
+    _enable_http = args.remote
 
     # DATA PATHS MODE: User specified file/directory paths
     # Uses auto-discovery to detect top-level files vs fixtures
@@ -665,7 +674,7 @@ def main():
                 print(f"      - {dup_id}: {file_names}")
 
         # Create catalog resolver
-        catalog_resolver = RegistryResolver(ROOT_DIR)
+        catalog_resolver = RegistryResolver(ROOT_DIR, enable_http=_enable_http)
 
         # Register discovered fixtures for IRI resolution
         if iri_to_file:
@@ -703,7 +712,7 @@ def main():
     # DOMAIN MODE: User specified catalog domains
     elif args.domain is not None:
         print(f"🔍 Domain mode: Using catalog for domain(s): {args.domain}", flush=True)
-        catalog_resolver = RegistryResolver(ROOT_DIR)
+        catalog_resolver = RegistryResolver(ROOT_DIR, enable_http=_enable_http)
 
         # Register additional artifact directories (before checking domains)
         if args.artifacts:
@@ -742,7 +751,7 @@ def main():
     # AUTO MODE: Discover all domains from catalog
     else:
         print("🔍 Auto mode: Discovering all domains from catalog", flush=True)
-        catalog_resolver = RegistryResolver(ROOT_DIR)
+        catalog_resolver = RegistryResolver(ROOT_DIR, enable_http=_enable_http)
         ontology_domains = catalog_resolver.get_test_domains()
 
         if not ontology_domains:

--- a/tests/unit/utils/test_http_artifact_resolver.py
+++ b/tests/unit/utils/test_http_artifact_resolver.py
@@ -4,12 +4,15 @@ import json
 import textwrap
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+from urllib.error import URLError
 
 import pytest
 
 from src.tools.utils.http_artifact_resolver import (
+    ALLOWED_HOSTS,
     HttpArtifactResolver,
     _get_default_cache_dir,
+    _validate_response_host,
 )
 
 
@@ -396,7 +399,7 @@ class TestDefaultCacheDir:
 
 
 class TestRegistryResolverHttpFallback:
-    """Tests for RegistryResolver.enable_http_fallback()."""
+    """Tests for RegistryResolver HTTP bootstrap via _bootstrap_from_http()."""
 
     def test_enable_http_false_default_no_http_calls(self, tmp_path):
         """Default enable_http=False does not trigger HTTP fetching."""
@@ -445,3 +448,154 @@ class TestRegistryResolverHttpFallback:
             resolver = RegistryResolver(tmp_path, enable_http=True)
             MockResolver.assert_not_called()
             assert resolver._http_enabled is False
+
+
+# ---------------------------------------------------------------------------
+# Host Allowlist Validation (SSRF prevention)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateResponseHost:
+    """Tests for _validate_response_host SSRF prevention."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://ascs-ev.github.io/ontology-management-base/registry.json",
+            "https://raw.githubusercontent.com/ASCS-eV/ontology-management-base/main/x",
+            "https://w3id.org/ascs-ev/envited-x/hdmap/v6/ontology.ttl",
+        ],
+    )
+    def test_allowed_hosts_pass(self, url):
+        """Trusted hosts do not raise."""
+        _validate_response_host(url)  # should not raise
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://evil.example.com/payload",
+            "http://169.254.169.254/latest/meta-data/",
+            "https://internal-service.company.com/secret",
+        ],
+    )
+    def test_untrusted_hosts_raise(self, url):
+        """Untrusted hosts raise URLError."""
+        with pytest.raises(URLError, match="untrusted host"):
+            _validate_response_host(url)
+
+    def test_allowed_hosts_constant_has_expected_entries(self):
+        """ALLOWED_HOSTS includes the three expected domains."""
+        assert "ascs-ev.github.io" in ALLOWED_HOSTS
+        assert "raw.githubusercontent.com" in ALLOWED_HOSTS
+        assert "w3id.org" in ALLOWED_HOSTS
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "file:///tmp/test",
+            "not-a-url",
+            "",
+        ],
+    )
+    def test_missing_host_raises(self, url):
+        """URLs without a hostname are rejected (fail-closed)."""
+        with pytest.raises(URLError, match="missing host"):
+            _validate_response_host(url)
+
+
+# ---------------------------------------------------------------------------
+# W3ID Content-Negotiation Fallback
+# ---------------------------------------------------------------------------
+
+
+class TestW3idConnegFallback:
+    """Tests for fetch_domain_artifacts w3id.org content-negotiation path."""
+
+    def test_falls_back_to_w3id_when_gh_pages_fails(self, tmp_path):
+        """When GH Pages returns 404, w3id.org content-negotiation is tried."""
+        from urllib.error import HTTPError
+
+        resolver = HttpArtifactResolver(cache_dir=tmp_path)
+
+        domain_info = {
+            "iri": "https://w3id.org/ascs-ev/envited-x/hdmap/v6",
+            "namespace": "ascs-ev",
+        }
+
+        gh_pages_404 = HTTPError(
+            url="https://ascs-ev.github.io/...",
+            code=404,
+            msg="Not Found",
+            hdrs={},
+            fp=None,
+        )
+
+        call_count = {"_http_get": 0, "_http_get_with_accept": 0}
+
+        def mock_http_get(url, timeout=30):
+            call_count["_http_get"] += 1
+            raise gh_pages_404
+
+        def mock_http_get_with_accept(url, accept, timeout=30):
+            call_count["_http_get_with_accept"] += 1
+            return b"# turtle content"
+
+        with (
+            patch(
+                "src.tools.utils.http_artifact_resolver._http_get",
+                side_effect=mock_http_get,
+            ),
+            patch(
+                "src.tools.utils.http_artifact_resolver._http_get_with_accept",
+                side_effect=mock_http_get_with_accept,
+            ),
+        ):
+            result = resolver.fetch_domain_artifacts("hdmap", domain_info, tmp_path)
+
+        assert result is True
+        # GH Pages was tried (and failed) for all 3 artifacts
+        assert call_count["_http_get"] == 3
+        # w3id.org conneg was tried as fallback for all 3
+        assert call_count["_http_get_with_accept"] == 3
+
+
+# ---------------------------------------------------------------------------
+# clear_cache Safety
+# ---------------------------------------------------------------------------
+
+
+class TestClearCacheSafety:
+    """Tests for clear_cache path validation."""
+
+    def test_clear_cache_no_version_removes_cache_base(self, tmp_path):
+        """clear_cache(None) removes the entire cache_base directory."""
+        cache_base = tmp_path / "omb"
+        cache_base.mkdir()
+        (cache_base / "v0.1.4").mkdir()
+        (cache_base / "v0.1.4" / "marker.txt").write_text("x")
+
+        resolver = HttpArtifactResolver(cache_dir=cache_base)
+        resolver.clear_cache()
+
+        assert not cache_base.exists()
+
+    def test_clear_cache_with_version_only_removes_version(self, tmp_path):
+        """clear_cache('v0.1.4') only removes that version subdir."""
+        cache_base = tmp_path / "omb"
+        (cache_base / "v0.1.4").mkdir(parents=True)
+        (cache_base / "v0.1.5").mkdir(parents=True)
+
+        resolver = HttpArtifactResolver(cache_dir=cache_base)
+        resolver.clear_cache("v0.1.4")
+
+        assert not (cache_base / "v0.1.4").exists()
+        assert (cache_base / "v0.1.5").exists()
+
+    def test_clear_cache_rejects_path_traversal(self, tmp_path):
+        """clear_cache rejects version strings that escape cache_base."""
+        cache_base = tmp_path / "omb"
+        cache_base.mkdir()
+
+        resolver = HttpArtifactResolver(cache_dir=cache_base)
+        with pytest.raises(ValueError, match="not under cache base"):
+            resolver.clear_cache("../../etc")

--- a/tests/unit/utils/test_http_artifact_resolver.py
+++ b/tests/unit/utils/test_http_artifact_resolver.py
@@ -1,0 +1,447 @@
+"""Tests for HTTP artifact resolution (src.tools.utils.http_artifact_resolver)."""
+
+import json
+import textwrap
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.tools.utils.http_artifact_resolver import (
+    HttpArtifactResolver,
+    _get_default_cache_dir,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SAMPLE_REGISTRY = {
+    "version": "2.1.0",
+    "latestRelease": "v0.1.4",
+    "ontologies": {
+        "hdmap": {
+            "namespace": "ascs-ev",
+            "iri": "https://w3id.org/ascs-ev/envited-x/hdmap/v6",
+            "latest": "v6",
+            "versions": {
+                "v6": {
+                    "releaseTag": "v0.1.4",
+                    "versionInfo": "v6",
+                    "versionIri": "https://w3id.org/ascs-ev/envited-x/hdmap/v6",
+                    "files": {
+                        "ontology": "artifacts/hdmap/hdmap.owl.ttl",
+                        "shacl": ["artifacts/hdmap/hdmap.shacl.ttl"],
+                        "jsonld": "artifacts/hdmap/hdmap.context.jsonld",
+                    },
+                }
+            },
+        },
+        "scenario": {
+            "namespace": "ascs-ev",
+            "iri": "https://w3id.org/ascs-ev/envited-x/scenario/v6",
+            "latest": "v6",
+            "versions": {
+                "v6": {
+                    "releaseTag": "v0.1.4",
+                    "versionInfo": "v6",
+                    "versionIri": "https://w3id.org/ascs-ev/envited-x/scenario/v6",
+                    "files": {
+                        "ontology": "artifacts/scenario/scenario.owl.ttl",
+                        "shacl": ["artifacts/scenario/scenario.shacl.ttl"],
+                        "jsonld": "artifacts/scenario/scenario.context.jsonld",
+                    },
+                }
+            },
+        },
+    },
+}
+
+SAMPLE_ARTIFACTS_CATALOG = textwrap.dedent("""\
+    <?xml version="1.0" encoding="UTF-8"?>
+    <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+      <uri name="https://w3id.org/ascs-ev/envited-x/hdmap/v6" uri="hdmap/hdmap.owl.ttl"/>
+      <uri name="https://w3id.org/ascs-ev/envited-x/hdmap/v6/shapes" uri="hdmap/hdmap.shacl.ttl"/>
+      <uri name="https://w3id.org/ascs-ev/envited-x/hdmap/v6/context" uri="hdmap/hdmap.context.jsonld"/>
+      <uri name="https://w3id.org/gaia-x/development#" uri="gx/gx.owl.ttl"/>
+      <uri name="https://w3id.org/gaia-x/development#shapes" uri="gx/gx.shacl.ttl"/>
+    </catalog>
+""")
+
+SAMPLE_IMPORTS_CATALOG = textwrap.dedent("""\
+    <?xml version="1.0" encoding="UTF-8"?>
+    <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+      <uri name="http://www.w3.org/1999/02/22-rdf-syntax-ns#" uri="rdf/rdf.owl.ttl"/>
+      <uri name="http://www.w3.org/2000/01/rdf-schema#" uri="rdfs/rdfs.owl.ttl"/>
+    </catalog>
+""")
+
+
+@pytest.fixture
+def resolver(tmp_path):
+    """Create an HttpArtifactResolver with a temp cache dir."""
+    return HttpArtifactResolver(
+        cache_dir=tmp_path / "cache",
+        registry_url="https://test.example.com/registry.json",
+        gh_pages_base="https://test.example.com/pages",
+        raw_github_base="https://test.example.com/raw",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registry Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryFetch:
+    """Tests for registry discovery."""
+
+    def test_fetch_registry_caches_result(self, resolver):
+        """Registry is fetched once and cached in memory."""
+        with patch("src.tools.utils.http_artifact_resolver._http_get") as mock_get:
+            mock_get.return_value = json.dumps(SAMPLE_REGISTRY).encode()
+            result = resolver.fetch_registry()
+            assert result["version"] == "2.1.0"
+            assert len(result["ontologies"]) == 2
+
+            # Second call should NOT trigger another HTTP request
+            result2 = resolver.fetch_registry()
+            assert result2 is result
+            mock_get.assert_called_once()
+
+    def test_get_registry_version(self, resolver):
+        """get_registry_version returns latestRelease."""
+        with patch("src.tools.utils.http_artifact_resolver._http_get") as mock_get:
+            mock_get.return_value = json.dumps(SAMPLE_REGISTRY).encode()
+            assert resolver.get_registry_version() == "v0.1.4"
+
+    def test_get_domain_info(self, resolver):
+        """get_domain_info returns ontologies dict."""
+        with patch("src.tools.utils.http_artifact_resolver._http_get") as mock_get:
+            mock_get.return_value = json.dumps(SAMPLE_REGISTRY).encode()
+            info = resolver.get_domain_info()
+            assert "hdmap" in info
+            assert "scenario" in info
+            assert info["hdmap"]["iri"] == "https://w3id.org/ascs-ev/envited-x/hdmap/v6"
+
+    def test_fetch_registry_raises_on_failure(self, resolver):
+        """RuntimeError raised when registry fetch fails."""
+        from urllib.error import URLError
+
+        with patch(
+            "src.tools.utils.http_artifact_resolver._http_get",
+            side_effect=URLError("connection refused"),
+        ):
+            with pytest.raises(RuntimeError, match="Failed to fetch registry"):
+                resolver.fetch_registry()
+
+
+# ---------------------------------------------------------------------------
+# Cache Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCacheManagement:
+    """Tests for cache freshness and directory management."""
+
+    def test_is_cache_valid_false_when_no_marker(self, resolver, tmp_path):
+        """Cache is invalid when no timestamp marker exists."""
+        cache_dir = tmp_path / "empty"
+        cache_dir.mkdir()
+        assert not resolver.is_cache_valid(cache_dir)
+
+    def test_is_cache_valid_true_when_fresh(self, resolver, tmp_path):
+        """Cache is valid when marker is recent."""
+        import time
+
+        cache_dir = tmp_path / "fresh"
+        cache_dir.mkdir()
+        (cache_dir / ".cache-timestamp").write_text(str(time.time()))
+        assert resolver.is_cache_valid(cache_dir)
+
+    def test_is_cache_valid_false_when_stale(self, resolver, tmp_path):
+        """Cache is invalid when marker is older than TTL."""
+        import time
+
+        cache_dir = tmp_path / "stale"
+        cache_dir.mkdir()
+        old_time = time.time() - 100000  # Way past TTL
+        (cache_dir / ".cache-timestamp").write_text(str(old_time))
+        assert not resolver.is_cache_valid(cache_dir)
+
+    def test_clear_cache_removes_directory(self, resolver, tmp_path):
+        """clear_cache removes the cache directory."""
+        resolver.cache_base = tmp_path / "cache"
+        version_dir = resolver.cache_base / "v0.1.4"
+        version_dir.mkdir(parents=True)
+        (version_dir / "test.txt").write_text("data")
+
+        resolver.clear_cache("v0.1.4")
+        assert not version_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# Catalog Fetch Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCatalogFetch:
+    """Tests for XML catalog fetching."""
+
+    def test_fetch_catalog_saves_to_correct_path(self, resolver, tmp_path):
+        """Catalog is saved under the correct relative path."""
+        cache_dir = tmp_path / "cache"
+        with patch("src.tools.utils.http_artifact_resolver._http_get") as mock_get:
+            mock_get.return_value = SAMPLE_ARTIFACTS_CATALOG.encode()
+            path = resolver.fetch_catalog("artifacts/catalog-v001.xml", cache_dir)
+
+            assert path == cache_dir / "artifacts" / "catalog-v001.xml"
+            assert path.exists()
+            assert "hdmap" in path.read_text()
+
+    def test_fetch_all_catalogs_fetches_three(self, resolver, tmp_path):
+        """fetch_all_catalogs requests all 3 catalog files."""
+        cache_dir = tmp_path / "cache"
+        with patch("src.tools.utils.http_artifact_resolver._http_get") as mock_get:
+            mock_get.return_value = b"<catalog/>"
+            resolver.fetch_all_catalogs(cache_dir)
+            assert mock_get.call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# Domain Artifact Fetch Tests
+# ---------------------------------------------------------------------------
+
+
+class TestDomainArtifactFetch:
+    """Tests for fetching OWL/SHACL/context files."""
+
+    def test_build_gh_pages_url_ascs_ev(self, resolver):
+        """GH Pages URL for ascs-ev namespace."""
+        info = {"iri": "https://w3id.org/ascs-ev/envited-x/hdmap/v6"}
+        url = resolver._build_gh_pages_url(info)
+        assert url == "https://test.example.com/pages/w3id/ascs-ev/envited-x/hdmap/v6"
+
+    def test_build_gh_pages_url_gaiax4plcaad(self, resolver):
+        """GH Pages URL for legacy gaia-x4plcaad namespace."""
+        info = {"iri": "https://w3id.org/gaia-x4plcaad/ontologies/general/v3"}
+        url = resolver._build_gh_pages_url(info)
+        assert (
+            url
+            == "https://test.example.com/pages/w3id/gaia-x4plcaad/ontologies/general/v3"
+        )
+
+    def test_build_gh_pages_url_gaiax_development_strips_hash(self, resolver):
+        """GH Pages URL strips trailing # from gx development IRI."""
+        info = {"iri": "https://w3id.org/gaia-x/development#"}
+        url = resolver._build_gh_pages_url(info)
+        assert url == "https://test.example.com/pages/w3id/gaia-x/development"
+
+    def test_fetch_domain_artifacts_creates_files(self, resolver, tmp_path):
+        """Domain artifacts are downloaded and saved with correct names."""
+        cache_dir = tmp_path / "cache"
+        info = {"iri": "https://w3id.org/ascs-ev/envited-x/hdmap/v6"}
+
+        with patch("src.tools.utils.http_artifact_resolver._http_get") as mock_get:
+            mock_get.return_value = b"@prefix hdmap: <...> ."
+            result = resolver.fetch_domain_artifacts("hdmap", info, cache_dir)
+
+            assert result is True
+            assert (cache_dir / "artifacts" / "hdmap" / "hdmap.owl.ttl").exists()
+            assert (cache_dir / "artifacts" / "hdmap" / "hdmap.shacl.ttl").exists()
+            assert (cache_dir / "artifacts" / "hdmap" / "hdmap.context.jsonld").exists()
+
+    def test_fetch_domain_artifacts_skips_cached(self, resolver, tmp_path):
+        """Already-cached files are not re-fetched."""
+        cache_dir = tmp_path / "cache"
+        domain_dir = cache_dir / "artifacts" / "hdmap"
+        domain_dir.mkdir(parents=True)
+        (domain_dir / "hdmap.owl.ttl").write_text("cached")
+        (domain_dir / "hdmap.shacl.ttl").write_text("cached")
+        (domain_dir / "hdmap.context.jsonld").write_text("cached")
+
+        info = {"iri": "https://w3id.org/ascs-ev/envited-x/hdmap/v6"}
+
+        with patch("src.tools.utils.http_artifact_resolver._http_get") as mock_get:
+            result = resolver.fetch_domain_artifacts("hdmap", info, cache_dir)
+            assert result is True
+            mock_get.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Import Fetch Tests
+# ---------------------------------------------------------------------------
+
+
+class TestImportFetch:
+    """Tests for base ontology import fetching."""
+
+    def test_fetch_import_files_from_catalog(self, resolver, tmp_path):
+        """Import files are fetched based on catalog entries."""
+        cache_dir = tmp_path / "cache"
+        imports_dir = cache_dir / "imports"
+        imports_dir.mkdir(parents=True)
+        (imports_dir / "catalog-v001.xml").write_text(SAMPLE_IMPORTS_CATALOG)
+
+        with patch("src.tools.utils.http_artifact_resolver._http_get") as mock_get:
+            mock_get.return_value = b"@prefix rdf: <...> ."
+            count = resolver.fetch_import_files(cache_dir)
+
+            assert count == 2
+            assert (imports_dir / "rdf" / "rdf.owl.ttl").exists()
+            assert (imports_dir / "rdfs" / "rdfs.owl.ttl").exists()
+
+
+# ---------------------------------------------------------------------------
+# Catalog-Based Artifact Fetch Tests (Gaia-X override)
+# ---------------------------------------------------------------------------
+
+
+class TestCatalogBasedArtifactFetch:
+    """Tests for fetching artifacts from catalog (covers gx domain)."""
+
+    def test_fetch_artifacts_from_catalog_fetches_gx(self, resolver, tmp_path):
+        """gx domain artifacts are fetched via catalog fallback."""
+        cache_dir = tmp_path / "cache"
+        artifacts_dir = cache_dir / "artifacts"
+        artifacts_dir.mkdir(parents=True)
+        (artifacts_dir / "catalog-v001.xml").write_text(SAMPLE_ARTIFACTS_CATALOG)
+
+        # Pre-create hdmap files (already fetched via registry)
+        hdmap_dir = artifacts_dir / "hdmap"
+        hdmap_dir.mkdir()
+        (hdmap_dir / "hdmap.owl.ttl").write_text("cached")
+        (hdmap_dir / "hdmap.shacl.ttl").write_text("cached")
+        (hdmap_dir / "hdmap.context.jsonld").write_text("cached")
+
+        with patch("src.tools.utils.http_artifact_resolver._http_get") as mock_get:
+            mock_get.return_value = b"@prefix gx: <...> ."
+            count = resolver.fetch_artifacts_from_catalog(cache_dir)
+
+            # Only gx files should be fetched (hdmap already cached)
+            assert count == 2  # gx.owl.ttl + gx.shacl.ttl
+            assert (artifacts_dir / "gx" / "gx.owl.ttl").exists()
+            assert (artifacts_dir / "gx" / "gx.shacl.ttl").exists()
+
+
+# ---------------------------------------------------------------------------
+# High-Level API Tests
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureCache:
+    """Tests for the high-level ensure_cache API."""
+
+    def test_ensure_cache_skips_when_valid(self, resolver, tmp_path):
+        """ensure_cache returns immediately when cache is fresh."""
+        import time
+
+        resolver.cache_base = tmp_path / "cache"
+        cache_dir = resolver.cache_base / "v0.1.4"
+        cache_dir.mkdir(parents=True)
+        (cache_dir / ".cache-timestamp").write_text(str(time.time()))
+
+        with patch("src.tools.utils.http_artifact_resolver._http_get") as mock_get:
+            mock_get.return_value = json.dumps(SAMPLE_REGISTRY).encode()
+            result = resolver.ensure_cache()
+            assert result == cache_dir
+            # Only registry fetch should happen (for version), no catalog fetches
+            assert mock_get.call_count == 1
+
+    def test_ensure_cache_for_iris_resolves_domains(self, resolver, tmp_path):
+        """ensure_cache_for_iris resolves IRIs to needed domains."""
+        resolver.cache_base = tmp_path / "cache"
+
+        iris = {
+            "https://w3id.org/ascs-ev/envited-x/hdmap/v6/HdMap",
+            "https://w3id.org/ascs-ev/envited-x/scenario/v6/Scenario",
+        }
+
+        with patch.object(resolver, "ensure_cache") as mock_ensure:
+            mock_ensure.return_value = tmp_path / "result"
+            with patch("src.tools.utils.http_artifact_resolver._http_get") as mock_get:
+                mock_get.return_value = json.dumps(SAMPLE_REGISTRY).encode()
+                resolver.ensure_cache_for_iris(iris)
+
+                # Should resolve to hdmap and scenario domains
+                call_args = mock_ensure.call_args
+                domains = set(
+                    call_args.kwargs.get(
+                        "domains", call_args.args[0] if call_args.args else []
+                    )
+                )
+                assert "hdmap" in domains
+                assert "scenario" in domains
+
+
+# ---------------------------------------------------------------------------
+# Default Cache Dir
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultCacheDir:
+    """Tests for platform-appropriate cache directory."""
+
+    def test_default_cache_dir_returns_path(self):
+        """Default cache dir is a valid Path."""
+        cache_dir = _get_default_cache_dir()
+        assert isinstance(cache_dir, Path)
+        assert cache_dir.name == "omb"
+
+
+# ---------------------------------------------------------------------------
+# RegistryResolver Integration
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryResolverHttpFallback:
+    """Tests for RegistryResolver.enable_http_fallback()."""
+
+    def test_enable_http_false_default_no_http_calls(self, tmp_path):
+        """Default enable_http=False does not trigger HTTP fetching."""
+        from src.tools.utils.registry_resolver import RegistryResolver
+
+        with patch("src.tools.utils.http_artifact_resolver._http_get") as mock_get:
+            resolver = RegistryResolver(tmp_path)
+            mock_get.assert_not_called()
+            assert resolver._http_enabled is False
+
+    def test_enable_http_true_triggers_bootstrap_when_no_catalogs(self, tmp_path):
+        """enable_http=True triggers HTTP bootstrap when catalogs missing."""
+        from src.tools.utils.registry_resolver import RegistryResolver
+
+        with patch(
+            "src.tools.utils.http_artifact_resolver.HttpArtifactResolver"
+        ) as MockResolver:
+            mock_instance = MagicMock()
+            mock_instance.ensure_cache.return_value = tmp_path / "cache"
+            MockResolver.return_value = mock_instance
+
+            # Create minimal cache dir so RegistryResolver doesn't fail
+            (tmp_path / "cache").mkdir()
+
+            resolver = RegistryResolver(tmp_path, enable_http=True)
+            mock_instance.ensure_cache.assert_called_once()
+            assert resolver._http_enabled is True
+
+    def test_enable_http_true_skips_bootstrap_when_catalogs_exist(self, tmp_path):
+        """enable_http=True does NOT bootstrap when local catalogs exist."""
+        from src.tools.utils.registry_resolver import RegistryResolver
+
+        # Create catalog files so _has_local_catalogs returns True
+        (tmp_path / "artifacts").mkdir()
+        (tmp_path / "artifacts" / "catalog-v001.xml").write_text(
+            '<?xml version="1.0"?><catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog"/>'
+        )
+        (tmp_path / "imports").mkdir()
+        (tmp_path / "imports" / "catalog-v001.xml").write_text(
+            '<?xml version="1.0"?><catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog"/>'
+        )
+
+        with patch(
+            "src.tools.utils.http_artifact_resolver.HttpArtifactResolver"
+        ) as MockResolver:
+            resolver = RegistryResolver(tmp_path, enable_http=True)
+            MockResolver.assert_not_called()
+            assert resolver._http_enabled is False

--- a/tests/unit/utils/test_http_artifact_resolver.py
+++ b/tests/unit/utils/test_http_artifact_resolver.py
@@ -2,6 +2,7 @@
 
 import json
 import textwrap
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 from urllib.error import URLError
@@ -10,8 +11,10 @@ import pytest
 
 from src.tools.utils.http_artifact_resolver import (
     ALLOWED_HOSTS,
+    STALE_BUILD_TIMEOUT_SECONDS,
     HttpArtifactResolver,
     _get_default_cache_dir,
+    _safe_cache_path,
     _validate_response_host,
 )
 
@@ -156,8 +159,6 @@ class TestCacheManagement:
 
     def test_is_cache_valid_true_when_fresh(self, resolver, tmp_path):
         """Cache is valid when marker is recent."""
-        import time
-
         cache_dir = tmp_path / "fresh"
         cache_dir.mkdir()
         (cache_dir / ".cache-timestamp").write_text(str(time.time()))
@@ -165,8 +166,6 @@ class TestCacheManagement:
 
     def test_is_cache_valid_false_when_stale(self, resolver, tmp_path):
         """Cache is invalid when marker is older than TTL."""
-        import time
-
         cache_dir = tmp_path / "stale"
         cache_dir.mkdir()
         old_time = time.time() - 100000  # Way past TTL
@@ -338,8 +337,6 @@ class TestEnsureCache:
 
     def test_ensure_cache_skips_when_valid(self, resolver, tmp_path):
         """ensure_cache returns immediately when cache is fresh."""
-        import time
-
         resolver.cache_base = tmp_path / "cache"
         cache_dir = resolver.cache_base / "v0.1.4"
         cache_dir.mkdir(parents=True)
@@ -408,7 +405,7 @@ class TestRegistryResolverHttpFallback:
         with patch("src.tools.utils.http_artifact_resolver._http_get") as mock_get:
             resolver = RegistryResolver(tmp_path)
             mock_get.assert_not_called()
-            assert resolver._http_enabled is False
+            assert resolver.is_http_bootstrapped is False
 
     def test_enable_http_true_triggers_bootstrap_when_no_catalogs(self, tmp_path):
         """enable_http=True triggers HTTP bootstrap when catalogs missing."""
@@ -426,7 +423,7 @@ class TestRegistryResolverHttpFallback:
 
             resolver = RegistryResolver(tmp_path, enable_http=True)
             mock_instance.ensure_cache.assert_called_once()
-            assert resolver._http_enabled is True
+            assert resolver.is_http_bootstrapped is True
 
     def test_enable_http_true_skips_bootstrap_when_catalogs_exist(self, tmp_path):
         """enable_http=True does NOT bootstrap when local catalogs exist."""
@@ -447,7 +444,7 @@ class TestRegistryResolverHttpFallback:
         ) as MockResolver:
             resolver = RegistryResolver(tmp_path, enable_http=True)
             MockResolver.assert_not_called()
-            assert resolver._http_enabled is False
+            assert resolver.is_http_bootstrapped is False
 
 
 # ---------------------------------------------------------------------------
@@ -530,33 +527,27 @@ class TestW3idConnegFallback:
             fp=None,
         )
 
-        call_count = {"_http_get": 0, "_http_get_with_accept": 0}
+        call_count = {"gh_pages": 0, "conneg": 0}
 
-        def mock_http_get(url, timeout=30):
-            call_count["_http_get"] += 1
-            raise gh_pages_404
+        def mock_http_get(url, timeout=30, accept=None):
+            if accept:
+                call_count["conneg"] += 1
+                return b"# turtle content"
+            else:
+                call_count["gh_pages"] += 1
+                raise gh_pages_404
 
-        def mock_http_get_with_accept(url, accept, timeout=30):
-            call_count["_http_get_with_accept"] += 1
-            return b"# turtle content"
-
-        with (
-            patch(
-                "src.tools.utils.http_artifact_resolver._http_get",
-                side_effect=mock_http_get,
-            ),
-            patch(
-                "src.tools.utils.http_artifact_resolver._http_get_with_accept",
-                side_effect=mock_http_get_with_accept,
-            ),
+        with patch(
+            "src.tools.utils.http_artifact_resolver._http_get",
+            side_effect=mock_http_get,
         ):
             result = resolver.fetch_domain_artifacts("hdmap", domain_info, tmp_path)
 
         assert result is True
         # GH Pages was tried (and failed) for all 3 artifacts
-        assert call_count["_http_get"] == 3
+        assert call_count["gh_pages"] == 3
         # w3id.org conneg was tried as fallback for all 3
-        assert call_count["_http_get_with_accept"] == 3
+        assert call_count["conneg"] == 3
 
 
 # ---------------------------------------------------------------------------
@@ -599,3 +590,410 @@ class TestClearCacheSafety:
         resolver = HttpArtifactResolver(cache_dir=cache_base)
         with pytest.raises(ValueError, match="not under cache base"):
             resolver.clear_cache("../../etc")
+
+
+# ---------------------------------------------------------------------------
+# Path Traversal Prevention (_safe_cache_path)
+# ---------------------------------------------------------------------------
+
+
+class TestSafeCachePath:
+    """Tests for _safe_cache_path path traversal prevention."""
+
+    def test_normal_relative_path_allowed(self, tmp_path):
+        """Normal relative path resolves within cache."""
+        result = _safe_cache_path(tmp_path, "imports", "rdf/rdf.owl.ttl")
+        assert result.is_relative_to(tmp_path.resolve())
+        assert result == (tmp_path / "imports" / "rdf" / "rdf.owl.ttl").resolve()
+
+    def test_nested_path_allowed(self, tmp_path):
+        """Multi-level nesting stays within cache."""
+        result = _safe_cache_path(tmp_path, "artifacts", "hdmap", "hdmap.owl.ttl")
+        assert result.is_relative_to(tmp_path.resolve())
+
+    def test_benign_dotdot_within_cache_allowed(self, tmp_path):
+        """Path with .. that stays within cache is allowed."""
+        result = _safe_cache_path(tmp_path, "artifacts", "a", "..", "b", "file.ttl")
+        assert result.is_relative_to(tmp_path.resolve())
+        assert result == (tmp_path / "artifacts" / "b" / "file.ttl").resolve()
+
+    def test_dotdot_traversal_rejected(self, tmp_path):
+        """../../etc/passwd is rejected."""
+        with pytest.raises(ValueError, match="Path traversal blocked"):
+            _safe_cache_path(tmp_path, "imports", "../../etc/passwd")
+
+    def test_deep_dotdot_traversal_rejected(self, tmp_path):
+        """Deep traversal like ../../../ is rejected."""
+        with pytest.raises(ValueError, match="Path traversal blocked"):
+            _safe_cache_path(tmp_path, "imports", "../../../etc/shadow")
+
+    def test_absolute_path_rejected(self, tmp_path):
+        """Absolute paths are rejected (resolved outside cache)."""
+        with pytest.raises(ValueError, match="Path traversal blocked"):
+            _safe_cache_path(tmp_path, "/etc/passwd")
+
+    def test_backslash_traversal_rejected(self, tmp_path):
+        """Backslash-based traversal is rejected."""
+        with pytest.raises(ValueError, match="Path traversal blocked"):
+            _safe_cache_path(tmp_path, "imports", "..\\..\\etc\\passwd")
+
+    def test_dot_prefixed_traversal_rejected(self, tmp_path):
+        """./../../ traversal is rejected."""
+        with pytest.raises(ValueError, match="Path traversal blocked"):
+            _safe_cache_path(tmp_path, "artifacts", "./../../escape")
+
+    def test_cache_dir_itself_allowed(self, tmp_path):
+        """Resolving to cache_dir itself is fine (no escape)."""
+        result = _safe_cache_path(tmp_path, "artifacts", "..")
+        assert result == tmp_path.resolve()
+
+
+class TestPathTraversalInCatalogs:
+    """Integration tests: traversal in catalog entries is skipped gracefully."""
+
+    MALICIOUS_IMPORTS_CATALOG = textwrap.dedent("""\
+        <?xml version="1.0" encoding="UTF-8"?>
+        <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+          <uri name="http://evil.example.com/" uri="../../etc/passwd"/>
+          <uri name="http://www.w3.org/2000/01/rdf-schema#" uri="rdfs/rdfs.owl.ttl"/>
+        </catalog>
+    """)
+
+    MALICIOUS_ARTIFACTS_CATALOG = textwrap.dedent("""\
+        <?xml version="1.0" encoding="UTF-8"?>
+        <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+          <uri name="http://evil.example.com/" uri="../../../etc/shadow"/>
+          <uri name="https://w3id.org/gaia-x/development#" uri="gx/gx.owl.ttl"/>
+        </catalog>
+    """)
+
+    def test_fetch_import_files_skips_traversal_entry(self, tmp_path):
+        """Malicious catalog uri with traversal is skipped; safe entries fetched."""
+        cache_dir = tmp_path / "cache"
+        imports_dir = cache_dir / "imports"
+        imports_dir.mkdir(parents=True)
+        (imports_dir / "catalog-v001.xml").write_text(self.MALICIOUS_IMPORTS_CATALOG)
+
+        resolver = HttpArtifactResolver(cache_dir=tmp_path)
+        with patch("src.tools.utils.http_artifact_resolver._http_get") as mock_get:
+            mock_get.return_value = b"@prefix rdfs: <...> ."
+            count = resolver.fetch_import_files(cache_dir)
+
+        # Only the safe rdfs entry should be fetched; ../../etc/passwd skipped
+        assert count == 1
+        assert (imports_dir / "rdfs" / "rdfs.owl.ttl").exists()
+        assert not (tmp_path / "etc" / "passwd").exists()
+
+    def test_fetch_artifacts_from_catalog_skips_traversal_entry(self, tmp_path):
+        """Malicious artifact catalog uri with traversal is skipped."""
+        cache_dir = tmp_path / "cache"
+        artifacts_dir = cache_dir / "artifacts"
+        artifacts_dir.mkdir(parents=True)
+        (artifacts_dir / "catalog-v001.xml").write_text(
+            self.MALICIOUS_ARTIFACTS_CATALOG
+        )
+
+        resolver = HttpArtifactResolver(cache_dir=tmp_path)
+        with patch("src.tools.utils.http_artifact_resolver._http_get") as mock_get:
+            mock_get.return_value = b"@prefix gx: <...> ."
+            count = resolver.fetch_artifacts_from_catalog(cache_dir)
+
+        # Only gx entry fetched; ../../../etc/shadow skipped
+        assert count == 1
+        assert (artifacts_dir / "gx" / "gx.owl.ttl").exists()
+        assert not (tmp_path / "etc" / "shadow").exists()
+
+    def test_fetch_domain_artifacts_rejects_traversal_domain(self, tmp_path):
+        """Domain name with traversal raises ValueError."""
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir(parents=True)
+        resolver = HttpArtifactResolver(cache_dir=tmp_path)
+        info = {"iri": "https://w3id.org/ascs-ev/envited-x/hdmap/v6"}
+
+        with pytest.raises(ValueError, match="Path traversal blocked"):
+            resolver.fetch_domain_artifacts("../../escape", info, cache_dir)
+
+    def test_fetch_catalog_rejects_traversal_path(self, tmp_path):
+        """Catalog relative path with traversal raises ValueError."""
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir(parents=True)
+        resolver = HttpArtifactResolver(cache_dir=tmp_path)
+
+        with pytest.raises(ValueError, match="Path traversal blocked"):
+            resolver.fetch_catalog("../../etc/passwd", cache_dir)
+
+
+# ---------------------------------------------------------------------------
+# TOCTOU Sentinel (Build Marker)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSentinel:
+    """Tests for .cache-building sentinel in ensure_cache / is_cache_valid."""
+
+    def test_building_marker_makes_cache_invalid(self, tmp_path):
+        """is_cache_valid returns False when .cache-building exists."""
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        (cache_dir / ".cache-timestamp").write_text(str(time.time()))
+        (cache_dir / ".cache-building").write_text(str(time.time()))
+
+        resolver = HttpArtifactResolver(cache_dir=tmp_path)
+        assert not resolver.is_cache_valid(cache_dir)
+
+    def test_stale_building_marker_cleaned_up(self, tmp_path):
+        """Stale .cache-building marker (>10 min) is removed."""
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        stale_time = time.time() - STALE_BUILD_TIMEOUT_SECONDS - 60
+        (cache_dir / ".cache-building").write_text(str(stale_time))
+        # No .cache-timestamp → still invalid, but marker should be cleaned up
+
+        resolver = HttpArtifactResolver(cache_dir=tmp_path)
+        assert not resolver.is_cache_valid(cache_dir)
+        assert not (cache_dir / ".cache-building").exists()
+
+    def test_corrupt_building_marker_cleaned_up(self, tmp_path):
+        """Corrupt .cache-building marker is removed and cache is invalid."""
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        (cache_dir / ".cache-building").write_text("not-a-number")
+        (cache_dir / ".cache-timestamp").write_text(str(time.time()))
+
+        resolver = HttpArtifactResolver(cache_dir=tmp_path)
+        assert not resolver.is_cache_valid(cache_dir)
+        assert not (cache_dir / ".cache-building").exists()
+
+    def test_ensure_cache_cleans_marker_on_success(self, tmp_path):
+        """ensure_cache removes .cache-building after successful build."""
+        resolver = HttpArtifactResolver(cache_dir=tmp_path)
+
+        with patch("src.tools.utils.http_artifact_resolver._http_get") as mock_get:
+            mock_get.return_value = json.dumps(SAMPLE_REGISTRY).encode()
+            with patch.object(resolver, "fetch_all_catalogs"):
+                with patch.object(
+                    resolver, "fetch_domain_artifacts", return_value=True
+                ):
+                    with patch.object(resolver, "fetch_import_files"):
+                        with patch.object(resolver, "fetch_artifacts_from_catalog"):
+                            cache_dir = resolver.ensure_cache(force=True)
+
+        assert not (cache_dir / ".cache-building").exists()
+        assert (cache_dir / ".cache-timestamp").exists()
+
+    def test_ensure_cache_cleans_marker_on_failure(self, tmp_path):
+        """ensure_cache removes .cache-building even when build fails."""
+        resolver = HttpArtifactResolver(cache_dir=tmp_path)
+
+        with patch("src.tools.utils.http_artifact_resolver._http_get") as mock_get:
+            mock_get.return_value = json.dumps(SAMPLE_REGISTRY).encode()
+            with patch.object(
+                resolver, "fetch_all_catalogs", side_effect=RuntimeError("boom")
+            ):
+                with pytest.raises(RuntimeError, match="boom"):
+                    resolver.ensure_cache(force=True)
+
+        # The versioned cache dir is created, but marker must be cleaned up
+        version_dir = tmp_path / SAMPLE_REGISTRY["latestRelease"]
+        assert not (version_dir / ".cache-building").exists()
+
+
+# ---------------------------------------------------------------------------
+# Coverage gap: URL builders with missing/non-w3id IRIs
+# ---------------------------------------------------------------------------
+
+
+class TestUrlBuilderEdgeCases:
+    """Tests for _build_w3id_url and _build_gh_pages_url edge cases."""
+
+    def test_build_w3id_url_missing_iri_returns_none(self, resolver):
+        """_build_w3id_url returns None when IRI is absent."""
+        assert resolver._build_w3id_url({}) is None
+        assert resolver._build_w3id_url({"iri": ""}) is None
+
+    def test_build_gh_pages_url_missing_iri_returns_none(self, resolver):
+        """_build_gh_pages_url returns None when IRI is absent."""
+        assert resolver._build_gh_pages_url({}) is None
+        assert resolver._build_gh_pages_url({"iri": ""}) is None
+
+    def test_build_gh_pages_url_non_w3id_returns_none(self, resolver):
+        """_build_gh_pages_url returns None for non-w3id IRIs."""
+        info = {"iri": "https://example.org/ontology/v1"}
+        assert resolver._build_gh_pages_url(info) is None
+
+
+# ---------------------------------------------------------------------------
+# Coverage gap: Missing catalogs return 0
+# ---------------------------------------------------------------------------
+
+
+class TestMissingCatalogReturnsZero:
+    """Tests for fetch_import_files / fetch_artifacts_from_catalog with no catalog."""
+
+    def test_fetch_import_files_no_catalog_returns_zero(self, resolver, tmp_path):
+        """Returns 0 when imports catalog does not exist."""
+        cache_dir = tmp_path / "empty"
+        cache_dir.mkdir()
+        assert resolver.fetch_import_files(cache_dir) == 0
+
+    def test_fetch_artifacts_from_catalog_no_catalog_returns_zero(
+        self, resolver, tmp_path
+    ):
+        """Returns 0 when artifacts catalog does not exist."""
+        cache_dir = tmp_path / "empty"
+        cache_dir.mkdir()
+        assert resolver.fetch_artifacts_from_catalog(cache_dir) == 0
+
+
+# ---------------------------------------------------------------------------
+# Coverage gap: Both fetch strategies fail
+# ---------------------------------------------------------------------------
+
+
+class TestBothStrategiesFail:
+    """Tests for fetch_domain_artifacts when all sources fail."""
+
+    def test_returns_false_when_all_sources_fail(self, tmp_path):
+        """fetch_domain_artifacts returns False when nothing can be fetched."""
+        from urllib.error import HTTPError
+
+        resolver = HttpArtifactResolver(cache_dir=tmp_path)
+        domain_info = {"iri": "https://w3id.org/ascs-ev/envited-x/hdmap/v6"}
+
+        error = HTTPError(
+            url="https://example.com",
+            code=404,
+            msg="Not Found",
+            hdrs={},
+            fp=None,
+        )
+
+        def mock_http_get(url, timeout=30, accept=None):
+            raise error
+
+        with patch(
+            "src.tools.utils.http_artifact_resolver._http_get",
+            side_effect=mock_http_get,
+        ):
+            result = resolver.fetch_domain_artifacts("hdmap", domain_info, tmp_path)
+
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Coverage gap: Corrupt .cache-timestamp
+# ---------------------------------------------------------------------------
+
+
+class TestCorruptCacheTimestamp:
+    """Tests for is_cache_valid with corrupt timestamp file."""
+
+    def test_corrupt_timestamp_returns_false(self, resolver, tmp_path):
+        """is_cache_valid returns False when timestamp is corrupt."""
+        cache_dir = tmp_path / "corrupt"
+        cache_dir.mkdir()
+        (cache_dir / ".cache-timestamp").write_text("not-a-number")
+        assert not resolver.is_cache_valid(cache_dir)
+
+    def test_is_cache_valid_no_arg_registry_fails_returns_false(self, tmp_path):
+        """is_cache_valid(None) returns False when registry fetch fails."""
+        resolver = HttpArtifactResolver(
+            cache_dir=tmp_path,
+            registry_url="https://test.example.com/registry.json",
+        )
+        with patch(
+            "src.tools.utils.http_artifact_resolver._http_get",
+            side_effect=URLError("fail"),
+        ):
+            assert not resolver.is_cache_valid()
+
+
+# ---------------------------------------------------------------------------
+# Coverage gap: ensure_cache_for_iris fallback to full cache
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureCacheForIrisFallback:
+    """Tests for ensure_cache_for_iris when no domain matches."""
+
+    def test_no_match_falls_back_to_full_cache(self, resolver, tmp_path):
+        """When no IRI matches any registry domain, ensure_cache() is called."""
+        resolver.cache_base = tmp_path / "cache"
+
+        iris = {
+            "https://unknown.example.org/ontology/Thing",
+        }
+
+        with patch.object(resolver, "ensure_cache") as mock_ensure:
+            mock_ensure.return_value = tmp_path / "result"
+            with patch("src.tools.utils.http_artifact_resolver._http_get") as mock_get:
+                mock_get.return_value = json.dumps(SAMPLE_REGISTRY).encode()
+                result = resolver.ensure_cache_for_iris(iris)
+
+                # Should fall back to full cache (no domains kwarg)
+                mock_ensure.assert_called_once_with()
+                assert result == tmp_path / "result"
+
+
+# ---------------------------------------------------------------------------
+# Coverage gap: fetch_all_catalogs re-raises non-test catalog failure
+# ---------------------------------------------------------------------------
+
+
+class TestFetchAllCatalogsErrorHandling:
+    """Tests for fetch_all_catalogs error propagation."""
+
+    def test_artifacts_catalog_failure_propagates(self, resolver, tmp_path):
+        """Failure to fetch artifacts catalog raises (not swallowed)."""
+        from urllib.error import HTTPError
+
+        cache_dir = tmp_path / "cache"
+        error = HTTPError(
+            url="https://example.com",
+            code=500,
+            msg="Server Error",
+            hdrs={},
+            fp=None,
+        )
+
+        call_idx = {"n": 0}
+
+        def mock_http_get(url, timeout=30, accept=None):
+            call_idx["n"] += 1
+            if call_idx["n"] == 1:
+                raise error  # First call = artifacts catalog
+            return b"<catalog/>"
+
+        with patch(
+            "src.tools.utils.http_artifact_resolver._http_get",
+            side_effect=mock_http_get,
+        ):
+            with pytest.raises(HTTPError):
+                resolver.fetch_all_catalogs(cache_dir)
+
+    def test_tests_catalog_failure_swallowed(self, resolver, tmp_path):
+        """Failure to fetch tests catalog is swallowed (not required)."""
+        from urllib.error import HTTPError
+
+        cache_dir = tmp_path / "cache"
+        error = HTTPError(
+            url="https://example.com",
+            code=404,
+            msg="Not Found",
+            hdrs={},
+            fp=None,
+        )
+
+        call_idx = {"n": 0}
+
+        def mock_http_get(url, timeout=30, accept=None):
+            call_idx["n"] += 1
+            if call_idx["n"] == 3:
+                raise error  # Third call = tests catalog
+            return b"<catalog/>"
+
+        with patch(
+            "src.tools.utils.http_artifact_resolver._http_get",
+            side_effect=mock_http_get,
+        ):
+            resolver.fetch_all_catalogs(cache_dir)  # Should not raise


### PR DESCRIPTION
## Problem

When OMB is installed via `pip install ontology-management-base`, the Python tools (`src/tools/`) are available but the data directories (`artifacts/`, `imports/`, `tests/`) with their XML catalogs are not. This means `RegistryResolver` finds no catalogs and validation silently fails.

## Solution

Add an HTTP resolution fallback that fetches ontology artifacts from the existing w3id.org / GitHub Pages infrastructure and caches them locally.

### New: `src/tools/utils/http_artifact_resolver.py`

`HttpArtifactResolver` class that:
- Fetches `docs/registry.json` from GitHub Pages for domain discovery
- Downloads XML catalogs from raw GitHub
- Fetches OWL/SHACL/context artifacts from GitHub Pages (w3id path)
- Falls back to w3id.org content-negotiation if Pages fails
- Caches everything in `~/.cache/omb/{version}/` mirroring repo structure
- Handles Gaia-X non-standard IRI (`https://w3id.org/gaia-x/development#`) via catalog-based fallback

### Modified: `RegistryResolver`

- New `enable_http` parameter in `__init__`
- When enabled and local catalogs are missing, bootstraps from HTTP cache
- Zero changes to default behavior (`enable_http=False`)

### Modified: `ShaclValidator`

- Threads `enable_http` parameter through to `RegistryResolver`

### Modified: `validation_suite.py`

- New `--remote` CLI flag enables HTTP resolution
- Passed through all 3 `RegistryResolver` construction sites

### Fixed: `graph_loader.py`

- Cross-platform fix for `Path.resolve()` calling `os.getcwd()` on Windows even for absolute paths
- Falls back to `Path.absolute()` when cwd is unavailable

## Usage

```bash
# Validate with remote artifact resolution (pip-only install)
python -m src.tools.validators.validation_suite --remote --data-paths my_data.jsonld
```

## Tested

- **313 unit tests pass** (23 new + 290 existing, 0 failures)
- **End-to-end validated** EVES-003 hdmap + manifest examples against latest ontology versions (hdmap v6, envited-x v3, manifest v5, georeference v5, gx development) using `--remote` from a pip-only installation
- All ontologies, SHACL shapes, and the modified Gaia-X ontology loaded correctly

## Cache

Artifacts are cached at `~/.cache/omb/{version}/` (Linux/macOS) or `%LOCALAPPDATA%/omb/{version}/` (Windows). Cache expires after 24 hours.