### PR TITLE
fix(context): resolve prefixes from @prefix declarations instead of IRI heuristic

### DIFF
--- a/artifacts/envited-x/envited-x.context.jsonld
+++ b/artifacts/envited-x/envited-x.context.jsonld
@@ -16,7 +16,7 @@
       "skos": "http://www.w3.org/2004/02/skos/core#",
       "envited-x": "https://w3id.org/ascs-ev/envited-x/envited-x/v3/",
       "manifest": "https://w3id.org/ascs-ev/envited-x/manifest/v5/",
-      "development": "https://w3id.org/gaia-x/development#",
+      "gx": "https://w3id.org/gaia-x/development#",
       "hasCodeArtifact": {
          "@id": "envited-x:hasCodeArtifact",
          "@type": "@id"

--- a/artifacts/openlabel/openlabel.context.jsonld
+++ b/artifacts/openlabel/openlabel.context.jsonld
@@ -14,398 +14,398 @@
       "owl": "http://www.w3.org/2002/07/owl#",
       "sh": "http://www.w3.org/ns/shacl#",
       "skos": "http://www.w3.org/2004/02/skos/core#",
-      "ontologies": "https://openlabel.asam.net/V1-0-0/ontologies/",
+      "openlabel": "https://openlabel.asam.net/V1-0-0/ontologies/",
       "AdminTag": {
-         "@id": "ontologies:AdminTag",
+         "@id": "openlabel:AdminTag",
          "@type": "@id"
       },
       "Behaviour": {
-         "@id": "ontologies:Behaviour",
+         "@id": "openlabel:Behaviour",
          "@type": "@id"
       },
       "BehaviourCommunication": {
-         "@id": "ontologies:BehaviourCommunication"
+         "@id": "openlabel:BehaviourCommunication"
       },
       "ConnectivityCommunication": {
-         "@id": "ontologies:ConnectivityCommunication"
+         "@id": "openlabel:ConnectivityCommunication"
       },
       "ConnectivityPositioning": {
-         "@id": "ontologies:ConnectivityPositioning"
+         "@id": "openlabel:ConnectivityPositioning"
       },
       "DaySunElevation": {
-         "@id": "ontologies:DaySunElevation",
+         "@id": "openlabel:DaySunElevation",
          "@type": "xsd:boolean"
       },
       "DaySunPosition": {
-         "@id": "ontologies:DaySunPosition"
+         "@id": "openlabel:DaySunPosition"
       },
       "DrivableAreaEdge": {
-         "@id": "ontologies:DrivableAreaEdge"
+         "@id": "openlabel:DrivableAreaEdge"
       },
       "DrivableAreaSurfaceCondition": {
-         "@id": "ontologies:DrivableAreaSurfaceCondition"
+         "@id": "openlabel:DrivableAreaSurfaceCondition"
       },
       "DrivableAreaSurfaceFeature": {
-         "@id": "ontologies:DrivableAreaSurfaceFeature"
+         "@id": "openlabel:DrivableAreaSurfaceFeature"
       },
       "DrivableAreaSurfaceType": {
-         "@id": "ontologies:DrivableAreaSurfaceType"
+         "@id": "openlabel:DrivableAreaSurfaceType"
       },
       "DrivableAreaType": {
-         "@id": "ontologies:DrivableAreaType"
+         "@id": "openlabel:DrivableAreaType"
       },
       "EnvironmentParticulates": {
-         "@id": "ontologies:EnvironmentParticulates"
+         "@id": "openlabel:EnvironmentParticulates"
       },
       "GeometryTransverse": {
-         "@id": "ontologies:GeometryTransverse"
+         "@id": "openlabel:GeometryTransverse"
       },
       "HorizontalCurves": {
-         "@id": "ontologies:HorizontalCurves",
+         "@id": "openlabel:HorizontalCurves",
          "@type": "xsd:boolean"
       },
       "HorizontalStraights": {
-         "@id": "ontologies:HorizontalStraights",
+         "@id": "openlabel:HorizontalStraights",
          "@type": "xsd:boolean"
       },
       "IlluminationArtificial": {
-         "@id": "ontologies:IlluminationArtificial"
+         "@id": "openlabel:IlluminationArtificial"
       },
       "IlluminationCloudiness": {
-         "@id": "ontologies:IlluminationCloudiness",
+         "@id": "openlabel:IlluminationCloudiness",
          "@type": "xsd:boolean"
       },
       "IlluminationLowLight": {
-         "@id": "ontologies:IlluminationLowLight"
+         "@id": "openlabel:IlluminationLowLight"
       },
       "JunctionIntersection": {
-         "@id": "ontologies:JunctionIntersection"
+         "@id": "openlabel:JunctionIntersection"
       },
       "JunctionRoundabout": {
-         "@id": "ontologies:JunctionRoundabout"
+         "@id": "openlabel:JunctionRoundabout"
       },
       "LaneSpecificationDimensions": {
-         "@id": "ontologies:LaneSpecificationDimensions",
+         "@id": "openlabel:LaneSpecificationDimensions",
          "@type": "xsd:boolean"
       },
       "LaneSpecificationLaneCount": {
-         "@id": "ontologies:LaneSpecificationLaneCount",
+         "@id": "openlabel:LaneSpecificationLaneCount",
          "@type": "xsd:boolean"
       },
       "LaneSpecificationMarking": {
-         "@id": "ontologies:LaneSpecificationMarking",
+         "@id": "openlabel:LaneSpecificationMarking",
          "@type": "xsd:boolean"
       },
       "LaneSpecificationTravelDirection": {
-         "@id": "ontologies:LaneSpecificationTravelDirection"
+         "@id": "openlabel:LaneSpecificationTravelDirection"
       },
       "LaneSpecificationType": {
-         "@id": "ontologies:LaneSpecificationType"
+         "@id": "openlabel:LaneSpecificationType"
       },
       "LongitudinalDownSlope": {
-         "@id": "ontologies:LongitudinalDownSlope",
+         "@id": "openlabel:LongitudinalDownSlope",
          "@type": "xsd:boolean"
       },
       "LongitudinalLevelPlane": {
-         "@id": "ontologies:LongitudinalLevelPlane",
+         "@id": "openlabel:LongitudinalLevelPlane",
          "@type": "xsd:boolean"
       },
       "LongitudinalUpSlope": {
-         "@id": "ontologies:LongitudinalUpSlope",
+         "@id": "openlabel:LongitudinalUpSlope",
          "@type": "xsd:boolean"
       },
       "MotionAccelerate": {
-         "@id": "ontologies:MotionAccelerate",
+         "@id": "openlabel:MotionAccelerate",
          "@type": "xsd:boolean"
       },
       "MotionAway": {
-         "@id": "ontologies:MotionAway",
+         "@id": "openlabel:MotionAway",
          "@type": "xsd:boolean"
       },
       "MotionCross": {
-         "@id": "ontologies:MotionCross",
+         "@id": "openlabel:MotionCross",
          "@type": "xsd:boolean"
       },
       "MotionCutIn": {
-         "@id": "ontologies:MotionCutIn",
+         "@id": "openlabel:MotionCutIn",
          "@type": "xsd:boolean"
       },
       "MotionCutOut": {
-         "@id": "ontologies:MotionCutOut",
+         "@id": "openlabel:MotionCutOut",
          "@type": "xsd:boolean"
       },
       "MotionDecelerate": {
-         "@id": "ontologies:MotionDecelerate",
+         "@id": "openlabel:MotionDecelerate",
          "@type": "xsd:boolean"
       },
       "MotionDrive": {
-         "@id": "ontologies:MotionDrive",
+         "@id": "openlabel:MotionDrive",
          "@type": "xsd:boolean"
       },
       "MotionLaneChangeLeft": {
-         "@id": "ontologies:MotionLaneChangeLeft",
+         "@id": "openlabel:MotionLaneChangeLeft",
          "@type": "xsd:boolean"
       },
       "MotionLaneChangeRight": {
-         "@id": "ontologies:MotionLaneChangeRight",
+         "@id": "openlabel:MotionLaneChangeRight",
          "@type": "xsd:boolean"
       },
       "MotionOvertake": {
-         "@id": "ontologies:MotionOvertake",
+         "@id": "openlabel:MotionOvertake",
          "@type": "xsd:boolean"
       },
       "MotionReverse": {
-         "@id": "ontologies:MotionReverse",
+         "@id": "openlabel:MotionReverse",
          "@type": "xsd:boolean"
       },
       "MotionRun": {
-         "@id": "ontologies:MotionRun",
+         "@id": "openlabel:MotionRun",
          "@type": "xsd:boolean"
       },
       "MotionSlide": {
-         "@id": "ontologies:MotionSlide",
+         "@id": "openlabel:MotionSlide",
          "@type": "xsd:boolean"
       },
       "MotionStop": {
-         "@id": "ontologies:MotionStop",
+         "@id": "openlabel:MotionStop",
          "@type": "xsd:boolean"
       },
       "MotionTowards": {
-         "@id": "ontologies:MotionTowards",
+         "@id": "openlabel:MotionTowards",
          "@type": "xsd:boolean"
       },
       "MotionTurn": {
-         "@id": "ontologies:MotionTurn",
+         "@id": "openlabel:MotionTurn",
          "@type": "xsd:boolean"
       },
       "MotionTurnLeft": {
-         "@id": "ontologies:MotionTurnLeft",
+         "@id": "openlabel:MotionTurnLeft",
          "@type": "xsd:boolean"
       },
       "MotionTurnRight": {
-         "@id": "ontologies:MotionTurnRight",
+         "@id": "openlabel:MotionTurnRight",
          "@type": "xsd:boolean"
       },
       "MotionUTurn": {
-         "@id": "ontologies:MotionUTurn",
+         "@id": "openlabel:MotionUTurn",
          "@type": "xsd:boolean"
       },
       "MotionWalk": {
-         "@id": "ontologies:MotionWalk",
+         "@id": "openlabel:MotionWalk",
          "@type": "xsd:boolean"
       },
       "Odd": {
-         "@id": "ontologies:Odd",
+         "@id": "openlabel:Odd",
          "@type": "@id"
       },
       "ParticulatesDust": {
-         "@id": "ontologies:ParticulatesDust",
+         "@id": "openlabel:ParticulatesDust",
          "@type": "xsd:boolean"
       },
       "ParticulatesMarine": {
-         "@id": "ontologies:ParticulatesMarine",
+         "@id": "openlabel:ParticulatesMarine",
          "@type": "xsd:boolean"
       },
       "ParticulatesPollution": {
-         "@id": "ontologies:ParticulatesPollution",
+         "@id": "openlabel:ParticulatesPollution",
          "@type": "xsd:boolean"
       },
       "ParticulatesVolcanic": {
-         "@id": "ontologies:ParticulatesVolcanic",
+         "@id": "openlabel:ParticulatesVolcanic",
          "@type": "xsd:boolean"
       },
       "RainType": {
-         "@id": "ontologies:RainType"
+         "@id": "openlabel:RainType"
       },
       "RoadUser": {
-         "@id": "ontologies:RoadUser",
+         "@id": "openlabel:RoadUser",
          "@type": "@id"
       },
       "RoadUserAnimal": {
-         "@id": "ontologies:RoadUserAnimal",
+         "@id": "openlabel:RoadUserAnimal",
          "@type": "xsd:boolean"
       },
       "RoadUserHuman": {
-         "@id": "ontologies:RoadUserHuman"
+         "@id": "openlabel:RoadUserHuman"
       },
       "RoadUserVehicle": {
-         "@id": "ontologies:RoadUserVehicle"
+         "@id": "openlabel:RoadUserVehicle"
       },
       "SceneryFixedStructure": {
-         "@id": "ontologies:SceneryFixedStructure"
+         "@id": "openlabel:SceneryFixedStructure"
       },
       "ScenerySpecialStructure": {
-         "@id": "ontologies:ScenerySpecialStructure"
+         "@id": "openlabel:ScenerySpecialStructure"
       },
       "SceneryTemporaryStructure": {
-         "@id": "ontologies:SceneryTemporaryStructure"
+         "@id": "openlabel:SceneryTemporaryStructure"
       },
       "SceneryZone": {
-         "@id": "ontologies:SceneryZone"
+         "@id": "openlabel:SceneryZone"
       },
       "SignsInformation": {
-         "@id": "ontologies:SignsInformation"
+         "@id": "openlabel:SignsInformation"
       },
       "SignsRegulatory": {
-         "@id": "ontologies:SignsRegulatory"
+         "@id": "openlabel:SignsRegulatory"
       },
       "SignsWarning": {
-         "@id": "ontologies:SignsWarning"
+         "@id": "openlabel:SignsWarning"
       },
       "SubjectVehicleSpeed": {
-         "@id": "ontologies:SubjectVehicleSpeed",
+         "@id": "openlabel:SubjectVehicleSpeed",
          "@type": "xsd:boolean"
       },
       "TrafficAgentDensity": {
-         "@id": "ontologies:TrafficAgentDensity",
+         "@id": "openlabel:TrafficAgentDensity",
          "@type": "xsd:boolean"
       },
       "TrafficFlowRate": {
-         "@id": "ontologies:TrafficFlowRate",
+         "@id": "openlabel:TrafficFlowRate",
          "@type": "xsd:boolean"
       },
       "TrafficSpecialVehicle": {
-         "@id": "ontologies:TrafficSpecialVehicle",
+         "@id": "openlabel:TrafficSpecialVehicle",
          "@type": "xsd:boolean"
       },
       "TrafficVolume": {
-         "@id": "ontologies:TrafficVolume",
+         "@id": "openlabel:TrafficVolume",
          "@type": "xsd:boolean"
       },
       "WeatherRain": {
-         "@id": "ontologies:WeatherRain",
+         "@id": "openlabel:WeatherRain",
          "@type": "xsd:boolean"
       },
       "WeatherSnow": {
-         "@id": "ontologies:WeatherSnow",
+         "@id": "openlabel:WeatherSnow",
          "@type": "xsd:boolean"
       },
       "WeatherWind": {
-         "@id": "ontologies:WeatherWind",
+         "@id": "openlabel:WeatherWind",
          "@type": "xsd:boolean"
       },
       "daySunElevationValue": {
-         "@id": "ontologies:daySunElevationValue",
+         "@id": "openlabel:daySunElevationValue",
          "@type": "xsd:decimal"
       },
       "horizontalCurvesValue": {
-         "@id": "ontologies:horizontalCurvesValue",
+         "@id": "openlabel:horizontalCurvesValue",
          "@type": "xsd:decimal"
       },
       "illuminationCloudinessValue": {
-         "@id": "ontologies:illuminationCloudinessValue",
+         "@id": "openlabel:illuminationCloudinessValue",
          "@type": "xsd:decimal"
       },
       "laneSpecificationDimensionsValue": {
-         "@id": "ontologies:laneSpecificationDimensionsValue",
+         "@id": "openlabel:laneSpecificationDimensionsValue",
          "@type": "xsd:decimal"
       },
       "laneSpecificationLaneCountValue": {
-         "@id": "ontologies:laneSpecificationLaneCountValue",
+         "@id": "openlabel:laneSpecificationLaneCountValue",
          "@type": "xsd:integer"
       },
       "licenseURI": {
-         "@id": "ontologies:licenseURI",
+         "@id": "openlabel:licenseURI",
          "@type": "http://www.w3.org/2000/01/rdf-schema#Literal"
       },
       "longitudinalDownSlopeValue": {
-         "@id": "ontologies:longitudinalDownSlopeValue",
+         "@id": "openlabel:longitudinalDownSlopeValue",
          "@type": "xsd:decimal"
       },
       "longitudinalUpSlopeValue": {
-         "@id": "ontologies:longitudinalUpSlopeValue",
+         "@id": "openlabel:longitudinalUpSlopeValue",
          "@type": "xsd:decimal"
       },
       "motionAccelerateValue": {
-         "@id": "ontologies:motionAccelerateValue",
+         "@id": "openlabel:motionAccelerateValue",
          "@type": "xsd:decimal"
       },
       "motionDecelerateValue": {
-         "@id": "ontologies:motionDecelerateValue",
+         "@id": "openlabel:motionDecelerateValue",
          "@type": "xsd:decimal"
       },
       "motionDriveValue": {
-         "@id": "ontologies:motionDriveValue",
+         "@id": "openlabel:motionDriveValue",
          "@type": "xsd:decimal"
       },
       "ownerEmail": {
-         "@id": "ontologies:ownerEmail",
+         "@id": "openlabel:ownerEmail",
          "@type": "http://www.w3.org/2000/01/rdf-schema#Literal"
       },
       "ownerName": {
-         "@id": "ontologies:ownerName",
+         "@id": "openlabel:ownerName",
          "@type": "http://www.w3.org/2000/01/rdf-schema#Literal"
       },
       "ownerURL": {
-         "@id": "ontologies:ownerURL",
+         "@id": "openlabel:ownerURL",
          "@type": "http://www.w3.org/2000/01/rdf-schema#Literal"
       },
       "particulatesWaterValue": {
-         "@id": "ontologies:particulatesWaterValue",
+         "@id": "openlabel:particulatesWaterValue",
          "@type": "xsd:decimal"
       },
       "scenarioCreatedDate": {
-         "@id": "ontologies:scenarioCreatedDate",
+         "@id": "openlabel:scenarioCreatedDate",
          "@type": "http://www.w3.org/2000/01/rdf-schema#Literal"
       },
       "scenarioDefinition": {
-         "@id": "ontologies:scenarioDefinition",
+         "@id": "openlabel:scenarioDefinition",
          "@type": "http://www.w3.org/2000/01/rdf-schema#Literal"
       },
       "scenarioDefinitionLanguageURI": {
-         "@id": "ontologies:scenarioDefinitionLanguageURI",
+         "@id": "openlabel:scenarioDefinitionLanguageURI",
          "@type": "http://www.w3.org/2000/01/rdf-schema#Literal"
       },
       "scenarioDescription": {
-         "@id": "ontologies:scenarioDescription",
+         "@id": "openlabel:scenarioDescription",
          "@type": "http://www.w3.org/2000/01/rdf-schema#Literal"
       },
       "scenarioName": {
-         "@id": "ontologies:scenarioName",
+         "@id": "openlabel:scenarioName",
          "@type": "http://www.w3.org/2000/01/rdf-schema#Literal"
       },
       "scenarioParentReference": {
-         "@id": "ontologies:scenarioParentReference",
+         "@id": "openlabel:scenarioParentReference",
          "@type": "http://www.w3.org/2000/01/rdf-schema#Literal"
       },
       "scenarioUniqueReference": {
-         "@id": "ontologies:scenarioUniqueReference",
+         "@id": "openlabel:scenarioUniqueReference",
          "@type": "http://www.w3.org/2000/01/rdf-schema#Literal"
       },
       "scenarioVersion": {
-         "@id": "ontologies:scenarioVersion",
+         "@id": "openlabel:scenarioVersion",
          "@type": "http://www.w3.org/2000/01/rdf-schema#Literal"
       },
       "scenarioVisualisationURL": {
-         "@id": "ontologies:scenarioVisualisationURL",
+         "@id": "openlabel:scenarioVisualisationURL",
          "@type": "http://www.w3.org/2000/01/rdf-schema#Literal"
       },
       "subjectVehicleSpeedValue": {
-         "@id": "ontologies:subjectVehicleSpeedValue",
+         "@id": "openlabel:subjectVehicleSpeedValue",
          "@type": "xsd:integer"
       },
       "trafficAgentDensityValue": {
-         "@id": "ontologies:trafficAgentDensityValue",
+         "@id": "openlabel:trafficAgentDensityValue",
          "@type": "xsd:integer"
       },
       "trafficFlowRateValue": {
-         "@id": "ontologies:trafficFlowRateValue",
+         "@id": "openlabel:trafficFlowRateValue",
          "@type": "xsd:integer"
       },
       "trafficVolumeValue": {
-         "@id": "ontologies:trafficVolumeValue",
+         "@id": "openlabel:trafficVolumeValue",
          "@type": "xsd:integer"
       },
       "weatherRainValue": {
-         "@id": "ontologies:weatherRainValue",
+         "@id": "openlabel:weatherRainValue",
          "@type": "xsd:decimal"
       },
       "weatherSnowValue": {
-         "@id": "ontologies:weatherSnowValue",
+         "@id": "openlabel:weatherSnowValue",
          "@type": "xsd:decimal"
       },
       "weatherWindValue": {
-         "@id": "ontologies:weatherWindValue",
+         "@id": "openlabel:weatherWindValue",
          "@type": "xsd:decimal"
       }
    }

