### PR TITLE
fix(http): pin raw GitHub fetches to registry release tag

### DIFF
--- a/src/tools/utils/http_artifact_resolver.py
+++ b/src/tools/utils/http_artifact_resolver.py
@@ -103,9 +103,11 @@ logger = get_logger(__name__)
 GH_PAGES_BASE = "https://ascs-ev.github.io/ontology-management-base"
 
 # Raw GitHub content for files not published to Pages (catalogs, imports).
-RAW_GITHUB_BASE = (
-    "https://raw.githubusercontent.com/ASCS-eV/ontology-management-base/main"
-)
+# The ref segment is replaced with the registry's release tag in ensure_cache()
+# so that catalogs, imports, and non-registry artifacts (e.g. gx) are fetched
+# from the same commit as the published registry — not from 'main' HEAD.
+_RAW_GITHUB_REPO = "https://raw.githubusercontent.com/ASCS-eV/ontology-management-base"
+RAW_GITHUB_BASE = f"{_RAW_GITHUB_REPO}/main"
 
 # Registry JSON URL (published via GH Pages docs workflow).
 REGISTRY_URL = f"{GH_PAGES_BASE}/registry.json"
@@ -370,6 +372,33 @@ class HttpArtifactResolver:
         """Write a timestamp marker for cache freshness tracking."""
         marker = cache_dir / ".cache-timestamp"
         marker.write_text(str(time.time()))
+
+    def _pin_raw_github_to_release(self, tag: str) -> None:
+        """Pin ``raw_github_base`` to a release tag instead of ``main``.
+
+        Replaces the Git ref segment (last path component) in the raw GitHub
+        URL with the given release tag so that catalogs, imports, and
+        non-registry artifacts are fetched from a deterministic commit.
+
+        Args:
+            tag: Release tag from the registry (e.g., "v0.1.6").
+        """
+        if not tag or tag == "unknown":
+            return
+
+        repo_base, _, current_ref = self.raw_github_base.rpartition("/")
+        if not repo_base:
+            return
+
+        if current_ref == tag:
+            return
+
+        self.raw_github_base = f"{repo_base}/{tag}"
+        logger.info(
+            "Pinned raw GitHub base to release tag: %s (was: %s)",
+            tag,
+            current_ref,
+        )
 
     # =========================================================================
     # Fetching: Catalogs
@@ -693,6 +722,11 @@ class HttpArtifactResolver:
         """
         version = self.get_registry_version()
         cache_dir = self._versioned_cache_dir(version)
+
+        # Pin raw GitHub fetches to the release tag so catalogs, imports, and
+        # non-registry artifacts (e.g. gx) come from the same commit as the
+        # published registry — not from an arbitrary 'main' HEAD.
+        self._pin_raw_github_to_release(version)
 
         if not force and self.is_cache_valid(cache_dir):
             logger.info("Using valid cache at %s", cache_dir)

--- a/tests/unit/utils/test_http_artifact_resolver.py
+++ b/tests/unit/utils/test_http_artifact_resolver.py
@@ -183,6 +183,34 @@ class TestCacheManagement:
         assert not version_dir.exists()
 
 
+class TestPinRawGithubToRelease:
+    """Tests for _pin_raw_github_to_release."""
+
+    def test_pins_main_to_release_tag(self, resolver):
+        """Default '/raw' ref is replaced with the release tag."""
+        resolver.raw_github_base = "https://test.example.com/raw/main"
+        resolver._pin_raw_github_to_release("v0.1.4")
+        assert resolver.raw_github_base == "https://test.example.com/raw/v0.1.4"
+
+    def test_skips_when_already_pinned(self, resolver):
+        """No-op when base already uses the target tag."""
+        resolver.raw_github_base = "https://test.example.com/raw/v0.1.4"
+        resolver._pin_raw_github_to_release("v0.1.4")
+        assert resolver.raw_github_base == "https://test.example.com/raw/v0.1.4"
+
+    def test_skips_unknown_version(self, resolver):
+        """No-op when version is 'unknown'."""
+        original = resolver.raw_github_base
+        resolver._pin_raw_github_to_release("unknown")
+        assert resolver.raw_github_base == original
+
+    def test_skips_empty_version(self, resolver):
+        """No-op when version is empty."""
+        original = resolver.raw_github_base
+        resolver._pin_raw_github_to_release("")
+        assert resolver.raw_github_base == original
+
+
 # ---------------------------------------------------------------------------
 # Catalog Fetch Tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The `RAW_GITHUB_BASE` constant was hardcoded to fetch from `/main`:

`python
RAW_GITHUB_BASE = "https://raw.githubusercontent.com/ASCS-eV/ontology-management-base/main"
``n
This meant catalogs, imports, and non-registry artifacts (e.g. `gx`) were always fetched from `main` HEAD -- even when the pip-installed package corresponded to a specific release tag. Registry-based domains (hdmap, envited-x, etc.) were fetched from GitHub Pages at the release tag, creating a **version skew** between the two artifact tiers.

## Fix

`ensure_cache()` now calls `_pin_raw_github_to_release(tag)` before any fetch operations. This method replaces the Git ref segment (last path component) in `raw_github_base` with the registry's `latestRelease` tag (e.g. `v0.1.6`).

**Before:** `https://raw.githubusercontent.com/.../main/artifacts/catalog-v001.xml`
**After:** `https://raw.githubusercontent.com/.../v0.1.6/artifacts/catalog-v001.xml`

The method is safe:
- No-op if version is `unknown` or empty
- No-op if already pinned to the target tag
- Works with custom `raw_github_base` URLs (uses `rpartition` to replace only the last segment)
- Logs the pin operation for debuggability

## Testing

- 4 new unit tests for `_pin_raw_github_to_release` (pin, already-pinned, unknown, empty)
- All 70 tests pass (66 existing + 4 new)