--- a/artifacts/tzip21/tzip21.context.jsonld
+++ b/artifacts/tzip21/tzip21.context.jsonld
@@ -16,7 +16,7 @@
       "skos": "http://www.w3.org/2004/02/skos/core#",
       "tzip21": "https://w3id.org/ascs-ev/envited-x/tzip21/v1/",
       "envited-x": "https://w3id.org/ascs-ev/envited-x/envited-x/v3/",
-      "development": "https://w3id.org/gaia-x/development#",
+      "gx": "https://w3id.org/gaia-x/development#",
       "artifactUri": {
          "@id": "tzip21:artifactUri",
          "@type": "xsd:anyURI"

--- a/src/tools/utils/context_generator.py
+++ b/src/tools/utils/context_generator.py
@@ -51,7 +51,7 @@ from rdflib import RDF, Graph, Namespace, URIRef
 from rdflib.namespace import OWL, XSD
 
 from src.tools.core.constants import FAST_STORE, Extensions
-from src.tools.core.iri_utils import get_local_name, iri_to_domain_hint, normalize_iri
+from src.tools.core.iri_utils import get_local_name, normalize_iri
 from src.tools.core.logging import get_logger
 from src.tools.utils.graph_loader import load_graph, load_graphs
 from src.tools.utils.print_formatter import normalize_path_for_display
@@ -92,6 +92,52 @@ def extract_ontology_iri(owl_graph: Graph) -> Optional[str]:
     """Extract the ontology IRI from an OWL graph."""
     for s in owl_graph.subjects(RDF.type, OWL.Ontology):
         return str(s)
+    return None
+
+
+def _build_ns_prefix_lookup(graph: Graph) -> Dict[str, str]:
+    """Build a reverse lookup from namespace URI to declared prefix name.
+
+    Uses the ``@prefix`` declarations from the parsed Turtle source
+    (available via ``graph.namespaces()``).  This is the
+    standards-conformant way to resolve prefix names — the ontology
+    author's declared prefixes are authoritative.
+
+    Returns:
+        Dict mapping namespace URI strings to prefix name strings.
+    """
+    lookup: Dict[str, str] = {}
+    for prefix, ns in graph.namespaces():
+        prefix_str = str(prefix)
+        ns_str = str(ns)
+        if prefix_str:
+            lookup[ns_str] = prefix_str
+    return lookup
+
+
+def _lookup_prefix(ns_lookup: Dict[str, str], iri: str) -> Optional[str]:
+    """Look up a prefix for an IRI using declared namespace bindings.
+
+    Tries the normalized IRI (with trailing ``/``) and both ``/`` and
+    ``#`` variants to handle hash-vs-slash namespace mismatches.
+
+    Args:
+        ns_lookup: Mapping from namespace URI to prefix name
+            (built by :func:`_build_ns_prefix_lookup`).
+        iri: The ontology IRI to look up.
+
+    Returns:
+        The declared prefix name, or ``None`` if not found.
+    """
+    normalized = normalize_iri(iri, trailing_slash=True)
+    if normalized in ns_lookup:
+        return ns_lookup[normalized]
+
+    base = iri.rstrip("/#")
+    for variant in (base + "#", base + "/"):
+        if variant in ns_lookup:
+            return ns_lookup[variant]
+
     return None
 
 
@@ -394,8 +440,13 @@ def generate_context(domain: str) -> Optional[Dict[str, Any]]:
 
     logger.info("Processing domain '%s' with IRI: %s", domain, ontology_iri)
 
-    # Determine prefix
-    prefix = iri_to_domain_hint(ontology_iri) or domain
+    # Build reverse lookup from namespace URIs to author-declared prefix names.
+    # This uses the @prefix declarations from the Turtle source, which are the
+    # authoritative prefix-to-namespace mappings.
+    ns_lookup = _build_ns_prefix_lookup(owl_graph)
+
+    # Determine prefix from namespace bindings, fall back to domain name
+    prefix = _lookup_prefix(ns_lookup, ontology_iri) or domain
 
     # Build context
     context: Dict[str, Any] = {
@@ -415,11 +466,20 @@ def generate_context(domain: str) -> Optional[Dict[str, Any]]:
     # Reserved keys that properties/classes must not overwrite
     reserved_keys = set(context.keys())
 
-    # Add prefixes for imported ontologies (resolved from owl:imports IRIs)
+    # Add prefixes for imported ontologies resolved from owl:imports IRIs.
+    # Only uses author-declared @prefix bindings; imports without a matching
+    # declaration are skipped with a warning (no heuristic guessing).
     for imported in sorted(owl_graph.objects(URIRef(ontology_iri), OWL.imports)):
         imported_str = str(imported)
-        imported_prefix = iri_to_domain_hint(imported_str)
-        if imported_prefix and imported_prefix not in context:
+        imported_prefix = _lookup_prefix(ns_lookup, imported_str)
+        if not imported_prefix:
+            logger.warning(
+                "No @prefix declaration for <%s> in %s, skipping import prefix",
+                imported_str,
+                domain,
+            )
+            continue
+        if imported_prefix not in context:
             imported_ns = normalize_iri(imported_str, trailing_slash=True)
             context[imported_prefix] = imported_ns
             reserved_keys.add(imported_prefix)
@@ -652,17 +712,22 @@ def _run_tests() -> bool:
     print("Running context_generator self-tests...")
     all_passed = True
 
-    # Test 1: iri_to_domain_hint (replaces extract_prefix_from_iri)
+    # Test 1: _build_ns_prefix_lookup / _lookup_prefix
     try:
-        iri1 = "https://w3id.org/ascs-ev/envited-x/manifest/v5"
-        assert iri_to_domain_hint(iri1) == "manifest"
+        g = Graph()
+        g.bind("gx", "https://w3id.org/gaia-x/development#")
+        g.bind("manifest", "https://w3id.org/ascs-ev/envited-x/manifest/v5/")
 
-        iri2 = "https://w3id.org/ascs-ev/envited-x/hdmap/v5/"
-        assert iri_to_domain_hint(iri2) == "hdmap"
+        ns_lookup = _build_ns_prefix_lookup(g)
+        assert _lookup_prefix(ns_lookup, "https://w3id.org/gaia-x/development#") == "gx"
+        assert (
+            _lookup_prefix(ns_lookup, "https://w3id.org/ascs-ev/envited-x/manifest/v5")
+            == "manifest"
+        )
 
-        print("PASS: iri_to_domain_hint")
+        print("PASS: namespace prefix lookup")
     except AssertionError as e:
-        print(f"FAIL: iri_to_domain_hint - {e}")
+        print(f"FAIL: namespace prefix lookup - {e}")
         all_passed = False
 
     # Test 2: Generate context for manifest (if files exist)

--- a/tests/unit/utils/test_context_generator.py
+++ b/tests/unit/utils/test_context_generator.py
@@ -12,9 +12,10 @@ import pytest
 from rdflib import BNode, Graph, Namespace, URIRef
 from rdflib.namespace import OWL, RDF, XSD
 
-from src.tools.core.iri_utils import iri_to_domain_hint
 from src.tools.utils.context_generator import (
     _analyze_or_branches,
+    _build_ns_prefix_lookup,
+    _lookup_prefix,
     extract_classes,
     extract_ontology_iri,
     extract_property_datatypes,
@@ -29,28 +30,58 @@ ROOT_DIR = Path(__file__).parent.parent.parent.parent.resolve()
 ARTIFACTS_DIR = ROOT_DIR / "artifacts"
 
 
-class TestIriToDomainHint:
-    """Tests for iri_to_domain_hint (replaces extract_prefix_from_iri)."""
+class TestNsPrefixLookup:
+    """Tests for _build_ns_prefix_lookup and _lookup_prefix."""
 
-    def test_iri_to_domain_hint_manifest_iri(self):
-        """Should extract 'manifest' from manifest ontology IRI."""
-        iri = "https://w3id.org/ascs-ev/envited-x/manifest/v5"
-        assert iri_to_domain_hint(iri) == "manifest"
+    def test_lookup_hash_namespace(self):
+        """Should find prefix for hash-terminated namespace."""
+        g = Graph()
+        g.bind("gx", "https://w3id.org/gaia-x/development#")
+        ns_lookup = _build_ns_prefix_lookup(g)
+        assert _lookup_prefix(ns_lookup, "https://w3id.org/gaia-x/development#") == "gx"
 
-    def test_iri_to_domain_hint_trailing_slash(self):
-        """Should extract 'hdmap' from hdmap ontology IRI with trailing slash."""
-        iri = "https://w3id.org/ascs-ev/envited-x/hdmap/v5/"
-        assert iri_to_domain_hint(iri) == "hdmap"
+    def test_lookup_slash_namespace(self):
+        """Should find prefix for slash-terminated namespace."""
+        g = Graph()
+        g.bind("manifest", "https://w3id.org/ascs-ev/envited-x/manifest/v5/")
+        ns_lookup = _build_ns_prefix_lookup(g)
+        assert (
+            _lookup_prefix(ns_lookup, "https://w3id.org/ascs-ev/envited-x/manifest/v5/")
+            == "manifest"
+        )
 
-    def test_iri_to_domain_hint_legacy_iri(self):
-        """Should extract domain from legacy gaia-x4plcaad IRI."""
-        iri = "https://w3id.org/gaia-x4plcaad/ontologies/scenario/v5"
-        assert iri_to_domain_hint(iri) == "scenario"
+    def test_lookup_normalizes_missing_trailing_slash(self):
+        """Should find prefix when IRI lacks trailing slash but namespace has it."""
+        g = Graph()
+        g.bind("manifest", "https://w3id.org/ascs-ev/envited-x/manifest/v5/")
+        ns_lookup = _build_ns_prefix_lookup(g)
+        assert (
+            _lookup_prefix(ns_lookup, "https://w3id.org/ascs-ev/envited-x/manifest/v5")
+            == "manifest"
+        )
 
-    def test_iri_to_domain_hint_simple_iri(self):
-        """Should handle simple IRI without version pattern."""
-        iri = "https://example.org/ontology/myterm"
-        assert iri_to_domain_hint(iri) == "myterm"
+    def test_lookup_tries_hash_variant(self):
+        """Should find prefix via hash variant when IRI has no terminator."""
+        g = Graph()
+        g.bind("gx", "https://w3id.org/gaia-x/development#")
+        ns_lookup = _build_ns_prefix_lookup(g)
+        assert _lookup_prefix(ns_lookup, "https://w3id.org/gaia-x/development") == "gx"
+
+    def test_lookup_returns_none_for_unknown(self):
+        """Should return None for unknown IRI."""
+        g = Graph()
+        g.bind("gx", "https://w3id.org/gaia-x/development#")
+        ns_lookup = _build_ns_prefix_lookup(g)
+        assert _lookup_prefix(ns_lookup, "https://example.org/unknown/") is None
+
+    def test_build_skips_empty_prefix(self):
+        """Should not include the default (empty) prefix in the lookup."""
+        g = Graph()
+        g.bind("", "https://example.org/default/")
+        g.bind("ex", "https://example.org/explicit/")
+        ns_lookup = _build_ns_prefix_lookup(g)
+        assert "https://example.org/default/" not in ns_lookup
+        assert ns_lookup["https://example.org/explicit/"] == "ex"
 
 
 class TestExtractOntologyIri:
@@ -406,6 +437,24 @@ class TestGenerateContext:
         # These properties use sh:or with sh:node branches
         assert ctx.get("hasResourceDescription", {}).get("@type") == "@id"
         assert ctx.get("hasManifest", {}).get("@type") == "@id"
+
+    def test_generate_context_envited_x_uses_gx_prefix(self):
+        """envited-x context should use 'gx' prefix from @prefix declaration, not 'development'."""
+        envited_x_owl = ARTIFACTS_DIR / "envited-x" / "envited-x.owl.ttl"
+        if not envited_x_owl.exists():
+            pytest.skip("envited-x OWL file not found")
+
+        result = generate_context("envited-x")
+        assert result is not None
+
+        ctx = result["@context"]
+        # Must use the declared @prefix name 'gx', not the path segment 'development'
+        assert "gx" in ctx, "Expected 'gx' prefix from @prefix declaration"
+        assert ctx["gx"] == "https://w3id.org/gaia-x/development#"
+        assert "development" not in ctx, (
+            "Prefix 'development' should not appear — "
+            "use the author-declared @prefix name 'gx' instead"
+        )
 
 
 class TestRoundTrip:


### PR DESCRIPTION
## Summary

Fix prefix name resolution in `context_generator.py` to use author-declared
`@prefix` bindings from OWL Turtle files instead of the unreliable
`iri_to_domain_hint()` heuristic.

**Root cause:** `iri_to_domain_hint("https://w3id.org/gaia-x/development#")`
returned `"development"` (last URL path segment) instead of the conventional
`"gx"` prefix. This caused `envited-x.context.jsonld` to map the Gaia-X
namespace under `"development"`, forcing every instance file to manually
override with inline `"gx": "https://w3id.org/gaia-x/development#"`.

**Fix:** Read `graph.namespaces()` from the parsed OWL graph — these contain
the `@prefix` declarations the ontology author wrote. This is the
standards-conformant way to resolve prefix names.

## Changes

- `src/tools/utils/context_generator.py`:
  - Add `_build_ns_prefix_lookup()` — builds reverse namespace→prefix map
  - Add `_lookup_prefix()` — looks up prefix with IRI variant handling
  - Use namespace bindings in `generate_context()` for both domain and import prefixes
  - Keep `iri_to_domain_hint` as fallback with warning log
  - Update `_run_tests()` to test namespace lookup instead of heuristic

- `tests/unit/utils/test_context_generator.py`:
  - Replace `TestIriToDomainHint` with `TestNsPrefixLookup` (6 tests)
  - Add `test_generate_context_envited_x_uses_gx_prefix` integration test

- Regenerated context files (3 affected):
  - `artifacts/envited-x/envited-x.context.jsonld` — `"development"` → `"gx"`
  - `artifacts/tzip21/tzip21.context.jsonld` — `"development"` → `"gx"`
  - `artifacts/openlabel/openlabel.context.jsonld` — prefix ordering update

## Testing

- [x] All 419 tests pass (`pytest tests/`)
- [x] Module self-tests pass (`python -m src.tools.utils.context_generator --test`)
- [x] Context regeneration produces correct output (`--all`)

## Related Issues

Fixes incorrect `"development"` prefix in generated JSON-LD contexts for
domains importing the Gaia-X ontology.
