### PR TITLE
demo: RDFC-1.0 blank-node renumbering problem (DO NOT MERGE)

### DIFF
--- a/artifacts/openlabel-v2/openlabel-v2.owl.ttl
+++ b/artifacts/openlabel-v2/openlabel-v2.owl.ttl
@@ -35,7 +35,7 @@
 openlabel_v2:AdminTag a owl:Class , owl:ObjectProperty , linkml:ClassDefinition , linkml:SlotDefinition ;
 	rdfs:label "AdminTag" ;
 	rdfs:range openlabel_v2:AdminTag ;
-	rdfs:subClassOf _:c14n102 , _:c14n107 , _:c14n129 , _:c14n146 , _:c14n183 , _:c14n201 , _:c14n211 , _:c14n216 , _:c14n239 , _:c14n260 , _:c14n270 , _:c14n290 , _:c14n305 , _:c14n315 , _:c14n344 , _:c14n363 , _:c14n366 , _:c14n370 , _:c14n418 , _:c14n454 , _:c14n474 , _:c14n588 , _:c14n62 , _:c14n650 , _:c14n662 , _:c14n668 , _:c14n691 , _:c14n750 , _:c14n769 , _:c14n789 , _:c14n813 , _:c14n817 , _:c14n830 , _:c14n834 , _:c14n873 , _:c14n892 , _:c14n905 , _:c14n907 , _:c14n910 ;
+	rdfs:subClassOf _:c14n102 , _:c14n107 , _:c14n129 , _:c14n146 , _:c14n183 , _:c14n201 , _:c14n211 , _:c14n216 , _:c14n225 , _:c14n240 , _:c14n261 , _:c14n271 , _:c14n291 , _:c14n306 , _:c14n316 , _:c14n345 , _:c14n364 , _:c14n367 , _:c14n371 , _:c14n419 , _:c14n452 , _:c14n456 , _:c14n476 , _:c14n590 , _:c14n62 , _:c14n652 , _:c14n664 , _:c14n670 , _:c14n693 , _:c14n752 , _:c14n771 , _:c14n791 , _:c14n815 , _:c14n819 , _:c14n832 , _:c14n835 , _:c14n837 , _:c14n876 , _:c14n895 , _:c14n908 , _:c14n910 , _:c14n913 ;
 	skos:definition "Administration tag." , "The base tag to use when extending the Administration tags with new classes." ;
 	skos:exactMatch openlabel_v2:AdminTag ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
@@ -51,14 +51,14 @@ openlabel_v2:Behaviour a owl:Class , owl:ObjectProperty , linkml:ClassDefinition
 	rdfs:label "Behaviour" ;
 	rdfs:range openlabel_v2:Behaviour ;
 	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-	rdfs:subClassOf _:c14n10 , _:c14n109 , _:c14n12 , _:c14n126 , _:c14n15 , _:c14n162 , _:c14n195 , _:c14n196 , _:c14n20 , _:c14n226 , _:c14n234 , _:c14n235 , _:c14n243 , _:c14n251 , _:c14n257 , _:c14n261 , _:c14n264 , _:c14n272 , _:c14n31 , _:c14n368 , _:c14n39 , _:c14n395 , _:c14n403 , _:c14n412 , _:c14n425 , _:c14n434 , _:c14n438 , _:c14n445 , _:c14n447 , _:c14n452 , _:c14n453 , _:c14n480 , _:c14n490 , _:c14n497 , _:c14n507 , _:c14n514 , _:c14n531 , _:c14n539 , _:c14n540 , _:c14n546 , _:c14n565 , _:c14n575 , _:c14n592 , _:c14n599 , _:c14n611 , _:c14n646 , _:c14n649 , _:c14n684 , _:c14n685 , _:c14n686 , _:c14n712 , _:c14n722 , _:c14n723 , _:c14n726 , _:c14n73 , _:c14n733 , _:c14n734 , _:c14n736 , _:c14n745 , _:c14n754 , _:c14n763 , _:c14n771 , _:c14n80 , _:c14n805 , _:c14n81 , _:c14n82 , _:c14n850 , _:c14n867 , _:c14n887 , _:c14n890 , _:c14n893 ;
+	rdfs:subClassOf _:c14n10 , _:c14n109 , _:c14n12 , _:c14n126 , _:c14n15 , _:c14n162 , _:c14n195 , _:c14n196 , _:c14n20 , _:c14n227 , _:c14n235 , _:c14n236 , _:c14n244 , _:c14n252 , _:c14n258 , _:c14n262 , _:c14n265 , _:c14n273 , _:c14n31 , _:c14n369 , _:c14n39 , _:c14n396 , _:c14n404 , _:c14n413 , _:c14n426 , _:c14n435 , _:c14n439 , _:c14n446 , _:c14n448 , _:c14n454 , _:c14n455 , _:c14n482 , _:c14n492 , _:c14n499 , _:c14n509 , _:c14n516 , _:c14n533 , _:c14n541 , _:c14n542 , _:c14n548 , _:c14n567 , _:c14n577 , _:c14n594 , _:c14n601 , _:c14n613 , _:c14n648 , _:c14n651 , _:c14n686 , _:c14n687 , _:c14n688 , _:c14n714 , _:c14n724 , _:c14n725 , _:c14n728 , _:c14n73 , _:c14n735 , _:c14n736 , _:c14n738 , _:c14n747 , _:c14n756 , _:c14n765 , _:c14n773 , _:c14n80 , _:c14n807 , _:c14n81 , _:c14n82 , _:c14n853 , _:c14n870 , _:c14n890 , _:c14n893 , _:c14n896 ;
 	skos:definition "An activity performed by a road user." , "Behaviour tag." ;
 	skos:exactMatch openlabel_v2:Behaviour ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
 openlabel_v2:BehaviourCommunication a owl:Class , owl:ObjectProperty , linkml:EnumDefinition , linkml:SlotDefinition ;
 	rdfs:label "BehaviourCommunication" , "BehaviourCommunicationEnum" ;
 	rdfs:range openlabel_v2:BehaviourCommunication ;
-	owl:unionOf _:c14n617 ;
+	owl:unionOf _:c14n619 ;
 	skos:definition "Communication type of road user behaviour." , "Types of communication behaviours by road users." ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
 	linkml:permissible_values openlabel_v2:CommunicationHeadlightFlash , openlabel_v2:CommunicationHorn , openlabel_v2:CommunicationSignalEmergency , openlabel_v2:CommunicationSignalHazard , openlabel_v2:CommunicationSignalLeft , openlabel_v2:CommunicationSignalRight , openlabel_v2:CommunicationSignalSlowing , openlabel_v2:CommunicationWave .
@@ -106,7 +106,7 @@ openlabel_v2:ConnectivityCommunication a owl:Class , owl:ObjectProperty , linkml
 	rdfs:label "ConnectivityCommunication" , "ConnectivityCommunicationEnum" ;
 	rdfs:range openlabel_v2:ConnectivityCommunication ;
 	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-	owl:unionOf _:c14n904 ;
+	owl:unionOf _:c14n907 ;
 	skos:definition "Communication connectivity type. Refer to BSI PAS-1883 Section 5.3.4.a." , "Types of communication connectivity. Refer to BSI PAS-1883 Section 5.3.4.a." ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
 	linkml:permissible_values openlabel_v2:CommunicationV2i , openlabel_v2:CommunicationV2v , openlabel_v2:V2iCellular , openlabel_v2:V2iSatellite , openlabel_v2:V2iWifi , openlabel_v2:V2vCellular , openlabel_v2:V2vSatellite , openlabel_v2:V2vWifi .
@@ -114,7 +114,7 @@ openlabel_v2:ConnectivityPositioning a owl:Class , owl:ObjectProperty , linkml:E
 	rdfs:label "ConnectivityPositioning" , "ConnectivityPositioningEnum" ;
 	rdfs:range openlabel_v2:ConnectivityPositioning ;
 	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-	owl:unionOf _:c14n313 ;
+	owl:unionOf _:c14n314 ;
 	skos:definition "Positioning system type. Refer to BSI PAS-1883 Section 5.3.4.b." , "Types of positioning systems. Refer to BSI PAS-1883 Section 5.3.4.b." ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
 	linkml:permissible_values openlabel_v2:PositioningGalileo , openlabel_v2:PositioningGlonass , openlabel_v2:PositioningGps .
@@ -128,7 +128,7 @@ openlabel_v2:DaySunPosition a owl:Class , owl:ObjectProperty , linkml:EnumDefini
 	rdfs:label "DaySunPosition" , "DaySunPositionEnum" ;
 	rdfs:range openlabel_v2:DaySunPosition ;
 	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-	owl:unionOf _:c14n863 ;
+	owl:unionOf _:c14n866 ;
 	skos:definition "Position of the sun relative to direction of travel. Refer to BSI PAS-1883 Section 5.3.3.a.2." , "Position of the sun. Refer to BSI PAS-1883 Section 5.3.3.a.2." ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
 	linkml:permissible_values openlabel_v2:SunPositionBehind , openlabel_v2:SunPositionFront , openlabel_v2:SunPositionLeft , openlabel_v2:SunPositionRight .
@@ -136,7 +136,7 @@ openlabel_v2:DrivableAreaEdge a owl:Class , owl:ObjectProperty , linkml:EnumDefi
 	rdfs:label "DrivableAreaEdge" , "DrivableAreaEdgeEnum" ;
 	rdfs:range openlabel_v2:DrivableAreaEdge ;
 	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-	owl:unionOf _:c14n407 ;
+	owl:unionOf _:c14n408 ;
 	skos:definition "Drivable area edge type. Refer to BSI PAS-1883 Section 5.2.3.1.e." , "Types of drivable area edges. Refer to BSI PAS-1883 Section 5.2.3.6." ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
 	linkml:permissible_values openlabel_v2:EdgeLineMarkers , openlabel_v2:EdgeNone , openlabel_v2:EdgeShoulderGrass , openlabel_v2:EdgeShoulderPavedOrGravel , openlabel_v2:EdgeSolidBarriers , openlabel_v2:EdgeTemporaryLineMarkers .
@@ -144,7 +144,7 @@ openlabel_v2:DrivableAreaSurfaceCondition a owl:Class , owl:ObjectProperty , lin
 	rdfs:label "DrivableAreaSurfaceCondition" , "DrivableAreaSurfaceConditionEnum" ;
 	rdfs:range openlabel_v2:DrivableAreaSurfaceCondition ;
 	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-	owl:unionOf _:c14n468 ;
+	owl:unionOf _:c14n470 ;
 	skos:definition "Road surface condition. Refer to BSI PAS-1883 Section 5.2.3.7.c." , "Road surface conditions. Refer to BSI PAS-1883 Section 5.2.3.7.c." ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
 	linkml:permissible_values openlabel_v2:SurfaceConditionContamination , openlabel_v2:SurfaceConditionFlooded , openlabel_v2:SurfaceConditionIcy , openlabel_v2:SurfaceConditionMirage , openlabel_v2:SurfaceConditionSnow , openlabel_v2:SurfaceConditionStandingWater , openlabel_v2:SurfaceConditionWet .
@@ -152,7 +152,7 @@ openlabel_v2:DrivableAreaSurfaceFeature a owl:Class , owl:ObjectProperty , linkm
 	rdfs:label "DrivableAreaSurfaceFeature" , "DrivableAreaSurfaceFeatureEnum" ;
 	rdfs:range openlabel_v2:DrivableAreaSurfaceFeature ;
 	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-	owl:unionOf _:c14n800 ;
+	owl:unionOf _:c14n802 ;
 	skos:definition "Road surface feature. Refer to BSI PAS-1883 Section 5.2.3.7.b." , "Road surface features. Refer to BSI PAS-1883 Section 5.2.3.7.b." ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
 	linkml:permissible_values openlabel_v2:SurfaceFeatureCrack , openlabel_v2:SurfaceFeaturePothole , openlabel_v2:SurfaceFeatureRut , openlabel_v2:SurfaceFeatureSwell .
@@ -160,7 +160,7 @@ openlabel_v2:DrivableAreaSurfaceType a owl:Class , owl:ObjectProperty , linkml:E
 	rdfs:label "DrivableAreaSurfaceType" , "DrivableAreaSurfaceTypeEnum" ;
 	rdfs:range openlabel_v2:DrivableAreaSurfaceType ;
 	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-	owl:unionOf _:c14n713 ;
+	owl:unionOf _:c14n715 ;
 	skos:definition "Road surface type. Refer to BSI PAS-1883 Section 5.2.3.7.a." , "Road surface types. Refer to BSI PAS-1883 Section 5.2.3.7.a." ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
 	linkml:permissible_values openlabel_v2:SurfaceTypeLoose , openlabel_v2:SurfaceTypeSegmented , openlabel_v2:SurfaceTypeUniform .
@@ -168,7 +168,7 @@ openlabel_v2:DrivableAreaType a owl:Class , owl:ObjectProperty , linkml:EnumDefi
 	rdfs:label "DrivableAreaType" , "DrivableAreaTypeEnum" ;
 	rdfs:range openlabel_v2:DrivableAreaType ;
 	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-	owl:unionOf _:c14n551 ;
+	owl:unionOf _:c14n553 ;
 	skos:definition "Road type. Refer to BSI PAS-1883 Section 5.2.3.2." , "Road types. Refer to BSI PAS-1883 Section 5.2.3.2." ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
 	linkml:permissible_values openlabel_v2:MotorwayManaged , openlabel_v2:MotorwayUnmanaged , openlabel_v2:RoadTypeDistributor , openlabel_v2:RoadTypeMinor , openlabel_v2:RoadTypeMotorway , openlabel_v2:RoadTypeParking , openlabel_v2:RoadTypeRadial , openlabel_v2:RoadTypeShared , openlabel_v2:RoadTypeSlip .
@@ -200,7 +200,7 @@ openlabel_v2:EnvironmentParticulates a owl:Class , owl:ObjectProperty , linkml:E
 	rdfs:label "EnvironmentParticulates" , "EnvironmentParticulatesEnum" ;
 	rdfs:range openlabel_v2:EnvironmentParticulates ;
 	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-	owl:unionOf _:c14n478 ;
+	owl:unionOf _:c14n480 ;
 	skos:definition "Particulate type. Refer to BSI PAS-1883 Section 5.3.2." , "Types of particulates. Refer to BSI PAS-1883 Section 5.3.2." ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
 	linkml:permissible_values openlabel_v2:ParticulatesDust , openlabel_v2:ParticulatesMarine , openlabel_v2:ParticulatesPollution , openlabel_v2:ParticulatesVolcanic , openlabel_v2:ParticulatesWater .
@@ -224,7 +224,7 @@ openlabel_v2:GeometryTransverse a owl:Class , owl:ObjectProperty , linkml:EnumDe
 	rdfs:label "GeometryTransverse" , "GeometryTransverseEnum" ;
 	rdfs:range openlabel_v2:GeometryTransverse ;
 	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-	owl:unionOf _:c14n820 ;
+	owl:unionOf _:c14n822 ;
 	skos:definition "Transverse geometry type. Refer to BSI PAS-1883 Section 5.2.3.3.b." , "Types of transverse geometry. Refer to BSI PAS-1883 Section 5.2.3.3.b." ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
 	linkml:permissible_values openlabel_v2:TransverseBarriers , openlabel_v2:TransverseDivided , openlabel_v2:TransverseLanesTogether , openlabel_v2:TransversePavements , openlabel_v2:TransverseUndivided .
@@ -286,7 +286,7 @@ openlabel_v2:IlluminationLowLight a owl:Class , owl:ObjectProperty , linkml:Enum
 	rdfs:label "IlluminationLowLight" , "IlluminationLowLightEnum" ;
 	rdfs:range openlabel_v2:IlluminationLowLight ;
 	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-	owl:unionOf _:c14n802 ;
+	owl:unionOf _:c14n804 ;
 	skos:definition "Low light condition. Refer to BSI PAS-1883 Section 5.3.3.b." , "Types of low light conditions. Refer to BSI PAS-1883 Section 5.3.3.b." ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
 	linkml:permissible_values openlabel_v2:LowLightAmbient , openlabel_v2:LowLightNight .
@@ -330,7 +330,7 @@ openlabel_v2:JunctionIntersection a owl:Class , owl:ObjectProperty , linkml:Enum
 	rdfs:label "JunctionIntersection" , "JunctionIntersectionEnum" ;
 	rdfs:range openlabel_v2:JunctionIntersection ;
 	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-	owl:unionOf _:c14n601 ;
+	owl:unionOf _:c14n603 ;
 	skos:definition "Intersection type. Refer to BSI PAS-1883 Section 5.2.4." , "Types of intersections. Refer to BSI PAS-1883 Section 5.2.4." ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
 	linkml:permissible_values openlabel_v2:IntersectionCrossroad , openlabel_v2:IntersectionGradeSeperated , openlabel_v2:IntersectionStaggered , openlabel_v2:IntersectionTJunction , openlabel_v2:IntersectionYJunction .
@@ -338,7 +338,7 @@ openlabel_v2:JunctionRoundabout a owl:Class , owl:ObjectProperty , linkml:EnumDe
 	rdfs:label "JunctionRoundabout" , "JunctionRoundaboutEnum" ;
 	rdfs:range openlabel_v2:JunctionRoundabout ;
 	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-	owl:unionOf _:c14n571 ;
+	owl:unionOf _:c14n573 ;
 	skos:definition "Roundabout type. Refer to BSI PAS-1883 Section 5.2.4." , "Types of roundabouts. Refer to BSI PAS-1883 Section 5.2.4." ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
 	linkml:permissible_values openlabel_v2:RoundaboutCompactNosignal , openlabel_v2:RoundaboutCompactSignal , openlabel_v2:RoundaboutDoubleNosignal , openlabel_v2:RoundaboutDoubleSignal , openlabel_v2:RoundaboutLargeNosignal , openlabel_v2:RoundaboutLargeSignal , openlabel_v2:RoundaboutMiniNosignal , openlabel_v2:RoundaboutMiniSignal , openlabel_v2:RoundaboutNormalNosignal , openlabel_v2:RoundaboutNormalSignal .
@@ -538,25 +538,25 @@ openlabel_v2:Odd a owl:Class , owl:ObjectProperty , linkml:ClassDefinition , lin
 	rdfs:label "Odd" ;
 	rdfs:range openlabel_v2:Odd ;
 	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-	rdfs:subClassOf _:c14n108 , _:c14n11 , _:c14n110 , _:c14n111 , _:c14n112 , _:c14n116 , _:c14n123 , _:c14n124 , _:c14n125 , _:c14n138 , _:c14n139 , _:c14n143 , _:c14n145 , _:c14n148 , _:c14n149 , _:c14n150 , _:c14n151 , _:c14n154 , _:c14n155 , _:c14n157 , _:c14n161 , _:c14n166 , _:c14n167 , _:c14n169 , _:c14n175 , _:c14n199 , _:c14n210 , _:c14n212 , _:c14n22 , _:c14n232 , _:c14n241 , _:c14n244 , _:c14n248 , _:c14n249 , _:c14n255 , _:c14n256 , _:c14n26 , _:c14n265 , _:c14n268 , _:c14n271 , _:c14n275 , _:c14n279 , _:c14n282 , _:c14n283 , _:c14n288 , _:c14n289 , _:c14n29 , _:c14n298 , _:c14n302 , _:c14n303 , _:c14n309 , _:c14n311 , _:c14n319 , _:c14n323 , _:c14n325 , _:c14n328 , _:c14n333 , _:c14n336 , _:c14n339 , _:c14n353 , _:c14n357 , _:c14n358 , _:c14n359 , _:c14n36 , _:c14n361 , _:c14n369 , _:c14n371 , _:c14n373 , _:c14n378 , _:c14n379 , _:c14n382 , _:c14n392 , _:c14n394 , _:c14n397 , _:c14n4 , _:c14n406 , _:c14n408 , _:c14n414 , _:c14n416 , _:c14n422 , _:c14n423 , _:c14n43 , _:c14n439 , _:c14n440 , _:c14n444 , _:c14n446 , _:c14n455 , _:c14n481 , _:c14n482 , _:c14n486 , _:c14n5 , _:c14n50 , _:c14n503 , _:c14n505 , _:c14n518 , _:c14n52 , _:c14n520 , _:c14n523 , _:c14n538 , _:c14n541 , _:c14n547 , _:c14n552 , _:c14n554 , _:c14n555 , _:c14n556 , _:c14n57 , _:c14n573 , _:c14n576 , _:c14n577 , _:c14n58 , _:c14n581 , _:c14n583 , _:c14n590 , _:c14n591 , _:c14n594 , _:c14n597 , _:c14n598 , _:c14n60 , _:c14n614 , _:c14n618 , _:c14n624 , _:c14n635 , _:c14n636 , _:c14n638 , _:c14n643 , _:c14n655 , _:c14n660 , _:c14n663 , _:c14n67 , _:c14n674 , _:c14n68 , _:c14n681 , _:c14n687 , _:c14n701 , _:c14n706 , _:c14n707 , _:c14n709 , _:c14n714 , _:c14n715 , _:c14n719 , _:c14n720 , _:c14n724 , _:c14n729 , _:c14n730 , _:c14n731 , _:c14n732 , _:c14n740 , _:c14n743 , _:c14n744 , _:c14n757 , _:c14n758 , _:c14n767 , _:c14n775 , _:c14n777 , _:c14n779 , _:c14n780 , _:c14n785 , _:c14n786 , _:c14n791 , _:c14n792 , _:c14n801 , _:c14n807 , _:c14n810 , _:c14n819 , _:c14n824 , _:c14n828 , _:c14n83 , _:c14n84 , _:c14n840 , _:c14n846 , _:c14n852 , _:c14n855 , _:c14n857 , _:c14n858 , _:c14n859 , _:c14n860 , _:c14n861 , _:c14n865 , _:c14n866 , _:c14n877 , _:c14n878 , _:c14n88 , _:c14n881 , _:c14n884 , _:c14n89 , _:c14n897 , _:c14n900 , _:c14n93 , _:c14n97 ;
+	rdfs:subClassOf _:c14n108 , _:c14n11 , _:c14n110 , _:c14n111 , _:c14n112 , _:c14n116 , _:c14n123 , _:c14n124 , _:c14n125 , _:c14n138 , _:c14n139 , _:c14n143 , _:c14n145 , _:c14n148 , _:c14n149 , _:c14n150 , _:c14n151 , _:c14n154 , _:c14n155 , _:c14n157 , _:c14n161 , _:c14n166 , _:c14n167 , _:c14n169 , _:c14n175 , _:c14n199 , _:c14n210 , _:c14n212 , _:c14n22 , _:c14n233 , _:c14n242 , _:c14n245 , _:c14n249 , _:c14n250 , _:c14n256 , _:c14n257 , _:c14n26 , _:c14n266 , _:c14n269 , _:c14n272 , _:c14n276 , _:c14n280 , _:c14n283 , _:c14n284 , _:c14n289 , _:c14n29 , _:c14n290 , _:c14n299 , _:c14n303 , _:c14n304 , _:c14n310 , _:c14n312 , _:c14n320 , _:c14n324 , _:c14n326 , _:c14n329 , _:c14n334 , _:c14n337 , _:c14n340 , _:c14n354 , _:c14n358 , _:c14n359 , _:c14n36 , _:c14n360 , _:c14n362 , _:c14n370 , _:c14n372 , _:c14n374 , _:c14n379 , _:c14n380 , _:c14n383 , _:c14n393 , _:c14n395 , _:c14n398 , _:c14n4 , _:c14n407 , _:c14n409 , _:c14n415 , _:c14n417 , _:c14n423 , _:c14n424 , _:c14n43 , _:c14n440 , _:c14n441 , _:c14n445 , _:c14n447 , _:c14n457 , _:c14n483 , _:c14n484 , _:c14n488 , _:c14n5 , _:c14n50 , _:c14n505 , _:c14n507 , _:c14n52 , _:c14n520 , _:c14n522 , _:c14n525 , _:c14n540 , _:c14n543 , _:c14n549 , _:c14n554 , _:c14n556 , _:c14n557 , _:c14n558 , _:c14n57 , _:c14n575 , _:c14n578 , _:c14n579 , _:c14n58 , _:c14n583 , _:c14n585 , _:c14n592 , _:c14n593 , _:c14n596 , _:c14n599 , _:c14n60 , _:c14n600 , _:c14n616 , _:c14n620 , _:c14n626 , _:c14n637 , _:c14n638 , _:c14n640 , _:c14n645 , _:c14n657 , _:c14n662 , _:c14n665 , _:c14n67 , _:c14n676 , _:c14n68 , _:c14n683 , _:c14n689 , _:c14n703 , _:c14n708 , _:c14n709 , _:c14n711 , _:c14n716 , _:c14n717 , _:c14n721 , _:c14n722 , _:c14n726 , _:c14n731 , _:c14n732 , _:c14n733 , _:c14n734 , _:c14n742 , _:c14n745 , _:c14n746 , _:c14n759 , _:c14n760 , _:c14n769 , _:c14n777 , _:c14n779 , _:c14n781 , _:c14n782 , _:c14n787 , _:c14n788 , _:c14n793 , _:c14n794 , _:c14n803 , _:c14n809 , _:c14n812 , _:c14n821 , _:c14n826 , _:c14n83 , _:c14n830 , _:c14n84 , _:c14n843 , _:c14n849 , _:c14n855 , _:c14n858 , _:c14n860 , _:c14n861 , _:c14n862 , _:c14n863 , _:c14n864 , _:c14n868 , _:c14n869 , _:c14n88 , _:c14n880 , _:c14n881 , _:c14n884 , _:c14n887 , _:c14n89 , _:c14n900 , _:c14n903 , _:c14n93 , _:c14n97 ;
 	skos:definition "Operational Design Domain tag." , "Operational Design Domain. Refer to BSI PAS-1883 Section 5." ;
 	skos:exactMatch openlabel_v2:Odd ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
 openlabel_v2:OddDynamicElements a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "OddDynamicElements" ;
-	rdfs:subClassOf openlabel_v2:Odd , _:c14n100 , _:c14n103 , _:c14n105 , _:c14n113 , _:c14n130 , _:c14n131 , _:c14n136 , _:c14n137 , _:c14n14 , _:c14n140 , _:c14n147 , _:c14n153 , _:c14n156 , _:c14n159 , _:c14n160 , _:c14n17 , _:c14n174 , _:c14n179 , _:c14n18 , _:c14n180 , _:c14n186 , _:c14n197 , _:c14n198 , _:c14n200 , _:c14n204 , _:c14n215 , _:c14n220 , _:c14n222 , _:c14n225 , _:c14n228 , _:c14n242 , _:c14n245 , _:c14n25 , _:c14n253 , _:c14n263 , _:c14n273 , _:c14n277 , _:c14n280 , _:c14n281 , _:c14n296 , _:c14n3 , _:c14n316 , _:c14n320 , _:c14n335 , _:c14n338 , _:c14n341 , _:c14n346 , _:c14n351 , _:c14n360 , _:c14n364 , _:c14n367 , _:c14n37 , _:c14n374 , _:c14n375 , _:c14n383 , _:c14n389 , _:c14n390 , _:c14n399 , _:c14n405 , _:c14n409 , _:c14n41 , _:c14n411 , _:c14n421 , _:c14n429 , _:c14n432 , _:c14n437 , _:c14n44 , _:c14n450 , _:c14n461 , _:c14n464 , _:c14n467 , _:c14n475 , _:c14n49 , _:c14n491 , _:c14n508 , _:c14n51 , _:c14n511 , _:c14n515 , _:c14n524 , _:c14n532 , _:c14n537 , _:c14n54 , _:c14n550 , _:c14n560 , _:c14n561 , _:c14n562 , _:c14n566 , _:c14n567 , _:c14n569 , _:c14n570 , _:c14n574 , _:c14n587 , _:c14n600 , _:c14n602 , _:c14n604 , _:c14n605 , _:c14n608 , _:c14n609 , _:c14n61 , _:c14n610 , _:c14n612 , _:c14n619 , _:c14n622 , _:c14n628 , _:c14n631 , _:c14n637 , _:c14n641 , _:c14n65 , _:c14n654 , _:c14n683 , _:c14n689 , _:c14n697 , _:c14n70 , _:c14n702 , _:c14n703 , _:c14n708 , _:c14n716 , _:c14n72 , _:c14n747 , _:c14n748 , _:c14n75 , _:c14n752 , _:c14n755 , _:c14n762 , _:c14n764 , _:c14n765 , _:c14n766 , _:c14n770 , _:c14n773 , _:c14n78 , _:c14n782 , _:c14n783 , _:c14n784 , _:c14n788 , _:c14n797 , _:c14n815 , _:c14n818 , _:c14n821 , _:c14n823 , _:c14n826 , _:c14n833 , _:c14n837 , _:c14n838 , _:c14n843 , _:c14n844 , _:c14n849 , _:c14n86 , _:c14n868 , _:c14n869 , _:c14n872 , _:c14n874 , _:c14n876 , _:c14n880 , _:c14n888 , _:c14n889 , _:c14n898 , _:c14n902 , _:c14n903 , _:c14n909 ;
+	rdfs:subClassOf openlabel_v2:Odd , _:c14n100 , _:c14n103 , _:c14n105 , _:c14n113 , _:c14n130 , _:c14n131 , _:c14n136 , _:c14n137 , _:c14n14 , _:c14n140 , _:c14n147 , _:c14n153 , _:c14n156 , _:c14n159 , _:c14n160 , _:c14n17 , _:c14n174 , _:c14n179 , _:c14n18 , _:c14n180 , _:c14n186 , _:c14n197 , _:c14n198 , _:c14n200 , _:c14n204 , _:c14n215 , _:c14n220 , _:c14n222 , _:c14n226 , _:c14n229 , _:c14n243 , _:c14n246 , _:c14n25 , _:c14n254 , _:c14n264 , _:c14n274 , _:c14n278 , _:c14n281 , _:c14n282 , _:c14n297 , _:c14n3 , _:c14n317 , _:c14n321 , _:c14n336 , _:c14n339 , _:c14n342 , _:c14n347 , _:c14n352 , _:c14n361 , _:c14n365 , _:c14n368 , _:c14n37 , _:c14n375 , _:c14n376 , _:c14n384 , _:c14n390 , _:c14n391 , _:c14n400 , _:c14n406 , _:c14n41 , _:c14n410 , _:c14n412 , _:c14n422 , _:c14n430 , _:c14n433 , _:c14n438 , _:c14n44 , _:c14n451 , _:c14n463 , _:c14n466 , _:c14n469 , _:c14n477 , _:c14n49 , _:c14n493 , _:c14n51 , _:c14n510 , _:c14n513 , _:c14n517 , _:c14n526 , _:c14n534 , _:c14n539 , _:c14n54 , _:c14n552 , _:c14n562 , _:c14n563 , _:c14n564 , _:c14n568 , _:c14n569 , _:c14n571 , _:c14n572 , _:c14n576 , _:c14n589 , _:c14n602 , _:c14n604 , _:c14n606 , _:c14n607 , _:c14n61 , _:c14n610 , _:c14n611 , _:c14n612 , _:c14n614 , _:c14n621 , _:c14n624 , _:c14n630 , _:c14n633 , _:c14n639 , _:c14n643 , _:c14n65 , _:c14n656 , _:c14n685 , _:c14n691 , _:c14n699 , _:c14n70 , _:c14n704 , _:c14n705 , _:c14n710 , _:c14n718 , _:c14n72 , _:c14n749 , _:c14n75 , _:c14n750 , _:c14n754 , _:c14n757 , _:c14n764 , _:c14n766 , _:c14n767 , _:c14n768 , _:c14n772 , _:c14n775 , _:c14n78 , _:c14n784 , _:c14n785 , _:c14n786 , _:c14n790 , _:c14n799 , _:c14n817 , _:c14n820 , _:c14n823 , _:c14n825 , _:c14n828 , _:c14n836 , _:c14n840 , _:c14n841 , _:c14n846 , _:c14n847 , _:c14n852 , _:c14n86 , _:c14n871 , _:c14n872 , _:c14n875 , _:c14n877 , _:c14n879 , _:c14n883 , _:c14n891 , _:c14n892 , _:c14n901 , _:c14n905 , _:c14n906 , _:c14n912 ;
 	skos:definition "Dynamic elements subset of the Operational Design Domain. Covers traffic agents, flow rates, volume, and subject vehicle speed. Refer to BSI PAS-1883 Section 5.4." ;
 	skos:exactMatch openlabel_v2:OddDynamicElements ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
 openlabel_v2:OddEnvironment a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "OddEnvironment" ;
-	rdfs:subClassOf openlabel_v2:Odd , _:c14n1 , _:c14n121 , _:c14n127 , _:c14n13 , _:c14n163 , _:c14n164 , _:c14n177 , _:c14n181 , _:c14n188 , _:c14n19 , _:c14n193 , _:c14n207 , _:c14n208 , _:c14n21 , _:c14n217 , _:c14n223 , _:c14n23 , _:c14n237 , _:c14n246 , _:c14n254 , _:c14n258 , _:c14n262 , _:c14n269 , _:c14n274 , _:c14n293 , _:c14n295 , _:c14n30 , _:c14n300 , _:c14n304 , _:c14n306 , _:c14n307 , _:c14n314 , _:c14n321 , _:c14n322 , _:c14n330 , _:c14n340 , _:c14n352 , _:c14n354 , _:c14n372 , _:c14n38 , _:c14n380 , _:c14n385 , _:c14n391 , _:c14n398 , _:c14n40 , _:c14n400 , _:c14n415 , _:c14n424 , _:c14n427 , _:c14n431 , _:c14n451 , _:c14n456 , _:c14n458 , _:c14n47 , _:c14n471 , _:c14n479 , _:c14n494 , _:c14n495 , _:c14n504 , _:c14n506 , _:c14n509 , _:c14n510 , _:c14n517 , _:c14n527 , _:c14n528 , _:c14n533 , _:c14n535 , _:c14n536 , _:c14n542 , _:c14n545 , _:c14n553 , _:c14n568 , _:c14n578 , _:c14n585 , _:c14n586 , _:c14n59 , _:c14n607 , _:c14n613 , _:c14n616 , _:c14n633 , _:c14n634 , _:c14n639 , _:c14n644 , _:c14n648 , _:c14n658 , _:c14n661 , _:c14n669 , _:c14n677 , _:c14n678 , _:c14n680 , _:c14n692 , _:c14n698 , _:c14n704 , _:c14n705 , _:c14n71 , _:c14n710 , _:c14n727 , _:c14n737 , _:c14n742 , _:c14n746 , _:c14n749 , _:c14n753 , _:c14n76 , _:c14n761 , _:c14n768 , _:c14n772 , _:c14n774 , _:c14n776 , _:c14n79 , _:c14n790 , _:c14n793 , _:c14n816 , _:c14n839 , _:c14n85 , _:c14n875 , _:c14n882 , _:c14n896 , _:c14n899 , _:c14n90 , _:c14n908 , _:c14n92 , _:c14n94 , _:c14n99 ;
+	rdfs:subClassOf openlabel_v2:Odd , _:c14n1 , _:c14n121 , _:c14n127 , _:c14n13 , _:c14n163 , _:c14n164 , _:c14n177 , _:c14n181 , _:c14n188 , _:c14n19 , _:c14n193 , _:c14n207 , _:c14n208 , _:c14n21 , _:c14n217 , _:c14n223 , _:c14n23 , _:c14n238 , _:c14n247 , _:c14n255 , _:c14n259 , _:c14n263 , _:c14n270 , _:c14n275 , _:c14n294 , _:c14n296 , _:c14n30 , _:c14n301 , _:c14n305 , _:c14n307 , _:c14n308 , _:c14n315 , _:c14n322 , _:c14n323 , _:c14n331 , _:c14n341 , _:c14n353 , _:c14n355 , _:c14n373 , _:c14n38 , _:c14n381 , _:c14n386 , _:c14n392 , _:c14n399 , _:c14n40 , _:c14n401 , _:c14n416 , _:c14n425 , _:c14n428 , _:c14n432 , _:c14n453 , _:c14n458 , _:c14n460 , _:c14n47 , _:c14n473 , _:c14n481 , _:c14n496 , _:c14n497 , _:c14n506 , _:c14n508 , _:c14n511 , _:c14n512 , _:c14n519 , _:c14n529 , _:c14n530 , _:c14n535 , _:c14n537 , _:c14n538 , _:c14n544 , _:c14n547 , _:c14n555 , _:c14n570 , _:c14n580 , _:c14n587 , _:c14n588 , _:c14n59 , _:c14n609 , _:c14n615 , _:c14n618 , _:c14n635 , _:c14n636 , _:c14n641 , _:c14n646 , _:c14n650 , _:c14n660 , _:c14n663 , _:c14n671 , _:c14n679 , _:c14n680 , _:c14n682 , _:c14n694 , _:c14n700 , _:c14n706 , _:c14n707 , _:c14n71 , _:c14n712 , _:c14n729 , _:c14n739 , _:c14n744 , _:c14n748 , _:c14n751 , _:c14n755 , _:c14n76 , _:c14n763 , _:c14n770 , _:c14n774 , _:c14n776 , _:c14n778 , _:c14n79 , _:c14n792 , _:c14n795 , _:c14n818 , _:c14n842 , _:c14n85 , _:c14n878 , _:c14n885 , _:c14n899 , _:c14n90 , _:c14n902 , _:c14n911 , _:c14n92 , _:c14n94 , _:c14n99 ;
 	skos:definition "Environment-related subset of the Operational Design Domain. Covers weather, illumination, connectivity, and particulates. Refer to BSI PAS-1883 Section 5.3." ;
 	skos:exactMatch openlabel_v2:OddEnvironment ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
 openlabel_v2:OddScenery a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "OddScenery" ;
-	rdfs:subClassOf openlabel_v2:Odd , _:c14n0 , _:c14n104 , _:c14n114 , _:c14n119 , _:c14n120 , _:c14n135 , _:c14n144 , _:c14n16 , _:c14n165 , _:c14n178 , _:c14n194 , _:c14n2 , _:c14n203 , _:c14n205 , _:c14n206 , _:c14n229 , _:c14n236 , _:c14n238 , _:c14n24 , _:c14n240 , _:c14n250 , _:c14n266 , _:c14n278 , _:c14n284 , _:c14n285 , _:c14n287 , _:c14n297 , _:c14n299 , _:c14n312 , _:c14n324 , _:c14n327 , _:c14n342 , _:c14n343 , _:c14n35 , _:c14n350 , _:c14n356 , _:c14n362 , _:c14n386 , _:c14n401 , _:c14n404 , _:c14n413 , _:c14n419 , _:c14n428 , _:c14n430 , _:c14n433 , _:c14n436 , _:c14n46 , _:c14n462 , _:c14n466 , _:c14n469 , _:c14n470 , _:c14n48 , _:c14n485 , _:c14n489 , _:c14n492 , _:c14n493 , _:c14n498 , _:c14n499 , _:c14n500 , _:c14n501 , _:c14n512 , _:c14n513 , _:c14n519 , _:c14n529 , _:c14n543 , _:c14n557 , _:c14n56 , _:c14n563 , _:c14n572 , _:c14n595 , _:c14n606 , _:c14n623 , _:c14n630 , _:c14n632 , _:c14n653 , _:c14n656 , _:c14n66 , _:c14n664 , _:c14n666 , _:c14n676 , _:c14n688 , _:c14n69 , _:c14n694 , _:c14n700 , _:c14n718 , _:c14n739 , _:c14n74 , _:c14n751 , _:c14n787 , _:c14n798 , _:c14n799 , _:c14n804 , _:c14n808 , _:c14n811 , _:c14n814 , _:c14n825 , _:c14n836 , _:c14n848 , _:c14n854 , _:c14n879 , _:c14n885 , _:c14n901 ;
+	rdfs:subClassOf openlabel_v2:Odd , _:c14n0 , _:c14n104 , _:c14n114 , _:c14n119 , _:c14n120 , _:c14n135 , _:c14n144 , _:c14n16 , _:c14n165 , _:c14n178 , _:c14n194 , _:c14n2 , _:c14n203 , _:c14n205 , _:c14n206 , _:c14n230 , _:c14n237 , _:c14n239 , _:c14n24 , _:c14n241 , _:c14n251 , _:c14n267 , _:c14n279 , _:c14n285 , _:c14n286 , _:c14n288 , _:c14n298 , _:c14n300 , _:c14n313 , _:c14n325 , _:c14n328 , _:c14n343 , _:c14n344 , _:c14n35 , _:c14n351 , _:c14n357 , _:c14n363 , _:c14n387 , _:c14n402 , _:c14n405 , _:c14n414 , _:c14n420 , _:c14n429 , _:c14n431 , _:c14n434 , _:c14n437 , _:c14n46 , _:c14n464 , _:c14n468 , _:c14n471 , _:c14n472 , _:c14n48 , _:c14n487 , _:c14n491 , _:c14n494 , _:c14n495 , _:c14n500 , _:c14n501 , _:c14n502 , _:c14n503 , _:c14n514 , _:c14n515 , _:c14n521 , _:c14n531 , _:c14n545 , _:c14n559 , _:c14n56 , _:c14n565 , _:c14n574 , _:c14n597 , _:c14n608 , _:c14n625 , _:c14n632 , _:c14n634 , _:c14n655 , _:c14n658 , _:c14n66 , _:c14n666 , _:c14n668 , _:c14n678 , _:c14n69 , _:c14n690 , _:c14n696 , _:c14n702 , _:c14n720 , _:c14n74 , _:c14n741 , _:c14n753 , _:c14n789 , _:c14n800 , _:c14n801 , _:c14n806 , _:c14n810 , _:c14n813 , _:c14n816 , _:c14n827 , _:c14n839 , _:c14n851 , _:c14n857 , _:c14n882 , _:c14n888 , _:c14n904 ;
 	skos:definition "Scenery-related subset of the Operational Design Domain. Covers drivable area, geometry, lane specifications, junctions, signs, and structures. Refer to BSI PAS-1883 Section 5.2." ;
 	skos:exactMatch openlabel_v2:OddScenery ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
@@ -609,7 +609,7 @@ openlabel_v2:PositioningGps a owl:Class , openlabel_v2:ConnectivityPositioning ;
 	skos:definition "Global Positioning System (GPS)." .
 openlabel_v2:QuantitativeValue a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "QuantitativeValue" ;
-	rdfs:subClassOf _:c14n122 , _:c14n219 , _:c14n291 , _:c14n384 , _:c14n457 , _:c14n530 , _:c14n794 , _:c14n803 , _:c14n831 , _:c14n864 , _:c14n891 , _:c14n895 ;
+	rdfs:subClassOf _:c14n122 , _:c14n219 , _:c14n292 , _:c14n385 , _:c14n459 , _:c14n532 , _:c14n796 , _:c14n805 , _:c14n833 , _:c14n867 , _:c14n894 , _:c14n898 ;
 	skos:definition "A point value or interval for quantitative measurements. Requires minValue and maxValue." ;
 	skos:exactMatch sdo:QuantitativeValue ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
@@ -681,7 +681,7 @@ openlabel_v2:RoadUser a owl:Class , owl:ObjectProperty , linkml:ClassDefinition 
 	rdfs:label "RoadUser" ;
 	rdfs:range openlabel_v2:RoadUser ;
 	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-	rdfs:subClassOf _:c14n128 , _:c14n184 , _:c14n190 , _:c14n345 , _:c14n377 , _:c14n549 , _:c14n667 , _:c14n682 , _:c14n827 , _:c14n870 , _:c14n883 , _:c14n894 ;
+	rdfs:subClassOf _:c14n128 , _:c14n184 , _:c14n190 , _:c14n346 , _:c14n378 , _:c14n551 , _:c14n669 , _:c14n684 , _:c14n829 , _:c14n873 , _:c14n886 , _:c14n897 ;
 	skos:definition "Road user tag." , "Something which uses a road to travel." ;
 	skos:exactMatch openlabel_v2:RoadUser ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
@@ -693,14 +693,14 @@ openlabel_v2:RoadUserAnimal a owl:ObjectProperty , linkml:SlotDefinition ;
 openlabel_v2:RoadUserHuman a owl:Class , owl:ObjectProperty , linkml:EnumDefinition , linkml:SlotDefinition ;
 	rdfs:label "RoadUserHuman" , "RoadUserHumanEnum" ;
 	rdfs:range openlabel_v2:RoadUserHuman ;
-	owl:unionOf _:c14n231 ;
+	owl:unionOf _:c14n232 ;
 	skos:definition "Human road user type." , "Types of human road users." ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
 	linkml:permissible_values openlabel_v2:HumanAnimalRider , openlabel_v2:HumanCyclist , openlabel_v2:HumanDriver , openlabel_v2:HumanMotorcyclist , openlabel_v2:HumanPassenger , openlabel_v2:HumanPedestrian , openlabel_v2:HumanWheelchairUser .
 openlabel_v2:RoadUserVehicle a owl:Class , owl:ObjectProperty , linkml:EnumDefinition , linkml:SlotDefinition ;
 	rdfs:label "RoadUserVehicle" , "RoadUserVehicleEnum" ;
 	rdfs:range openlabel_v2:RoadUserVehicle ;
-	owl:unionOf _:c14n460 ;
+	owl:unionOf _:c14n462 ;
 	skos:definition "Types of vehicles." , "Vehicle type." ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
 	linkml:permissible_values openlabel_v2:VehicleAgricultural , openlabel_v2:VehicleBus , openlabel_v2:VehicleCar , openlabel_v2:VehicleConstruction , openlabel_v2:VehicleCycle , openlabel_v2:VehicleEmergency , openlabel_v2:VehicleMotorcycle , openlabel_v2:VehicleTrailer , openlabel_v2:VehicleTruck , openlabel_v2:VehicleVan , openlabel_v2:VehicleWheelchair .
@@ -746,7 +746,7 @@ openlabel_v2:RoundaboutNormalSignal a owl:Class , openlabel_v2:JunctionRoundabou
 	skos:definition "Normal signalised." .
 openlabel_v2:Scenario a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "Scenario" ;
-	rdfs:subClassOf _:c14n227 , _:c14n32 , _:c14n463 ;
+	rdfs:subClassOf _:c14n228 , _:c14n32 , _:c14n465 ;
 	skos:definition "A scenario that can be tagged with OpenLABEL tags." ;
 	skos:exactMatch openlabel_v2:Scenario ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
@@ -786,7 +786,7 @@ openlabel_v2:SignsInformation a owl:Class , owl:ObjectProperty , linkml:EnumDefi
 	rdfs:label "SignsInformation" , "SignsInformationEnum" ;
 	rdfs:range openlabel_v2:SignsInformation ;
 	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-	owl:unionOf _:c14n642 ;
+	owl:unionOf _:c14n644 ;
 	skos:definition "Information sign type. Refer to BSI PAS-1883 Section 5.2.3.5.a." , "Types of information signs. Refer to BSI PAS-1883 Section 5.2.3.5.a." ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
 	linkml:permissible_values openlabel_v2:InformationSignsUniformFullTime , openlabel_v2:InformationSignsUniformTemporary , openlabel_v2:InformationSignsVariableFullTime , openlabel_v2:InformationSignsVariableTemporary .
@@ -794,7 +794,7 @@ openlabel_v2:SignsRegulatory a owl:Class , owl:ObjectProperty , linkml:EnumDefin
 	rdfs:label "SignsRegulatory" , "SignsRegulatoryEnum" ;
 	rdfs:range openlabel_v2:SignsRegulatory ;
 	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-	owl:unionOf _:c14n657 ;
+	owl:unionOf _:c14n659 ;
 	skos:definition "Regulatory sign type. Refer to BSI PAS-1883 Section 5.2.3.5.b." , "Types of regulatory signs. Refer to BSI PAS-1883 Section 5.2.3.5.b." ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
 	linkml:permissible_values openlabel_v2:RegulatorySignsUniformFullTime , openlabel_v2:RegulatorySignsUniformTemporary , openlabel_v2:RegulatorySignsVariableFullTime , openlabel_v2:RegulatorySignsVariableTemporary .
@@ -802,7 +802,7 @@ openlabel_v2:SignsWarning a owl:Class , owl:ObjectProperty , linkml:EnumDefiniti
 	rdfs:label "SignsWarning" , "SignsWarningEnum" ;
 	rdfs:range openlabel_v2:SignsWarning ;
 	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-	owl:unionOf _:c14n584 ;
+	owl:unionOf _:c14n586 ;
 	skos:definition "Types of warning signs. Refer to BSI PAS-1883 Section 5.2.3.5.c." , "Warning sign type. Refer to BSI PAS-1883 Section 5.2.3.5.c." ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
 	linkml:permissible_values openlabel_v2:WarningSignsUniform , openlabel_v2:WarningSignsUniformFullTime , openlabel_v2:WarningSignsUniformTemporary , openlabel_v2:WarningSignsVariableFullTime , openlabel_v2:WarningSignsVariableTemporary .
@@ -910,7 +910,7 @@ openlabel_v2:SurfaceTypeUniform a owl:Class , openlabel_v2:DrivableAreaSurfaceTy
 	skos:definition "Uniform (e.g. asphalt)." .
 openlabel_v2:Tag a owl:Class , linkml:ClassDefinition ;
 	rdfs:label "Tag" ;
-	rdfs:subClassOf _:c14n117 , _:c14n132 , _:c14n187 , _:c14n318 , _:c14n388 , _:c14n42 , _:c14n448 , _:c14n487 , _:c14n579 , _:c14n690 , _:c14n906 , _:c14n911 ;
+	rdfs:subClassOf _:c14n117 , _:c14n132 , _:c14n187 , _:c14n319 , _:c14n389 , _:c14n42 , _:c14n449 , _:c14n489 , _:c14n581 , _:c14n692 , _:c14n909 , _:c14n914 ;
 	skos:definition "The base tag." ;
 	skos:exactMatch openlabel_v2:Tag ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
@@ -1155,7 +1155,7 @@ openlabel_v2:laneSpecificationDimensionsValue a owl:ObjectProperty , linkml:Slot
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
 openlabel_v2:laneSpecificationLaneCountValue a owl:ObjectProperty , linkml:SlotDefinition ;
 	rdfs:label "laneSpecificationLaneCountValue" ;
-	rdfs:range _:c14n629 ;
+	rdfs:range _:c14n631 ;
 	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
 	skos:definition "Number of lanes (unit). Refer to BSI PAS-1883 Section 5.2.3.4.d." ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
@@ -1193,12 +1193,12 @@ openlabel_v2:motionAccelerateValue a owl:ObjectProperty , linkml:SlotDefinition 
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
 openlabel_v2:motionDecelerateValue a owl:ObjectProperty , linkml:SlotDefinition ;
 	rdfs:label "motionDecelerateValue" ;
-	rdfs:range _:c14n756 ;
+	rdfs:range _:c14n758 ;
 	skos:definition "Rate of deceleration (ms-2)." ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
 openlabel_v2:motionDriveValue a owl:ObjectProperty , linkml:SlotDefinition ;
 	rdfs:label "motionDriveValue" ;
-	rdfs:range _:c14n483 ;
+	rdfs:range _:c14n485 ;
 	skos:definition "Speed (km/h)." ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
 openlabel_v2:ownerEmail a owl:ObjectProperty , linkml:SlotDefinition ;
@@ -1221,6 +1221,11 @@ openlabel_v2:particulatesWaterValue a owl:ObjectProperty , linkml:SlotDefinition
 	rdfs:range linkml:Decimal ;
 	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
 	skos:definition "Meteorological Optical Range (MOR) (m). Refer to BSI PAS-1883 Section 5.3.2.b." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:scenarioComment a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "scenarioComment" ;
+	rdfs:range linkml:String ;
+	skos:definition "An optional free-text comment for the scenario." ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
 openlabel_v2:scenarioCreatedDate a owl:ObjectProperty , linkml:SlotDefinition ;
 	rdfs:label "scenarioCreatedDate" ;
@@ -1269,25 +1274,25 @@ openlabel_v2:scenarioVisualisationURL a owl:ObjectProperty , linkml:SlotDefiniti
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
 openlabel_v2:subjectVehicleSpeedValue a owl:ObjectProperty , linkml:SlotDefinition ;
 	rdfs:label "subjectVehicleSpeedValue" ;
-	rdfs:range _:c14n334 ;
+	rdfs:range _:c14n335 ;
 	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
 	skos:definition "Speed (km/h). Refer to BSI PAS-1883 Section 5.4.b." ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
 openlabel_v2:trafficAgentDensityValue a owl:ObjectProperty , linkml:SlotDefinition ;
 	rdfs:label "trafficAgentDensityValue" ;
-	rdfs:range _:c14n679 ;
+	rdfs:range _:c14n681 ;
 	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
 	skos:definition "Density (vehicles/km). Refer to BSI PAS-1883 Section 5.4.a.1." ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
 openlabel_v2:trafficAgentTypeValue a owl:ObjectProperty , linkml:SlotDefinition ;
 	rdfs:label "trafficAgentTypeValue" ;
-	rdfs:range _:c14n308 ;
+	rdfs:range _:c14n309 ;
 	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
 	skos:definition "Agent type. Refer to BSI PAS-1883 Section 5.4.a.4." ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
 openlabel_v2:trafficFlowRateValue a owl:ObjectProperty , linkml:SlotDefinition ;
 	rdfs:label "trafficFlowRateValue" ;
-	rdfs:range _:c14n665 ;
+	rdfs:range _:c14n667 ;
 	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
 	skos:definition "Rate (vehicles/h). Refer to BSI PAS-1883 Section 5.4.a.3." ;
 	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
@@ -1333,157 +1338,157 @@ _:c14n10 a owl:Restriction ;
 _:c14n100 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:horizontalCurvesValue .
-_:c14n1000 rdf:first openlabel_v2:QuantitativeValue ;
+_:c14n1000 rdf:first linkml:Decimal ;
+	rdf:rest _:c14n999 .
+_:c14n1001 rdf:first openlabel_v2:QuantitativeValue ;
 	rdf:rest rdf:nil .
-_:c14n1001 rdf:first linkml:Decimal ;
-	rdf:rest _:c14n1000 .
-_:c14n1002 rdf:first openlabel_v2:QuantitativeValue ;
+_:c14n1002 rdf:first _:c14n1003 ;
+	rdf:rest _:c14n1001 .
+_:c14n1003 a rdfs:Datatype ;
+	owl:intersectionOf _:c14n1004 .
+_:c14n1004 rdf:first linkml:Integer ;
+	rdf:rest _:c14n1005 .
+_:c14n1005 rdf:first _:c14n1006 ;
 	rdf:rest rdf:nil .
-_:c14n1003 rdf:first _:c14n1004 ;
-	rdf:rest _:c14n1002 .
-_:c14n1004 a rdfs:Datatype ;
-	owl:intersectionOf _:c14n1005 .
-_:c14n1005 rdf:first linkml:Integer ;
-	rdf:rest _:c14n1006 .
-_:c14n1006 rdf:first _:c14n1007 ;
-	rdf:rest rdf:nil .
-_:c14n1007 a rdfs:Datatype ;
+_:c14n1006 a rdfs:Datatype ;
 	owl:onDatatype xsd:integer ;
-	owl:withRestrictions _:c14n1008 .
-_:c14n1008 rdf:first _:c14n1009 ;
+	owl:withRestrictions _:c14n1007 .
+_:c14n1007 rdf:first _:c14n1008 ;
 	rdf:rest rdf:nil .
-_:c14n1009 xsd:minInclusive 0 .
+_:c14n1008 xsd:minInclusive 0 .
+_:c14n1009 rdf:first openlabel_v2:QuantitativeValue ;
+	rdf:rest rdf:nil .
 _:c14n101 rdf:first openlabel_v2:SurfaceFeaturePothole ;
-	rdf:rest _:c14n672 .
-_:c14n1010 rdf:first openlabel_v2:QuantitativeValue ;
+	rdf:rest _:c14n674 .
+_:c14n1010 rdf:first _:c14n1011 ;
+	rdf:rest _:c14n1009 .
+_:c14n1011 a rdfs:Datatype ;
+	owl:intersectionOf _:c14n1012 .
+_:c14n1012 rdf:first linkml:Integer ;
+	rdf:rest _:c14n1013 .
+_:c14n1013 rdf:first _:c14n1014 ;
 	rdf:rest rdf:nil .
-_:c14n1011 rdf:first _:c14n1012 ;
-	rdf:rest _:c14n1010 .
-_:c14n1012 a rdfs:Datatype ;
-	owl:intersectionOf _:c14n1013 .
-_:c14n1013 rdf:first linkml:Integer ;
-	rdf:rest _:c14n1014 .
-_:c14n1014 rdf:first _:c14n1015 ;
-	rdf:rest rdf:nil .
-_:c14n1015 a rdfs:Datatype ;
+_:c14n1014 a rdfs:Datatype ;
 	owl:onDatatype xsd:integer ;
-	owl:withRestrictions _:c14n1016 .
-_:c14n1016 rdf:first _:c14n1017 ;
+	owl:withRestrictions _:c14n1015 .
+_:c14n1015 rdf:first _:c14n1016 ;
 	rdf:rest rdf:nil .
-_:c14n1017 xsd:minInclusive 1 .
-_:c14n1018 rdf:first openlabel_v2:QuantitativeValue ;
+_:c14n1016 xsd:minInclusive 1 .
+_:c14n1017 rdf:first openlabel_v2:QuantitativeValue ;
 	rdf:rest rdf:nil .
-_:c14n1019 rdf:first linkml:Decimal ;
-	rdf:rest _:c14n1018 .
+_:c14n1018 rdf:first linkml:Decimal ;
+	rdf:rest _:c14n1017 .
+_:c14n1019 rdf:first openlabel_v2:QuantitativeValue ;
+	rdf:rest rdf:nil .
 _:c14n102 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:ownerURL .
-_:c14n1020 a rdfs:Datatype ;
-	owl:onDatatype xsd:integer ;
-	owl:withRestrictions _:c14n1024 .
-_:c14n1021 rdf:first _:c14n1020 ;
+_:c14n1020 rdf:first linkml:Decimal ;
+	rdf:rest _:c14n1019 .
+_:c14n1021 rdf:first openlabel_v2:QuantitativeValue ;
 	rdf:rest rdf:nil .
-_:c14n1022 rdf:first linkml:Integer ;
+_:c14n1022 rdf:first linkml:Decimal ;
 	rdf:rest _:c14n1021 .
 _:c14n1023 a rdfs:Datatype ;
-	owl:intersectionOf _:c14n1022 .
-_:c14n1024 rdf:first _:c14n1025 ;
-	rdf:rest rdf:nil .
-_:c14n1025 xsd:minInclusive 0 .
-_:c14n1026 a rdfs:Datatype ;
 	owl:onDatatype xsd:integer ;
-	owl:withRestrictions _:c14n1029 .
-_:c14n1027 rdf:first _:c14n1026 ;
+	owl:withRestrictions _:c14n1027 .
+_:c14n1024 rdf:first _:c14n1023 ;
 	rdf:rest rdf:nil .
-_:c14n1028 rdf:first linkml:Integer ;
-	rdf:rest _:c14n1027 .
-_:c14n1029 rdf:first _:c14n1030 ;
+_:c14n1025 rdf:first linkml:Integer ;
+	rdf:rest _:c14n1024 .
+_:c14n1026 a rdfs:Datatype ;
+	owl:intersectionOf _:c14n1025 .
+_:c14n1027 rdf:first _:c14n1028 ;
 	rdf:rest rdf:nil .
+_:c14n1028 xsd:minInclusive 0 .
+_:c14n1029 a rdfs:Datatype ;
+	owl:onDatatype xsd:integer ;
+	owl:withRestrictions _:c14n1032 .
 _:c14n103 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:particulatesWaterValue .
-_:c14n1030 xsd:minInclusive 0 .
-_:c14n1031 a rdfs:Datatype ;
+_:c14n1030 rdf:first _:c14n1029 ;
+	rdf:rest rdf:nil .
+_:c14n1031 rdf:first linkml:Integer ;
+	rdf:rest _:c14n1030 .
+_:c14n1032 rdf:first _:c14n1033 ;
+	rdf:rest rdf:nil .
+_:c14n1033 xsd:minInclusive 0 .
+_:c14n1034 a rdfs:Datatype ;
 	owl:onDatatype xsd:integer ;
-	owl:withRestrictions _:c14n1034 .
-_:c14n1032 rdf:first _:c14n1031 ;
+	owl:withRestrictions _:c14n1037 .
+_:c14n1035 rdf:first _:c14n1034 ;
 	rdf:rest rdf:nil .
-_:c14n1033 rdf:first linkml:Integer ;
-	rdf:rest _:c14n1032 .
-_:c14n1034 rdf:first _:c14n1035 ;
+_:c14n1036 rdf:first linkml:Integer ;
+	rdf:rest _:c14n1035 .
+_:c14n1037 rdf:first _:c14n1038 ;
 	rdf:rest rdf:nil .
-_:c14n1035 xsd:minInclusive 0 .
-_:c14n1036 a rdfs:Datatype ;
-	owl:onDatatype xsd:integer ;
-	owl:withRestrictions _:c14n1040 .
-_:c14n1037 rdf:first _:c14n1036 ;
-	rdf:rest rdf:nil .
-_:c14n1038 rdf:first linkml:Integer ;
-	rdf:rest _:c14n1037 .
+_:c14n1038 xsd:minInclusive 0 .
 _:c14n1039 a rdfs:Datatype ;
-	owl:intersectionOf _:c14n1038 .
+	owl:onDatatype xsd:integer ;
+	owl:withRestrictions _:c14n1042 .
 _:c14n104 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:EnvironmentParticulates .
-_:c14n1040 rdf:first _:c14n1041 ;
+_:c14n1040 rdf:first _:c14n1039 ;
 	rdf:rest rdf:nil .
-_:c14n1041 xsd:minInclusive 0 .
-_:c14n1042 a rdfs:Datatype ;
+_:c14n1041 rdf:first linkml:Integer ;
+	rdf:rest _:c14n1040 .
+_:c14n1042 rdf:first _:c14n1043 ;
+	rdf:rest rdf:nil .
+_:c14n1043 xsd:minInclusive 0 .
+_:c14n1044 a rdfs:Datatype ;
 	owl:onDatatype xsd:integer ;
-	owl:withRestrictions _:c14n1045 .
-_:c14n1043 rdf:first _:c14n1042 ;
+	owl:withRestrictions _:c14n1048 .
+_:c14n1045 rdf:first _:c14n1044 ;
 	rdf:rest rdf:nil .
-_:c14n1044 rdf:first linkml:Integer ;
-	rdf:rest _:c14n1043 .
-_:c14n1045 rdf:first _:c14n1046 ;
-	rdf:rest rdf:nil .
-_:c14n1046 xsd:minInclusive 0 .
+_:c14n1046 rdf:first linkml:Integer ;
+	rdf:rest _:c14n1045 .
 _:c14n1047 a rdfs:Datatype ;
-	owl:onDatatype xsd:integer ;
-	owl:withRestrictions _:c14n1051 .
-_:c14n1048 rdf:first _:c14n1047 ;
+	owl:intersectionOf _:c14n1046 .
+_:c14n1048 rdf:first _:c14n1049 ;
 	rdf:rest rdf:nil .
-_:c14n1049 rdf:first linkml:Integer ;
-	rdf:rest _:c14n1048 .
+_:c14n1049 xsd:minInclusive 0 .
 _:c14n105 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:DrivableAreaEdge .
 _:c14n1050 a rdfs:Datatype ;
-	owl:intersectionOf _:c14n1049 .
-_:c14n1051 rdf:first _:c14n1052 ;
+	owl:onDatatype xsd:integer ;
+	owl:withRestrictions _:c14n1054 .
+_:c14n1051 rdf:first _:c14n1050 ;
 	rdf:rest rdf:nil .
-_:c14n1052 xsd:minInclusive 0 .
-_:c14n1053 rdf:first _:c14n435 ;
-	rdf:rest _:c14n1055 .
-_:c14n1054 rdfs:subClassOf _:c14n851 ;
-	owl:intersectionOf _:c14n1053 .
-_:c14n1055 rdf:first openlabel_v2:Behaviour ;
+_:c14n1052 rdf:first linkml:Integer ;
+	rdf:rest _:c14n1051 .
+_:c14n1053 a rdfs:Datatype ;
+	owl:intersectionOf _:c14n1052 .
+_:c14n1054 rdf:first _:c14n1055 ;
 	rdf:rest rdf:nil .
-_:c14n1056 rdf:first _:c14n580 ;
+_:c14n1055 xsd:minInclusive 0 .
+_:c14n1056 rdf:first _:c14n582 ;
 	rdf:rest _:c14n1058 .
-_:c14n1057 rdfs:subClassOf _:c14n526 ;
+_:c14n1057 rdfs:subClassOf _:c14n528 ;
 	owl:intersectionOf _:c14n1056 .
 _:c14n1058 rdf:first openlabel_v2:Behaviour ;
 	rdf:rest rdf:nil .
-_:c14n1059 rdf:first _:c14n806 ;
+_:c14n1059 rdf:first _:c14n436 ;
 	rdf:rest _:c14n1061 .
 _:c14n106 a owl:Restriction ;
 	owl:onProperty openlabel_v2:subjectVehicleSpeedValue ;
 	owl:someValuesFrom linkml:String .
-_:c14n1060 rdfs:subClassOf _:c14n521 ;
+_:c14n1060 rdfs:subClassOf _:c14n854 ;
 	owl:intersectionOf _:c14n1059 .
 _:c14n1061 rdf:first openlabel_v2:Behaviour ;
 	rdf:rest rdf:nil .
-_:c14n1062 rdf:first openlabel_v2:RoadUserVehicle ;
+_:c14n1062 rdf:first _:c14n808 ;
+	rdf:rest _:c14n1064 .
+_:c14n1063 rdfs:subClassOf _:c14n523 ;
+	owl:intersectionOf _:c14n1062 .
+_:c14n1064 rdf:first openlabel_v2:Behaviour ;
 	rdf:rest rdf:nil .
-_:c14n1063 rdf:first openlabel_v2:RoadUserHuman ;
-	rdf:rest _:c14n1062 .
-_:c14n1064 xsd:pattern "true" .
-_:c14n1065 rdf:first _:c14n1064 ;
+_:c14n1065 rdf:first openlabel_v2:RoadUserVehicle ;
 	rdf:rest rdf:nil .
-_:c14n1066 a rdfs:Datatype ;
-	owl:onDatatype xsd:string ;
-	owl:withRestrictions _:c14n1065 .
+_:c14n1066 rdf:first openlabel_v2:RoadUserHuman ;
+	rdf:rest _:c14n1065 .
 _:c14n1067 xsd:pattern "true" .
 _:c14n1068 rdf:first _:c14n1067 ;
 	rdf:rest rdf:nil .
@@ -1613,6 +1618,12 @@ _:c14n112 a owl:Restriction ;
 _:c14n1120 a rdfs:Datatype ;
 	owl:onDatatype xsd:string ;
 	owl:withRestrictions _:c14n1119 .
+_:c14n1121 xsd:pattern "true" .
+_:c14n1122 rdf:first _:c14n1121 ;
+	rdf:rest rdf:nil .
+_:c14n1123 a rdfs:Datatype ;
+	owl:onDatatype xsd:string ;
+	owl:withRestrictions _:c14n1122 .
 _:c14n113 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:SignsRegulatory .
@@ -1629,7 +1640,7 @@ _:c14n117 a owl:Restriction ;
 	owl:onProperty openlabel_v2:AdminTag .
 _:c14n118 a owl:Restriction ;
 	owl:onProperty openlabel_v2:WeatherRain ;
-	owl:someValuesFrom _:c14n1120 .
+	owl:someValuesFrom _:c14n1123 .
 _:c14n119 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:TrafficVolume .
@@ -1680,8 +1691,8 @@ _:c14n132 a owl:Restriction ;
 	owl:onProperty openlabel_v2:Odd .
 _:c14n133 a owl:Restriction ;
 	owl:onProperty openlabel_v2:TrafficAgentType ;
-	owl:someValuesFrom _:c14n1066 .
-_:c14n134 owl:unionOf _:c14n1019 .
+	owl:someValuesFrom _:c14n1069 .
+_:c14n134 owl:unionOf _:c14n1020 .
 _:c14n135 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:ParticulatesWater .
@@ -1704,9 +1715,9 @@ _:c14n140 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:WeatherWind .
 _:c14n141 rdf:first openlabel_v2:RoundaboutMiniSignal ;
-	rdf:rest _:c14n862 .
+	rdf:rest _:c14n865 .
 _:c14n142 rdf:first openlabel_v2:HumanCyclist ;
-	rdf:rest _:c14n294 .
+	rdf:rest _:c14n295 .
 _:c14n143 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:laneSpecificationDimensionsValue .
@@ -1756,7 +1767,7 @@ _:c14n157 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:HorizontalStraights .
 _:c14n158 rdf:first openlabel_v2:ZoneGeoFenced ;
-	rdf:rest _:c14n337 .
+	rdf:rest _:c14n338 .
 _:c14n159 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:HorizontalCurves .
@@ -1797,14 +1808,14 @@ _:c14n17 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:DrivableAreaSurfaceFeature .
 _:c14n170 rdf:first openlabel_v2:SurfaceConditionIcy ;
-	rdf:rest _:c14n472 .
+	rdf:rest _:c14n474 .
 _:c14n171 rdf:first openlabel_v2:EdgeShoulderGrass ;
 	rdf:rest _:c14n192 .
 _:c14n172 a owl:Restriction ;
 	owl:onProperty openlabel_v2:DaySunElevation ;
-	owl:someValuesFrom _:c14n1108 .
+	owl:someValuesFrom _:c14n1117 .
 _:c14n173 rdf:first openlabel_v2:TemporaryStructureConstructionDetour ;
-	rdf:rest _:c14n355 .
+	rdf:rest _:c14n356 .
 _:c14n174 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:DaySunPosition .
@@ -1852,7 +1863,7 @@ _:c14n188 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:ScenerySpecialStructure .
 _:c14n189 rdf:first openlabel_v2:CommunicationHorn ;
-	rdf:rest _:c14n252 .
+	rdf:rest _:c14n253 .
 _:c14n19 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:trafficFlowRateValue .
@@ -1860,9 +1871,9 @@ _:c14n190 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:RoadUserVehicle .
 _:c14n191 rdf:first openlabel_v2:IntersectionTJunction ;
-	rdf:rest _:c14n652 .
+	rdf:rest _:c14n654 .
 _:c14n192 rdf:first openlabel_v2:EdgeShoulderPavedOrGravel ;
-	rdf:rest _:c14n847 .
+	rdf:rest _:c14n850 .
 _:c14n193 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:DrivableAreaType .
@@ -1898,7 +1909,7 @@ _:c14n201 a owl:Restriction ;
 	owl:onProperty openlabel_v2:scenarioUniqueReference .
 _:c14n202 a owl:Restriction ;
 	owl:onProperty openlabel_v2:LongitudinalDownSlope ;
-	owl:someValuesFrom _:c14n1081 .
+	owl:someValuesFrom _:c14n1093 .
 _:c14n203 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:TrafficFlowRate .
@@ -1918,7 +1929,7 @@ _:c14n208 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:TrafficFlowRate .
 _:c14n209 a rdfs:Datatype ;
-	owl:intersectionOf _:c14n1028 .
+	owl:intersectionOf _:c14n1031 .
 _:c14n21 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:HorizontalCurves .
@@ -1932,10 +1943,10 @@ _:c14n212 a owl:Restriction ;
 	owl:allValuesFrom linkml:Decimal ;
 	owl:onProperty openlabel_v2:particulatesWaterValue .
 _:c14n213 rdf:first openlabel_v2:HumanPassenger ;
-	rdf:rest _:c14n558 .
+	rdf:rest _:c14n560 .
 _:c14n214 a owl:Restriction ;
 	owl:onProperty openlabel_v2:LaneSpecificationDimensions ;
-	owl:someValuesFrom _:c14n1075 .
+	owl:someValuesFrom _:c14n1087 .
 _:c14n215 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:IlluminationArtificial .
@@ -1946,7 +1957,7 @@ _:c14n217 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:SceneryZone .
 _:c14n218 rdf:first openlabel_v2:RainTypeConvective ;
-	rdf:rest _:c14n332 .
+	rdf:rest _:c14n333 .
 _:c14n219 a owl:Restriction ;
 	owl:allValuesFrom linkml:Decimal ;
 	owl:onProperty openlabel_v2:hasUpperBound .
@@ -1957,7 +1968,7 @@ _:c14n220 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:DrivableAreaSurfaceType .
 _:c14n221 rdf:first openlabel_v2:ZoneSchool ;
-	rdf:rest _:c14n402 .
+	rdf:rest _:c14n403 .
 _:c14n222 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:SceneryZone .
@@ -1965,241 +1976,241 @@ _:c14n223 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:longitudinalDownSlopeValue .
 _:c14n224 rdf:first openlabel_v2:TravelDirectionLeft ;
-	rdf:rest _:c14n835 .
+	rdf:rest _:c14n838 .
 _:c14n225 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:scenarioComment .
+_:c14n226 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:GeometryTransverse .
-_:c14n226 a owl:Restriction ;
+_:c14n227 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
 	owl:onProperty openlabel_v2:MotionDrive .
-_:c14n227 a owl:Restriction ;
+_:c14n228 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:hasTag .
-_:c14n228 a owl:Restriction ;
+_:c14n229 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:ParticulatesPollution .
-_:c14n229 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:trafficAgentDensityValue .
 _:c14n23 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:HorizontalStraights .
-_:c14n230 rdf:first openlabel_v2:VehicleTruck ;
-	rdf:rest _:c14n420 .
-_:c14n231 rdf:first openlabel_v2:HumanAnimalRider ;
+_:c14n230 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:trafficAgentDensityValue .
+_:c14n231 rdf:first openlabel_v2:VehicleTruck ;
+	rdf:rest _:c14n421 .
+_:c14n232 rdf:first openlabel_v2:HumanAnimalRider ;
 	rdf:rest _:c14n142 .
-_:c14n232 a owl:Restriction ;
+_:c14n233 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:WeatherWind .
-_:c14n233 rdf:first openlabel_v2:RoundaboutDoubleNosignal ;
-	rdf:rest _:c14n310 .
-_:c14n234 a owl:Restriction ;
+_:c14n234 rdf:first openlabel_v2:RoundaboutDoubleNosignal ;
+	rdf:rest _:c14n311 .
+_:c14n235 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
 	owl:onProperty openlabel_v2:MotionOvertake .
-_:c14n235 a owl:Restriction ;
+_:c14n236 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:MotionReverse .
-_:c14n236 a owl:Restriction ;
+_:c14n237 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:WeatherRain .
-_:c14n237 a owl:Restriction ;
+_:c14n238 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:TrafficAgentDensity .
-_:c14n238 a owl:Restriction ;
+_:c14n239 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:ParticulatesDust .
-_:c14n239 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty openlabel_v2:scenarioVisualisationURL .
 _:c14n24 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:TrafficSpecialVehicle .
 _:c14n240 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:scenarioVisualisationURL .
+_:c14n241 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:ConnectivityPositioning .
-_:c14n241 a owl:Restriction ;
+_:c14n242 a owl:Restriction ;
 	owl:allValuesFrom openlabel_v2:JunctionRoundabout ;
 	owl:onProperty openlabel_v2:JunctionRoundabout .
-_:c14n242 a owl:Restriction ;
+_:c14n243 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:weatherSnowValue .
-_:c14n243 a owl:Restriction ;
+_:c14n244 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:MotionLaneChangeLeft .
-_:c14n244 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:trafficAgentTypeValue .
 _:c14n245 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:LaneSpecificationTravelDirection .
+	owl:onProperty openlabel_v2:trafficAgentTypeValue .
 _:c14n246 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationTravelDirection .
+_:c14n247 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:laneSpecificationDimensionsValue .
-_:c14n247 rdf:first openlabel_v2:PositioningGlonass ;
-	rdf:rest _:c14n695 .
-_:c14n248 a owl:Restriction ;
+_:c14n248 rdf:first openlabel_v2:PositioningGlonass ;
+	rdf:rest _:c14n697 .
+_:c14n249 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:EnvironmentParticulates .
-_:c14n249 a owl:Restriction ;
-	owl:allValuesFrom _:c14n981 ;
-	owl:onProperty openlabel_v2:subjectVehicleSpeedValue .
 _:c14n25 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:IlluminationCloudiness .
 _:c14n250 a owl:Restriction ;
+	owl:allValuesFrom _:c14n990 ;
+	owl:onProperty openlabel_v2:subjectVehicleSpeedValue .
+_:c14n251 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:SubjectVehicleSpeed .
-_:c14n251 a owl:Restriction ;
+_:c14n252 a owl:Restriction ;
 	owl:allValuesFrom openlabel_v2:BehaviourCommunication ;
 	owl:onProperty openlabel_v2:BehaviourCommunication .
-_:c14n252 rdf:first openlabel_v2:CommunicationSignalEmergency ;
+_:c14n253 rdf:first openlabel_v2:CommunicationSignalEmergency ;
 	rdf:rest _:c14n87 .
-_:c14n253 a owl:Restriction ;
+_:c14n254 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:LongitudinalUpSlope .
-_:c14n254 a owl:Restriction ;
+_:c14n255 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:ScenerySpecialStructure .
-_:c14n255 a owl:Restriction ;
+_:c14n256 a owl:Restriction ;
 	owl:allValuesFrom linkml:Decimal ;
 	owl:onProperty openlabel_v2:longitudinalDownSlopeValue .
-_:c14n256 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:SceneryFixedStructure .
 _:c14n257 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:motionDriveValue .
+	owl:onProperty openlabel_v2:SceneryFixedStructure .
 _:c14n258 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:motionDriveValue .
+_:c14n259 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:longitudinalDownSlopeValue .
-_:c14n259 rdf:first openlabel_v2:SurfaceConditionSnow ;
-	rdf:rest _:c14n329 .
 _:c14n26 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:ParticulatesPollution .
-_:c14n260 a owl:Restriction ;
+_:c14n260 rdf:first openlabel_v2:SurfaceConditionSnow ;
+	rdf:rest _:c14n330 .
+_:c14n261 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:licenseURI .
-_:c14n261 a owl:Restriction ;
-	owl:allValuesFrom _:c14n963 ;
-	owl:onProperty openlabel_v2:motionDriveValue .
 _:c14n262 a owl:Restriction ;
+	owl:allValuesFrom _:c14n966 ;
+	owl:onProperty openlabel_v2:motionDriveValue .
+_:c14n263 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:LongitudinalDownSlope .
-_:c14n263 a owl:Restriction ;
+_:c14n264 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:SignsInformation .
-_:c14n264 a owl:Restriction ;
+_:c14n265 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:MotionTurnRight .
-_:c14n265 a owl:Restriction ;
+_:c14n266 a owl:Restriction ;
 	owl:allValuesFrom linkml:Decimal ;
 	owl:onProperty openlabel_v2:weatherRainValue .
-_:c14n266 a owl:Restriction ;
+_:c14n267 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:EnvironmentParticulates .
-_:c14n267 rdf:first openlabel_v2:HumanWheelchairUser ;
+_:c14n268 rdf:first openlabel_v2:HumanWheelchairUser ;
 	rdf:rest rdf:nil .
-_:c14n268 a owl:Restriction ;
+_:c14n269 a owl:Restriction ;
 	owl:allValuesFrom openlabel_v2:ScenerySpecialStructure ;
 	owl:onProperty openlabel_v2:ScenerySpecialStructure .
-_:c14n269 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:HorizontalCurves .
 _:c14n27 rdf:first openlabel_v2:SurfaceTypeUniform ;
 	rdf:rest rdf:nil .
 _:c14n270 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:HorizontalCurves .
+_:c14n271 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:scenarioName .
-_:c14n271 a owl:Restriction ;
+_:c14n272 a owl:Restriction ;
 	owl:allValuesFrom openlabel_v2:GeometryTransverse ;
 	owl:onProperty openlabel_v2:GeometryTransverse .
-_:c14n272 a owl:Restriction ;
+_:c14n273 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:MotionStop .
-_:c14n273 a owl:Restriction ;
+_:c14n274 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:weatherSnowValue .
-_:c14n274 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:LaneSpecificationTravelDirection .
 _:c14n275 a owl:Restriction ;
 	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationTravelDirection .
+_:c14n276 a owl:Restriction ;
+	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:SignsWarning .
-_:c14n276 rdf:first openlabel_v2:VehicleTrailer ;
-	rdf:rest _:c14n230 .
-_:c14n277 a owl:Restriction ;
+_:c14n277 rdf:first openlabel_v2:VehicleTrailer ;
+	rdf:rest _:c14n231 .
+_:c14n278 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:ConnectivityCommunication .
-_:c14n278 a owl:Restriction ;
+_:c14n279 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:trafficAgentTypeValue .
-_:c14n279 a owl:Restriction ;
+_:c14n28 rdf:first openlabel_v2:ParticulatesPollution ;
+	rdf:rest _:c14n761 .
+_:c14n280 a owl:Restriction ;
 	owl:allValuesFrom openlabel_v2:DrivableAreaEdge ;
 	owl:onProperty openlabel_v2:DrivableAreaEdge .
-_:c14n28 rdf:first openlabel_v2:ParticulatesPollution ;
-	rdf:rest _:c14n759 .
-_:c14n280 a owl:Restriction ;
+_:c14n281 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:RainType .
-_:c14n281 a owl:Restriction ;
+_:c14n282 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:ConnectivityPositioning .
-_:c14n282 a owl:Restriction ;
+_:c14n283 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
 	owl:onProperty openlabel_v2:LaneSpecificationDimensions .
-_:c14n283 a owl:Restriction ;
+_:c14n284 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:trafficAgentDensityValue .
-_:c14n284 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:daySunElevationValue .
 _:c14n285 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:ParticulatesWater .
+	owl:onProperty openlabel_v2:daySunElevationValue .
 _:c14n286 a owl:Restriction ;
-	owl:onProperty openlabel_v2:ParticulatesWater ;
-	owl:someValuesFrom _:c14n1099 .
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:ParticulatesWater .
 _:c14n287 a owl:Restriction ;
+	owl:onProperty openlabel_v2:ParticulatesWater ;
+	owl:someValuesFrom _:c14n1072 .
+_:c14n288 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:WeatherWind .
-_:c14n288 a owl:Restriction ;
-	owl:allValuesFrom _:c14n1039 ;
-	owl:onProperty openlabel_v2:trafficAgentDensityValue .
 _:c14n289 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty openlabel_v2:ParticulatesVolcanic .
+	owl:allValuesFrom _:c14n1053 ;
+	owl:onProperty openlabel_v2:trafficAgentDensityValue .
 _:c14n29 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:LongitudinalUpSlope .
 _:c14n290 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:ParticulatesVolcanic .
+_:c14n291 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:ownerURL .
-_:c14n291 a owl:Restriction ;
+_:c14n292 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty openlabel_v2:minValue .
-_:c14n292 rdf:first openlabel_v2:EdgeTemporaryLineMarkers ;
+_:c14n293 rdf:first openlabel_v2:EdgeTemporaryLineMarkers ;
 	rdf:rest rdf:nil .
-_:c14n293 a owl:Restriction ;
+_:c14n294 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:LaneSpecificationTravelDirection .
-_:c14n294 rdf:first openlabel_v2:HumanDriver ;
-	rdf:rest _:c14n326 .
-_:c14n295 a owl:Restriction ;
+_:c14n295 rdf:first openlabel_v2:HumanDriver ;
+	rdf:rest _:c14n327 .
+_:c14n296 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:longitudinalUpSlopeValue .
-_:c14n296 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:LongitudinalLevelPlane .
 _:c14n297 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:weatherSnowValue .
+	owl:onProperty openlabel_v2:LongitudinalLevelPlane .
 _:c14n298 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:weatherSnowValue .
+_:c14n299 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:laneSpecificationLaneCountValue .
-_:c14n299 a owl:Restriction ;
-	owl:maxCardinality 0 ;
-	owl:onProperty openlabel_v2:SubjectVehicleSpeed .
 _:c14n3 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:SceneryZone .
@@ -2208,308 +2219,308 @@ _:c14n30 a owl:Restriction ;
 	owl:onProperty openlabel_v2:GeometryTransverse .
 _:c14n300 a owl:Restriction ;
 	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:SubjectVehicleSpeed .
+_:c14n301 a owl:Restriction ;
+	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:LaneSpecificationLaneCount .
-_:c14n301 rdf:first openlabel_v2:ParticulatesMarine ;
+_:c14n302 rdf:first openlabel_v2:ParticulatesMarine ;
 	rdf:rest _:c14n28 .
-_:c14n302 a owl:Restriction ;
+_:c14n303 a owl:Restriction ;
 	owl:allValuesFrom linkml:Decimal ;
 	owl:onProperty openlabel_v2:daySunElevationValue .
-_:c14n303 a owl:Restriction ;
+_:c14n304 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
 	owl:onProperty openlabel_v2:HorizontalStraights .
-_:c14n304 a owl:Restriction ;
+_:c14n305 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:DrivableAreaType .
-_:c14n305 a owl:Restriction ;
+_:c14n306 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:scenarioDefinition .
-_:c14n306 a owl:Restriction ;
+_:c14n307 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:DrivableAreaSurfaceFeature .
-_:c14n307 a owl:Restriction ;
+_:c14n308 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:trafficAgentDensityValue .
-_:c14n308 owl:unionOf _:c14n1063 .
-_:c14n309 a owl:Restriction ;
-	owl:allValuesFrom openlabel_v2:DaySunPosition ;
-	owl:onProperty openlabel_v2:DaySunPosition .
+_:c14n309 owl:unionOf _:c14n1066 .
 _:c14n31 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
 	owl:onProperty openlabel_v2:MotionWalk .
-_:c14n310 rdf:first openlabel_v2:RoundaboutDoubleSignal ;
-	rdf:rest _:c14n853 .
-_:c14n311 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:IlluminationLowLight .
+_:c14n310 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:DaySunPosition ;
+	owl:onProperty openlabel_v2:DaySunPosition .
+_:c14n311 rdf:first openlabel_v2:RoundaboutDoubleSignal ;
+	rdf:rest _:c14n856 .
 _:c14n312 a owl:Restriction ;
 	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:IlluminationLowLight .
+_:c14n313 a owl:Restriction ;
+	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:TrafficAgentType .
-_:c14n313 rdf:first openlabel_v2:PositioningGalileo ;
-	rdf:rest _:c14n247 .
-_:c14n314 a owl:Restriction ;
+_:c14n314 rdf:first openlabel_v2:PositioningGalileo ;
+	rdf:rest _:c14n248 .
+_:c14n315 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:DrivableAreaSurfaceType .
-_:c14n315 a owl:Restriction ;
+_:c14n316 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:scenarioUniqueReference .
-_:c14n316 a owl:Restriction ;
+_:c14n317 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:IlluminationArtificial .
-_:c14n317 rdf:first openlabel_v2:RegulatorySignsVariableFullTime ;
-	rdf:rest _:c14n459 .
-_:c14n318 a owl:Restriction ;
+_:c14n318 rdf:first openlabel_v2:RegulatorySignsVariableFullTime ;
+	rdf:rest _:c14n461 .
+_:c14n319 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:Behaviour .
-_:c14n319 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:subjectVehicleSpeedValue .
 _:c14n32 a owl:Restriction ;
 	owl:allValuesFrom openlabel_v2:Tag ;
 	owl:onProperty openlabel_v2:hasTag .
 _:c14n320 a owl:Restriction ;
-	owl:maxCardinality 0 ;
-	owl:onProperty openlabel_v2:DrivableAreaEdge .
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:subjectVehicleSpeedValue .
 _:c14n321 a owl:Restriction ;
 	owl:maxCardinality 0 ;
-	owl:onProperty openlabel_v2:trafficFlowRateValue .
+	owl:onProperty openlabel_v2:DrivableAreaEdge .
 _:c14n322 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:trafficFlowRateValue .
+_:c14n323 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:LaneSpecificationLaneCount .
-_:c14n323 a owl:Restriction ;
+_:c14n324 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:JunctionIntersection .
-_:c14n324 a owl:Restriction ;
+_:c14n325 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:TrafficAgentType .
-_:c14n325 a owl:Restriction ;
+_:c14n326 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:LongitudinalUpSlope .
-_:c14n326 rdf:first openlabel_v2:HumanMotorcyclist ;
+_:c14n327 rdf:first openlabel_v2:HumanMotorcyclist ;
 	rdf:rest _:c14n213 .
-_:c14n327 a owl:Restriction ;
+_:c14n328 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:IlluminationCloudiness .
-_:c14n328 a owl:Restriction ;
+_:c14n329 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:WeatherSnow .
-_:c14n329 rdf:first openlabel_v2:SurfaceConditionStandingWater ;
-	rdf:rest _:c14n516 .
 _:c14n33 rdf:first openlabel_v2:FixedStructureBuilding ;
-	rdf:rest _:c14n347 .
-_:c14n330 a owl:Restriction ;
+	rdf:rest _:c14n348 .
+_:c14n330 rdf:first openlabel_v2:SurfaceConditionStandingWater ;
+	rdf:rest _:c14n518 .
+_:c14n331 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:SubjectVehicleSpeed .
-_:c14n331 a owl:Restriction ;
+_:c14n332 a owl:Restriction ;
 	owl:onProperty openlabel_v2:WeatherWind ;
-	owl:someValuesFrom _:c14n1069 .
-_:c14n332 rdf:first openlabel_v2:RainTypeDynamic ;
-	rdf:rest _:c14n645 .
-_:c14n333 a owl:Restriction ;
+	owl:someValuesFrom _:c14n1075 .
+_:c14n333 rdf:first openlabel_v2:RainTypeDynamic ;
+	rdf:rest _:c14n647 .
+_:c14n334 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:ScenerySpecialStructure .
-_:c14n334 owl:unionOf _:c14n1003 .
-_:c14n335 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:JunctionRoundabout .
+_:c14n335 owl:unionOf _:c14n1002 .
 _:c14n336 a owl:Restriction ;
 	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:JunctionRoundabout .
+_:c14n337 a owl:Restriction ;
+	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:ConnectivityPositioning .
-_:c14n337 rdf:first openlabel_v2:ZoneInterference ;
-	rdf:rest _:c14n760 .
-_:c14n338 a owl:Restriction ;
+_:c14n338 rdf:first openlabel_v2:ZoneInterference ;
+	rdf:rest _:c14n762 .
+_:c14n339 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:IlluminationCloudiness .
-_:c14n339 a owl:Restriction ;
+_:c14n34 rdf:first openlabel_v2:ArtificialStreetLighting ;
+	rdf:rest _:c14n598 .
+_:c14n340 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:ParticulatesWater .
-_:c14n34 rdf:first openlabel_v2:ArtificialStreetLighting ;
-	rdf:rest _:c14n596 .
-_:c14n340 a owl:Restriction ;
+_:c14n341 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:DrivableAreaEdge .
-_:c14n341 a owl:Restriction ;
+_:c14n342 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:HorizontalStraights .
-_:c14n342 a owl:Restriction ;
+_:c14n343 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:WeatherSnow .
-_:c14n343 a owl:Restriction ;
+_:c14n344 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:ConnectivityCommunication .
-_:c14n344 a owl:Restriction ;
+_:c14n345 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:ownerEmail .
-_:c14n345 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:RoadUserVehicle .
 _:c14n346 a owl:Restriction ;
 	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:RoadUserVehicle .
+_:c14n347 a owl:Restriction ;
+	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:ParticulatesWater .
-_:c14n347 rdf:first openlabel_v2:FixedStructureStreetFurniture ;
-	rdf:rest _:c14n626 .
-_:c14n348 a owl:Restriction ;
+_:c14n348 rdf:first openlabel_v2:FixedStructureStreetFurniture ;
+	rdf:rest _:c14n628 .
+_:c14n349 a owl:Restriction ;
 	owl:onProperty openlabel_v2:laneSpecificationLaneCountValue ;
 	owl:someValuesFrom linkml:String .
-_:c14n349 rdf:first openlabel_v2:TemporaryStructureRoadWorks ;
-	rdf:rest rdf:nil .
 _:c14n35 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:ParticulatesMarine .
-_:c14n350 a owl:Restriction ;
-	owl:maxCardinality 0 ;
-	owl:onProperty openlabel_v2:trafficAgentDensityValue .
+_:c14n350 rdf:first openlabel_v2:TemporaryStructureRoadWorks ;
+	rdf:rest rdf:nil .
 _:c14n351 a owl:Restriction ;
 	owl:maxCardinality 0 ;
-	owl:onProperty openlabel_v2:LaneSpecificationType .
+	owl:onProperty openlabel_v2:trafficAgentDensityValue .
 _:c14n352 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationType .
+_:c14n353 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:LaneSpecificationDimensions .
-_:c14n353 a owl:Restriction ;
+_:c14n354 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:ParticulatesDust .
-_:c14n354 a owl:Restriction ;
+_:c14n355 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:LaneSpecificationTravelDirection .
-_:c14n355 rdf:first openlabel_v2:TemporaryStructureRefuseCollection ;
-	rdf:rest _:c14n484 .
-_:c14n356 a owl:Restriction ;
+_:c14n356 rdf:first openlabel_v2:TemporaryStructureRefuseCollection ;
+	rdf:rest _:c14n486 .
+_:c14n357 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:IlluminationArtificial .
-_:c14n357 a owl:Restriction ;
+_:c14n358 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:TrafficAgentType .
-_:c14n358 a owl:Restriction ;
+_:c14n359 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
 	owl:onProperty openlabel_v2:LongitudinalDownSlope .
-_:c14n359 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty openlabel_v2:subjectVehicleSpeedValue .
 _:c14n36 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:WeatherRain .
 _:c14n360 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:subjectVehicleSpeedValue .
+_:c14n361 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:RainType .
-_:c14n361 a owl:Restriction ;
+_:c14n362 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
 	owl:onProperty openlabel_v2:LaneSpecificationLaneCount .
-_:c14n362 a owl:Restriction ;
+_:c14n363 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:TrafficVolume .
-_:c14n363 a owl:Restriction ;
+_:c14n364 a owl:Restriction ;
 	owl:allValuesFrom linkml:Datetime ;
 	owl:onProperty openlabel_v2:scenarioCreatedDate .
-_:c14n364 a owl:Restriction ;
+_:c14n365 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:illuminationCloudinessValue .
-_:c14n365 rdf:first openlabel_v2:TransverseDivided ;
-	rdf:rest _:c14n725 .
-_:c14n366 a owl:Restriction ;
+_:c14n366 rdf:first openlabel_v2:TransverseDivided ;
+	rdf:rest _:c14n727 .
+_:c14n367 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:scenarioUniqueReference .
-_:c14n367 a owl:Restriction ;
+_:c14n368 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:DrivableAreaSurfaceType .
-_:c14n368 a owl:Restriction ;
+_:c14n369 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
 	owl:onProperty openlabel_v2:MotionAway .
-_:c14n369 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:trafficVolumeValue .
 _:c14n37 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:ParticulatesMarine .
 _:c14n370 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty openlabel_v2:scenarioDefinition .
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:trafficVolumeValue .
 _:c14n371 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty openlabel_v2:RainType .
+	owl:onProperty openlabel_v2:scenarioDefinition .
 _:c14n372 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:SceneryFixedStructure .
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:RainType .
 _:c14n373 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:IlluminationArtificial .
+	owl:onProperty openlabel_v2:SceneryFixedStructure .
 _:c14n374 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:IlluminationArtificial .
+_:c14n375 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:ConnectivityPositioning .
-_:c14n375 a owl:Restriction ;
+_:c14n376 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:ParticulatesMarine .
-_:c14n376 rdf:first openlabel_v2:RoadTypeMotorway ;
-	rdf:rest _:c14n856 .
-_:c14n377 a owl:Restriction ;
+_:c14n377 rdf:first openlabel_v2:RoadTypeMotorway ;
+	rdf:rest _:c14n859 .
+_:c14n378 a owl:Restriction ;
 	owl:allValuesFrom openlabel_v2:RoadUserHuman ;
 	owl:onProperty openlabel_v2:RoadUserHuman .
-_:c14n378 a owl:Restriction ;
+_:c14n379 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:EnvironmentParticulates .
-_:c14n379 a owl:Restriction ;
-	owl:allValuesFrom linkml:Boolean ;
-	owl:onProperty openlabel_v2:TrafficVolume .
 _:c14n38 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:HorizontalStraights .
 _:c14n380 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:TrafficVolume .
+_:c14n381 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:SubjectVehicleSpeed .
-_:c14n381 rdf:first openlabel_v2:TransverseUndivided ;
+_:c14n382 rdf:first openlabel_v2:TransverseUndivided ;
 	rdf:rest rdf:nil .
-_:c14n382 a owl:Restriction ;
+_:c14n383 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:trafficFlowRateValue .
-_:c14n383 a owl:Restriction ;
+_:c14n384 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:DrivableAreaSurfaceType .
-_:c14n384 a owl:Restriction ;
+_:c14n385 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:hasLowerBound .
-_:c14n385 a owl:Restriction ;
+_:c14n386 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:laneSpecificationLaneCountValue .
-_:c14n386 a owl:Restriction ;
+_:c14n387 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:IlluminationLowLight .
-_:c14n387 rdf:first openlabel_v2:V2iWifi ;
-	rdf:rest _:c14n696 .
-_:c14n388 a owl:Restriction ;
+_:c14n388 rdf:first openlabel_v2:V2iWifi ;
+	rdf:rest _:c14n698 .
+_:c14n389 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:Odd .
-_:c14n389 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:SceneryTemporaryStructure .
 _:c14n39 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:motionAccelerateValue .
 _:c14n390 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:ConnectivityCommunication .
+	owl:onProperty openlabel_v2:SceneryTemporaryStructure .
 _:c14n391 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:ConnectivityCommunication .
+_:c14n392 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:HorizontalCurves .
-_:c14n392 a owl:Restriction ;
+_:c14n393 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:SceneryZone .
-_:c14n393 rdf:first openlabel_v2:RegulatorySignsUniformTemporary ;
-	rdf:rest _:c14n317 .
-_:c14n394 a owl:Restriction ;
+_:c14n394 rdf:first openlabel_v2:RegulatorySignsUniformTemporary ;
+	rdf:rest _:c14n318 .
+_:c14n395 a owl:Restriction ;
 	owl:allValuesFrom openlabel_v2:JunctionIntersection ;
 	owl:onProperty openlabel_v2:JunctionIntersection .
-_:c14n395 a owl:Restriction ;
+_:c14n396 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
 	owl:onProperty openlabel_v2:MotionCutOut .
-_:c14n396 rdf:first openlabel_v2:VehicleBus ;
-	rdf:rest _:c14n671 .
-_:c14n397 a owl:Restriction ;
+_:c14n397 rdf:first openlabel_v2:VehicleBus ;
+	rdf:rest _:c14n673 .
+_:c14n398 a owl:Restriction ;
 	owl:allValuesFrom openlabel_v2:DrivableAreaType ;
 	owl:onProperty openlabel_v2:DrivableAreaType .
-_:c14n398 a owl:Restriction ;
+_:c14n399 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:SignsInformation .
-_:c14n399 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:weatherWindValue .
 _:c14n4 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:DaySunElevation .
@@ -2517,312 +2528,312 @@ _:c14n40 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:TrafficAgentType .
 _:c14n400 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:weatherWindValue .
+_:c14n401 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:LaneSpecificationDimensions .
-_:c14n401 a owl:Restriction ;
+_:c14n402 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:ParticulatesMarine .
-_:c14n402 rdf:first openlabel_v2:ZoneTrafficManagement ;
+_:c14n403 rdf:first openlabel_v2:ZoneTrafficManagement ;
 	rdf:rest rdf:nil .
-_:c14n403 a owl:Restriction ;
+_:c14n404 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:BehaviourCommunication .
-_:c14n404 a owl:Restriction ;
+_:c14n405 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:trafficFlowRateValue .
-_:c14n405 a owl:Restriction ;
+_:c14n406 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:ScenerySpecialStructure .
-_:c14n406 a owl:Restriction ;
+_:c14n407 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:DrivableAreaSurfaceType .
-_:c14n407 rdf:first openlabel_v2:EdgeLineMarkers ;
+_:c14n408 rdf:first openlabel_v2:EdgeLineMarkers ;
 	rdf:rest _:c14n115 .
-_:c14n408 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:SignsInformation .
 _:c14n409 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:LaneSpecificationDimensions .
+	owl:onProperty openlabel_v2:SignsInformation .
 _:c14n41 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:WeatherRain .
-_:c14n410 rdf:first openlabel_v2:RoundaboutMiniNosignal ;
+_:c14n410 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationDimensions .
+_:c14n411 rdf:first openlabel_v2:RoundaboutMiniNosignal ;
 	rdf:rest _:c14n141 .
-_:c14n411 a owl:Restriction ;
+_:c14n412 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:ParticulatesWater .
-_:c14n412 a owl:Restriction ;
+_:c14n413 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:MotionRun .
-_:c14n413 a owl:Restriction ;
+_:c14n414 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:IlluminationLowLight .
-_:c14n414 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:HorizontalCurves .
 _:c14n415 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:trafficAgentTypeValue .
+	owl:onProperty openlabel_v2:HorizontalCurves .
 _:c14n416 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty openlabel_v2:LongitudinalLevelPlane .
-_:c14n417 a owl:Restriction ;
-	owl:onProperty openlabel_v2:daySunElevationValue ;
-	owl:someValuesFrom linkml:String .
-_:c14n418 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty openlabel_v2:scenarioName .
-_:c14n419 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:trafficAgentTypeValue .
+_:c14n417 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:LongitudinalLevelPlane .
+_:c14n418 a owl:Restriction ;
+	owl:onProperty openlabel_v2:daySunElevationValue ;
+	owl:someValuesFrom linkml:String .
+_:c14n419 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:scenarioName .
 _:c14n42 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:AdminTag .
-_:c14n420 rdf:first openlabel_v2:VehicleVan ;
-	rdf:rest _:c14n693 .
-_:c14n421 a owl:Restriction ;
+_:c14n420 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:ConnectivityCommunication .
+	owl:onProperty openlabel_v2:trafficAgentTypeValue .
+_:c14n421 rdf:first openlabel_v2:VehicleVan ;
+	rdf:rest _:c14n695 .
 _:c14n422 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:DrivableAreaEdge .
+	owl:onProperty openlabel_v2:ConnectivityCommunication .
 _:c14n423 a owl:Restriction ;
-	owl:allValuesFrom openlabel_v2:SceneryZone ;
-	owl:onProperty openlabel_v2:SceneryZone .
-_:c14n424 a owl:Restriction ;
-	owl:maxCardinality 0 ;
-	owl:onProperty openlabel_v2:trafficVolumeValue .
-_:c14n425 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty openlabel_v2:MotionUTurn .
-_:c14n426 rdf:first openlabel_v2:SpecialStructureBridge ;
-	rdf:rest _:c14n795 .
-_:c14n427 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:trafficAgentTypeValue .
-_:c14n428 a owl:Restriction ;
-	owl:maxCardinality 0 ;
-	owl:onProperty openlabel_v2:daySunElevationValue .
-_:c14n429 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:DrivableAreaEdge .
+_:c14n424 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:SceneryZone ;
+	owl:onProperty openlabel_v2:SceneryZone .
+_:c14n425 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:trafficVolumeValue .
+_:c14n426 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:MotionUTurn .
+_:c14n427 rdf:first openlabel_v2:SpecialStructureBridge ;
+	rdf:rest _:c14n797 .
+_:c14n428 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:trafficAgentTypeValue .
+_:c14n429 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:daySunElevationValue .
 _:c14n43 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:SceneryTemporaryStructure .
 _:c14n430 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:DrivableAreaEdge .
+_:c14n431 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:weatherRainValue .
-_:c14n431 a owl:Restriction ;
+_:c14n432 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:JunctionIntersection .
-_:c14n432 a owl:Restriction ;
-	owl:maxCardinality 0 ;
-	owl:onProperty openlabel_v2:weatherWindValue .
 _:c14n433 a owl:Restriction ;
 	owl:maxCardinality 0 ;
-	owl:onProperty openlabel_v2:weatherSnowValue .
+	owl:onProperty openlabel_v2:weatherWindValue .
 _:c14n434 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:weatherSnowValue .
+_:c14n435 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:MotionOvertake .
-_:c14n435 a owl:Restriction ;
+_:c14n436 a owl:Restriction ;
 	owl:onProperty openlabel_v2:motionDecelerateValue ;
 	owl:someValuesFrom linkml:String .
-_:c14n436 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:trafficAgentDensityValue .
 _:c14n437 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:SceneryZone .
+	owl:onProperty openlabel_v2:trafficAgentDensityValue .
 _:c14n438 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:MotionStop .
+	owl:onProperty openlabel_v2:SceneryZone .
 _:c14n439 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:TrafficAgentDensity .
+	owl:onProperty openlabel_v2:MotionStop .
 _:c14n44 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:DrivableAreaType .
 _:c14n440 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:TrafficAgentDensity .
+_:c14n441 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
 	owl:onProperty openlabel_v2:ParticulatesVolcanic .
-_:c14n441 rdf:first openlabel_v2:SunPositionRight ;
+_:c14n442 rdf:first openlabel_v2:SunPositionRight ;
 	rdf:rest rdf:nil .
-_:c14n442 rdf:first openlabel_v2:WarningSignsUniformTemporary ;
+_:c14n443 rdf:first openlabel_v2:WarningSignsUniformTemporary ;
 	rdf:rest _:c14n53 .
-_:c14n443 rdf:first openlabel_v2:V2iSatellite ;
-	rdf:rest _:c14n387 .
-_:c14n444 a owl:Restriction ;
+_:c14n444 rdf:first openlabel_v2:V2iSatellite ;
+	rdf:rest _:c14n388 .
+_:c14n445 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:DrivableAreaType .
-_:c14n445 a owl:Restriction ;
+_:c14n446 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
 	owl:onProperty openlabel_v2:MotionCutIn .
-_:c14n446 a owl:Restriction ;
+_:c14n447 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:ParticulatesWater .
-_:c14n447 a owl:Restriction ;
+_:c14n448 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:MotionCutOut .
-_:c14n448 a owl:Restriction ;
+_:c14n449 a owl:Restriction ;
 	owl:allValuesFrom openlabel_v2:Behaviour ;
 	owl:onProperty openlabel_v2:Behaviour .
-_:c14n449 a owl:Restriction ;
-	owl:onProperty openlabel_v2:TrafficVolume ;
-	owl:someValuesFrom _:c14n1084 .
 _:c14n45 rdf:first openlabel_v2:SpecialStructureAutoAccess ;
-	rdf:rest _:c14n426 .
+	rdf:rest _:c14n427 .
 _:c14n450 a owl:Restriction ;
+	owl:onProperty openlabel_v2:TrafficVolume ;
+	owl:someValuesFrom _:c14n1096 .
+_:c14n451 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:IlluminationCloudiness .
-_:c14n451 a owl:Restriction ;
+_:c14n452 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:scenarioComment .
+_:c14n453 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:TrafficSpecialVehicle .
-_:c14n452 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty openlabel_v2:MotionDecelerate .
-_:c14n453 a owl:Restriction ;
-	owl:allValuesFrom linkml:Boolean ;
-	owl:onProperty openlabel_v2:MotionTurnRight .
 _:c14n454 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty openlabel_v2:scenarioParentReference .
+	owl:onProperty openlabel_v2:MotionDecelerate .
 _:c14n455 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:TrafficVolume .
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:MotionTurnRight .
 _:c14n456 a owl:Restriction ;
-	owl:maxCardinality 0 ;
-	owl:onProperty openlabel_v2:DrivableAreaEdge .
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:scenarioParentReference .
 _:c14n457 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:hasUpperBound .
+	owl:onProperty openlabel_v2:TrafficVolume .
 _:c14n458 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:DrivableAreaEdge .
+_:c14n459 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:trafficVolumeValue .
-_:c14n459 rdf:first openlabel_v2:RegulatorySignsVariableTemporary ;
-	rdf:rest rdf:nil .
+	owl:onProperty openlabel_v2:hasUpperBound .
 _:c14n46 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:WeatherSnow .
-_:c14n460 rdf:first openlabel_v2:VehicleAgricultural ;
-	rdf:rest _:c14n396 .
-_:c14n461 a owl:Restriction ;
+_:c14n460 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:trafficVolumeValue .
+_:c14n461 rdf:first openlabel_v2:RegulatorySignsVariableTemporary ;
+	rdf:rest rdf:nil .
+_:c14n462 rdf:first openlabel_v2:VehicleAgricultural ;
+	rdf:rest _:c14n397 .
+_:c14n463 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:WeatherWind .
-_:c14n462 a owl:Restriction ;
+_:c14n464 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:ParticulatesVolcanic .
-_:c14n463 a owl:Restriction ;
+_:c14n465 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:hasTag .
-_:c14n464 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:longitudinalUpSlopeValue .
-_:c14n465 a owl:Restriction ;
-	owl:onProperty openlabel_v2:trafficFlowRateValue ;
-	owl:someValuesFrom linkml:String .
 _:c14n466 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:weatherRainValue .
+	owl:onProperty openlabel_v2:longitudinalUpSlopeValue .
 _:c14n467 a owl:Restriction ;
+	owl:onProperty openlabel_v2:trafficFlowRateValue ;
+	owl:someValuesFrom linkml:String .
+_:c14n468 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:weatherRainValue .
+_:c14n469 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:IlluminationLowLight .
-_:c14n468 rdf:first openlabel_v2:SurfaceConditionContamination ;
-	rdf:rest _:c14n182 .
-_:c14n469 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:trafficVolumeValue .
 _:c14n47 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:laneSpecificationLaneCountValue .
-_:c14n470 a owl:Restriction ;
+_:c14n470 rdf:first openlabel_v2:SurfaceConditionContamination ;
+	rdf:rest _:c14n182 .
+_:c14n471 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:trafficVolumeValue .
+_:c14n472 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:TrafficFlowRate .
-_:c14n471 a owl:Restriction ;
+_:c14n473 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:SignsWarning .
-_:c14n472 rdf:first openlabel_v2:SurfaceConditionMirage ;
-	rdf:rest _:c14n259 .
-_:c14n473 a owl:Restriction ;
+_:c14n474 rdf:first openlabel_v2:SurfaceConditionMirage ;
+	rdf:rest _:c14n260 .
+_:c14n475 a owl:Restriction ;
 	owl:onProperty openlabel_v2:HorizontalCurves ;
-	owl:someValuesFrom _:c14n1102 .
-_:c14n474 a owl:Restriction ;
+	owl:someValuesFrom _:c14n1081 .
+_:c14n476 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:scenarioDefinitionLanguageURI .
-_:c14n475 a owl:Restriction ;
+_:c14n477 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:ParticulatesPollution .
-_:c14n476 rdf:first openlabel_v2:CommunicationWave ;
+_:c14n478 rdf:first openlabel_v2:CommunicationWave ;
 	rdf:rest rdf:nil .
-_:c14n477 rdf:first openlabel_v2:FixedStructureVegetation ;
+_:c14n479 rdf:first openlabel_v2:FixedStructureVegetation ;
 	rdf:rest rdf:nil .
-_:c14n478 rdf:first openlabel_v2:ParticulatesDust ;
-	rdf:rest _:c14n301 .
-_:c14n479 a owl:Restriction ;
-	owl:maxCardinality 0 ;
-	owl:onProperty openlabel_v2:SceneryTemporaryStructure .
 _:c14n48 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:ConnectivityPositioning .
-_:c14n480 a owl:Restriction ;
+_:c14n480 rdf:first openlabel_v2:ParticulatesDust ;
+	rdf:rest _:c14n302 .
+_:c14n481 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:SceneryTemporaryStructure .
+_:c14n482 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:MotionCutIn .
-_:c14n481 a owl:Restriction ;
+_:c14n483 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:LaneSpecificationDimensions .
-_:c14n482 a owl:Restriction ;
+_:c14n484 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:ScenerySpecialStructure .
-_:c14n483 owl:unionOf _:c14n999 .
-_:c14n484 rdf:first openlabel_v2:TemporaryStructureRoadSignage ;
-	rdf:rest _:c14n349 .
-_:c14n485 a owl:Restriction ;
+_:c14n485 owl:unionOf _:c14n1018 .
+_:c14n486 rdf:first openlabel_v2:TemporaryStructureRoadSignage ;
+	rdf:rest _:c14n350 .
+_:c14n487 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:ParticulatesMarine .
-_:c14n486 a owl:Restriction ;
+_:c14n488 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
 	owl:onProperty openlabel_v2:WeatherRain .
-_:c14n487 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:RoadUser .
-_:c14n488 a owl:Restriction ;
-	owl:onProperty openlabel_v2:longitudinalDownSlopeValue ;
-	owl:someValuesFrom linkml:String .
 _:c14n489 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:ParticulatesPollution .
+	owl:onProperty openlabel_v2:RoadUser .
 _:c14n49 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:LongitudinalUpSlope .
 _:c14n490 a owl:Restriction ;
+	owl:onProperty openlabel_v2:longitudinalDownSlopeValue ;
+	owl:someValuesFrom linkml:String .
+_:c14n491 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:ParticulatesPollution .
+_:c14n492 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:motionDriveValue .
-_:c14n491 a owl:Restriction ;
+_:c14n493 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:ParticulatesVolcanic .
-_:c14n492 a owl:Restriction ;
-	owl:maxCardinality 0 ;
-	owl:onProperty openlabel_v2:RainType .
-_:c14n493 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:weatherSnowValue .
 _:c14n494 a owl:Restriction ;
 	owl:maxCardinality 0 ;
-	owl:onProperty openlabel_v2:LaneSpecificationMarking .
+	owl:onProperty openlabel_v2:RainType .
 _:c14n495 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:weatherSnowValue .
+_:c14n496 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationMarking .
+_:c14n497 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:DrivableAreaSurfaceType .
-_:c14n496 rdf:first openlabel_v2:SunPositionFront ;
-	rdf:rest _:c14n735 .
-_:c14n497 a owl:Restriction ;
+_:c14n498 rdf:first openlabel_v2:SunPositionFront ;
+	rdf:rest _:c14n737 .
+_:c14n499 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:MotionTurn .
-_:c14n498 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:TrafficAgentType .
-_:c14n499 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:SubjectVehicleSpeed .
 _:c14n5 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
 	owl:onProperty openlabel_v2:LongitudinalLevelPlane .
@@ -2830,619 +2841,620 @@ _:c14n50 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:TrafficAgentDensity .
 _:c14n500 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:TrafficAgentType .
+_:c14n501 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:SubjectVehicleSpeed .
+_:c14n502 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:ConnectivityCommunication .
-_:c14n501 a owl:Restriction ;
+_:c14n503 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:WeatherWind .
-_:c14n502 a owl:Restriction ;
+_:c14n504 a owl:Restriction ;
 	owl:onProperty openlabel_v2:trafficAgentDensityValue ;
 	owl:someValuesFrom linkml:String .
-_:c14n503 a owl:Restriction ;
+_:c14n505 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:JunctionRoundabout .
-_:c14n504 a owl:Restriction ;
+_:c14n506 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:DrivableAreaSurfaceFeature .
-_:c14n505 a owl:Restriction ;
+_:c14n507 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:trafficFlowRateValue .
-_:c14n506 a owl:Restriction ;
+_:c14n508 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:JunctionIntersection .
-_:c14n507 a owl:Restriction ;
+_:c14n509 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:motionDecelerateValue .
-_:c14n508 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:IlluminationArtificial .
-_:c14n509 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:TrafficFlowRate .
 _:c14n51 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:EnvironmentParticulates .
 _:c14n510 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:LongitudinalDownSlope .
+	owl:onProperty openlabel_v2:IlluminationArtificial .
 _:c14n511 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:longitudinalDownSlopeValue .
+	owl:onProperty openlabel_v2:TrafficFlowRate .
 _:c14n512 a owl:Restriction ;
-	owl:maxCardinality 0 ;
-	owl:onProperty openlabel_v2:DaySunElevation .
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:LongitudinalDownSlope .
 _:c14n513 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:weatherWindValue .
+	owl:onProperty openlabel_v2:longitudinalDownSlopeValue .
 _:c14n514 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:DaySunElevation .
+_:c14n515 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:weatherWindValue .
+_:c14n516 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:MotionTurnLeft .
-_:c14n515 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:longitudinalUpSlopeValue .
-_:c14n516 rdf:first openlabel_v2:SurfaceConditionWet ;
-	rdf:rest rdf:nil .
 _:c14n517 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:SceneryTemporaryStructure .
-_:c14n518 a owl:Restriction ;
-	owl:allValuesFrom _:c14n1050 ;
-	owl:onProperty openlabel_v2:trafficFlowRateValue .
+	owl:onProperty openlabel_v2:longitudinalUpSlopeValue .
+_:c14n518 rdf:first openlabel_v2:SurfaceConditionWet ;
+	rdf:rest rdf:nil .
 _:c14n519 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:TrafficSpecialVehicle .
+	owl:onProperty openlabel_v2:SceneryTemporaryStructure .
 _:c14n52 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
 	owl:onProperty openlabel_v2:IlluminationCloudiness .
 _:c14n520 a owl:Restriction ;
+	owl:allValuesFrom _:c14n1047 ;
+	owl:onProperty openlabel_v2:trafficFlowRateValue .
+_:c14n521 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:TrafficSpecialVehicle .
+_:c14n522 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:ConnectivityCommunication .
-_:c14n521 a owl:Restriction ;
-	owl:onProperty openlabel_v2:MotionAccelerate ;
-	owl:someValuesFrom _:c14n1078 .
-_:c14n522 rdf:first openlabel_v2:RoadTypeParking ;
-	rdf:rest _:c14n728 .
 _:c14n523 a owl:Restriction ;
+	owl:onProperty openlabel_v2:MotionAccelerate ;
+	owl:someValuesFrom _:c14n1111 .
+_:c14n524 rdf:first openlabel_v2:RoadTypeParking ;
+	rdf:rest _:c14n730 .
+_:c14n525 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:TrafficSpecialVehicle .
-_:c14n524 a owl:Restriction ;
+_:c14n526 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:HorizontalStraights .
-_:c14n525 rdf:first openlabel_v2:RoundaboutLargeSignal ;
-	rdf:rest _:c14n410 .
-_:c14n526 a owl:Restriction ;
+_:c14n527 rdf:first openlabel_v2:RoundaboutLargeSignal ;
+	rdf:rest _:c14n411 .
+_:c14n528 a owl:Restriction ;
 	owl:onProperty openlabel_v2:MotionDrive ;
-	owl:someValuesFrom _:c14n1114 .
-_:c14n527 a owl:Restriction ;
+	owl:someValuesFrom _:c14n1102 .
+_:c14n529 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:GeometryTransverse .
-_:c14n528 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:DrivableAreaSurfaceType .
-_:c14n529 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:IlluminationCloudiness .
 _:c14n53 rdf:first openlabel_v2:WarningSignsVariableFullTime ;
-	rdf:rest _:c14n627 .
+	rdf:rest _:c14n629 .
 _:c14n530 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:hasLowerBound .
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceType .
 _:c14n531 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:IlluminationCloudiness .
+_:c14n532 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:hasLowerBound .
+_:c14n533 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:motionAccelerateValue .
-_:c14n532 a owl:Restriction ;
+_:c14n534 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:laneSpecificationDimensionsValue .
-_:c14n533 a owl:Restriction ;
+_:c14n535 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:LaneSpecificationMarking .
-_:c14n534 rdf:first openlabel_v2:SpecialStructureTunnel ;
+_:c14n536 rdf:first openlabel_v2:SpecialStructureTunnel ;
 	rdf:rest rdf:nil .
-_:c14n535 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:LongitudinalLevelPlane .
-_:c14n536 a owl:Restriction ;
-	owl:maxCardinality 0 ;
-	owl:onProperty openlabel_v2:LongitudinalLevelPlane .
 _:c14n537 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:DaySunPosition .
+	owl:onProperty openlabel_v2:LongitudinalLevelPlane .
 _:c14n538 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty openlabel_v2:DaySunElevation .
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:LongitudinalLevelPlane .
 _:c14n539 a owl:Restriction ;
-	owl:allValuesFrom linkml:Boolean ;
-	owl:onProperty openlabel_v2:MotionSlide .
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:DaySunPosition .
 _:c14n54 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:HorizontalCurves .
 _:c14n540 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty openlabel_v2:MotionRun .
+	owl:onProperty openlabel_v2:DaySunElevation .
 _:c14n541 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
-	owl:onProperty openlabel_v2:HorizontalCurves .
+	owl:onProperty openlabel_v2:MotionSlide .
 _:c14n542 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:MotionRun .
+_:c14n543 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:HorizontalCurves .
+_:c14n544 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:LaneSpecificationDimensions .
-_:c14n543 a owl:Restriction ;
+_:c14n545 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:ConnectivityCommunication .
-_:c14n544 rdf:first openlabel_v2:VehicleConstruction ;
+_:c14n546 rdf:first openlabel_v2:VehicleConstruction ;
 	rdf:rest _:c14n63 .
-_:c14n545 a owl:Restriction ;
+_:c14n547 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:SignsWarning .
-_:c14n546 a owl:Restriction ;
+_:c14n548 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:MotionTurn .
-_:c14n547 a owl:Restriction ;
+_:c14n549 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:SubjectVehicleSpeed .
-_:c14n548 rdf:first openlabel_v2:VehicleMotorcycle ;
-	rdf:rest _:c14n276 .
-_:c14n549 a owl:Restriction ;
+_:c14n55 owl:unionOf _:c14n1000 .
+_:c14n550 rdf:first openlabel_v2:VehicleMotorcycle ;
+	rdf:rest _:c14n277 .
+_:c14n551 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:RoadUserAnimal .
-_:c14n55 owl:unionOf _:c14n1001 .
-_:c14n550 a owl:Restriction ;
+_:c14n552 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:HorizontalStraights .
-_:c14n551 rdf:first openlabel_v2:RoadTypeDistributor ;
-	rdf:rest _:c14n711 .
-_:c14n552 a owl:Restriction ;
+_:c14n553 rdf:first openlabel_v2:RoadTypeDistributor ;
+	rdf:rest _:c14n713 .
+_:c14n554 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:IlluminationArtificial .
-_:c14n553 a owl:Restriction ;
+_:c14n555 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:SceneryZone .
-_:c14n554 a owl:Restriction ;
+_:c14n556 a owl:Restriction ;
 	owl:allValuesFrom openlabel_v2:RainType ;
 	owl:onProperty openlabel_v2:RainType .
-_:c14n555 a owl:Restriction ;
+_:c14n557 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:WeatherWind .
-_:c14n556 a owl:Restriction ;
+_:c14n558 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
 	owl:onProperty openlabel_v2:DaySunElevation .
-_:c14n557 a owl:Restriction ;
+_:c14n559 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:weatherWindValue .
-_:c14n558 rdf:first openlabel_v2:HumanPedestrian ;
-	rdf:rest _:c14n267 .
-_:c14n559 rdf:first openlabel_v2:IntersectionStaggered ;
-	rdf:rest _:c14n191 .
 _:c14n56 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:ParticulatesDust .
-_:c14n560 a owl:Restriction ;
+_:c14n560 rdf:first openlabel_v2:HumanPedestrian ;
+	rdf:rest _:c14n268 .
+_:c14n561 rdf:first openlabel_v2:IntersectionStaggered ;
+	rdf:rest _:c14n191 .
+_:c14n562 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:longitudinalUpSlopeValue .
-_:c14n561 a owl:Restriction ;
+_:c14n563 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:SignsWarning .
-_:c14n562 a owl:Restriction ;
+_:c14n564 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:EnvironmentParticulates .
-_:c14n563 a owl:Restriction ;
+_:c14n565 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:ConnectivityPositioning .
-_:c14n564 rdf:first openlabel_v2:LaneTypeSpecial ;
+_:c14n566 rdf:first openlabel_v2:LaneTypeSpecial ;
 	rdf:rest _:c14n77 .
-_:c14n565 a owl:Restriction ;
+_:c14n567 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
 	owl:onProperty openlabel_v2:MotionLaneChangeRight .
-_:c14n566 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:DrivableAreaSurfaceCondition .
-_:c14n567 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:ParticulatesVolcanic .
 _:c14n568 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:SignsRegulatory .
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceCondition .
 _:c14n569 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:LongitudinalLevelPlane .
+	owl:onProperty openlabel_v2:ParticulatesVolcanic .
 _:c14n57 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:WeatherSnow .
 _:c14n570 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:SignsRegulatory .
+_:c14n571 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:LongitudinalLevelPlane .
+_:c14n572 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:ParticulatesMarine .
-_:c14n571 rdf:first openlabel_v2:RoundaboutCompactNosignal ;
-	rdf:rest _:c14n841 .
-_:c14n572 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:daySunElevationValue .
-_:c14n573 a owl:Restriction ;
-	owl:allValuesFrom _:c14n960 ;
-	owl:onProperty openlabel_v2:trafficAgentTypeValue .
+_:c14n573 rdf:first openlabel_v2:RoundaboutCompactNosignal ;
+	rdf:rest _:c14n844 .
 _:c14n574 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:LaneSpecificationLaneCount .
+	owl:onProperty openlabel_v2:daySunElevationValue .
 _:c14n575 a owl:Restriction ;
+	owl:allValuesFrom _:c14n972 ;
+	owl:onProperty openlabel_v2:trafficAgentTypeValue .
+_:c14n576 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationLaneCount .
+_:c14n577 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
 	owl:onProperty openlabel_v2:MotionCross .
-_:c14n576 a owl:Restriction ;
+_:c14n578 a owl:Restriction ;
 	owl:allValuesFrom openlabel_v2:SceneryFixedStructure ;
 	owl:onProperty openlabel_v2:SceneryFixedStructure .
-_:c14n577 a owl:Restriction ;
+_:c14n579 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:RainType .
-_:c14n578 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:DrivableAreaEdge .
-_:c14n579 a owl:Restriction ;
-	owl:allValuesFrom openlabel_v2:AdminTag ;
-	owl:onProperty openlabel_v2:AdminTag .
 _:c14n58 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:illuminationCloudinessValue .
 _:c14n580 a owl:Restriction ;
-	owl:onProperty openlabel_v2:motionDriveValue ;
-	owl:someValuesFrom linkml:String .
-_:c14n581 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:longitudinalUpSlopeValue .
+	owl:onProperty openlabel_v2:DrivableAreaEdge .
+_:c14n581 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:AdminTag ;
+	owl:onProperty openlabel_v2:AdminTag .
 _:c14n582 a owl:Restriction ;
-	owl:onProperty openlabel_v2:particulatesWaterValue ;
+	owl:onProperty openlabel_v2:motionDriveValue ;
 	owl:someValuesFrom linkml:String .
 _:c14n583 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:LaneSpecificationType .
-_:c14n584 rdf:first openlabel_v2:WarningSignsUniform ;
-	rdf:rest _:c14n781 .
+	owl:onProperty openlabel_v2:longitudinalUpSlopeValue .
+_:c14n584 a owl:Restriction ;
+	owl:onProperty openlabel_v2:particulatesWaterValue ;
+	owl:someValuesFrom linkml:String .
 _:c14n585 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationType .
+_:c14n586 rdf:first openlabel_v2:WarningSignsUniform ;
+	rdf:rest _:c14n783 .
+_:c14n587 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:LaneSpecificationLaneCount .
-_:c14n586 a owl:Restriction ;
+_:c14n588 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:DrivableAreaSurfaceCondition .
-_:c14n587 a owl:Restriction ;
+_:c14n589 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:SceneryTemporaryStructure .
-_:c14n588 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:scenarioParentReference .
-_:c14n589 rdf:first openlabel_v2:SpecialStructureRailCrossing ;
-	rdf:rest _:c14n812 .
 _:c14n59 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:TrafficSpecialVehicle .
 _:c14n590 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:scenarioParentReference .
+_:c14n591 rdf:first openlabel_v2:SpecialStructureRailCrossing ;
+	rdf:rest _:c14n814 .
+_:c14n592 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
 	owl:onProperty openlabel_v2:ParticulatesWater .
-_:c14n591 a owl:Restriction ;
+_:c14n593 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
 	owl:onProperty openlabel_v2:TrafficAgentType .
-_:c14n592 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty openlabel_v2:MotionAway .
-_:c14n593 rdf:first openlabel_v2:RoundaboutNormalSignal ;
-	rdf:rest rdf:nil .
 _:c14n594 a owl:Restriction ;
 	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:MotionAway .
+_:c14n595 rdf:first openlabel_v2:RoundaboutNormalSignal ;
+	rdf:rest rdf:nil .
+_:c14n596 a owl:Restriction ;
+	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:SignsInformation .
-_:c14n595 a owl:Restriction ;
+_:c14n597 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:ParticulatesDust .
-_:c14n596 rdf:first openlabel_v2:ArtificialVehicleLighting ;
+_:c14n598 rdf:first openlabel_v2:ArtificialVehicleLighting ;
 	rdf:rest rdf:nil .
-_:c14n597 a owl:Restriction ;
+_:c14n599 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:horizontalCurvesValue .
-_:c14n598 a owl:Restriction ;
-	owl:allValuesFrom linkml:Boolean ;
-	owl:onProperty openlabel_v2:TrafficSpecialVehicle .
-_:c14n599 a owl:Restriction ;
-	owl:allValuesFrom _:c14n978 ;
-	owl:onProperty openlabel_v2:motionAccelerateValue .
 _:c14n6 a owl:Restriction ;
 	owl:onProperty openlabel_v2:WeatherSnow ;
-	owl:someValuesFrom _:c14n1105 .
+	owl:someValuesFrom _:c14n1114 .
 _:c14n60 a owl:Restriction ;
 	owl:allValuesFrom openlabel_v2:SignsRegulatory ;
 	owl:onProperty openlabel_v2:SignsRegulatory .
 _:c14n600 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:TrafficSpecialVehicle .
+_:c14n601 a owl:Restriction ;
+	owl:allValuesFrom _:c14n963 ;
+	owl:onProperty openlabel_v2:motionAccelerateValue .
+_:c14n602 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:WeatherWind .
-_:c14n601 rdf:first openlabel_v2:IntersectionCrossroad ;
-	rdf:rest _:c14n625 .
-_:c14n602 a owl:Restriction ;
+_:c14n603 rdf:first openlabel_v2:IntersectionCrossroad ;
+	rdf:rest _:c14n627 .
+_:c14n604 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:SceneryTemporaryStructure .
-_:c14n603 rdf:first openlabel_v2:ParticulatesWater ;
+_:c14n605 rdf:first openlabel_v2:ParticulatesWater ;
 	rdf:rest rdf:nil .
-_:c14n604 a owl:Restriction ;
+_:c14n606 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:daySunElevationValue .
-_:c14n605 a owl:Restriction ;
+_:c14n607 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:DrivableAreaSurfaceFeature .
-_:c14n606 a owl:Restriction ;
+_:c14n608 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:trafficFlowRateValue .
-_:c14n607 a owl:Restriction ;
+_:c14n609 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:trafficVolumeValue .
-_:c14n608 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:SceneryFixedStructure .
-_:c14n609 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:laneSpecificationLaneCountValue .
 _:c14n61 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:WeatherRain .
 _:c14n610 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:SceneryFixedStructure .
+_:c14n611 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:laneSpecificationLaneCountValue .
+_:c14n612 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:DaySunPosition .
-_:c14n611 a owl:Restriction ;
+_:c14n613 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:MotionDrive .
-_:c14n612 a owl:Restriction ;
+_:c14n614 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:longitudinalDownSlopeValue .
-_:c14n613 a owl:Restriction ;
+_:c14n615 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:LaneSpecificationType .
-_:c14n614 a owl:Restriction ;
+_:c14n616 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:HorizontalCurves .
-_:c14n615 rdf:first openlabel_v2:CommunicationSignalLeft ;
-	rdf:rest _:c14n796 .
-_:c14n616 a owl:Restriction ;
+_:c14n617 rdf:first openlabel_v2:CommunicationSignalLeft ;
+	rdf:rest _:c14n798 .
+_:c14n618 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:TrafficAgentType .
-_:c14n617 rdf:first openlabel_v2:CommunicationHeadlightFlash ;
+_:c14n619 rdf:first openlabel_v2:CommunicationHeadlightFlash ;
 	rdf:rest _:c14n189 .
-_:c14n618 a owl:Restriction ;
-	owl:allValuesFrom openlabel_v2:DrivableAreaSurfaceType ;
-	owl:onProperty openlabel_v2:DrivableAreaSurfaceType .
-_:c14n619 a owl:Restriction ;
-	owl:maxCardinality 0 ;
-	owl:onProperty openlabel_v2:GeometryTransverse .
 _:c14n62 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:scenarioDefinition .
-_:c14n620 rdf:first openlabel_v2:VehicleEmergency ;
-	rdf:rest _:c14n548 .
-_:c14n621 rdf:first openlabel_v2:LaneTypeCycle ;
+_:c14n620 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:DrivableAreaSurfaceType ;
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceType .
+_:c14n621 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:GeometryTransverse .
+_:c14n622 rdf:first openlabel_v2:VehicleEmergency ;
+	rdf:rest _:c14n550 .
+_:c14n623 rdf:first openlabel_v2:LaneTypeCycle ;
 	rdf:rest _:c14n95 .
-_:c14n622 a owl:Restriction ;
+_:c14n624 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:DrivableAreaSurfaceCondition .
-_:c14n623 a owl:Restriction ;
+_:c14n625 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:trafficAgentTypeValue .
-_:c14n624 a owl:Restriction ;
+_:c14n626 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:weatherSnowValue .
-_:c14n625 rdf:first openlabel_v2:IntersectionGradeSeperated ;
-	rdf:rest _:c14n559 .
-_:c14n626 rdf:first openlabel_v2:FixedStructureStreetlight ;
-	rdf:rest _:c14n477 .
-_:c14n627 rdf:first openlabel_v2:WarningSignsVariableTemporary ;
+_:c14n627 rdf:first openlabel_v2:IntersectionGradeSeperated ;
+	rdf:rest _:c14n561 .
+_:c14n628 rdf:first openlabel_v2:FixedStructureStreetlight ;
+	rdf:rest _:c14n479 .
+_:c14n629 rdf:first openlabel_v2:WarningSignsVariableTemporary ;
 	rdf:rest rdf:nil .
-_:c14n628 a owl:Restriction ;
+_:c14n63 rdf:first openlabel_v2:VehicleCycle ;
+	rdf:rest _:c14n622 .
+_:c14n630 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:LaneSpecificationTravelDirection .
-_:c14n629 owl:unionOf _:c14n1011 .
-_:c14n63 rdf:first openlabel_v2:VehicleCycle ;
-	rdf:rest _:c14n620 .
-_:c14n630 a owl:Restriction ;
-	owl:maxCardinality 0 ;
-	owl:onProperty openlabel_v2:trafficFlowRateValue .
-_:c14n631 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:ConnectivityPositioning .
+_:c14n631 owl:unionOf _:c14n1010 .
 _:c14n632 a owl:Restriction ;
 	owl:maxCardinality 0 ;
-	owl:onProperty openlabel_v2:EnvironmentParticulates .
+	owl:onProperty openlabel_v2:trafficFlowRateValue .
 _:c14n633 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:ConnectivityPositioning .
+_:c14n634 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:EnvironmentParticulates .
+_:c14n635 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:DrivableAreaType .
-_:c14n634 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:horizontalCurvesValue .
-_:c14n635 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty openlabel_v2:ConnectivityCommunication .
 _:c14n636 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:ParticulatesMarine .
+	owl:onProperty openlabel_v2:horizontalCurvesValue .
 _:c14n637 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:GeometryTransverse .
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:ConnectivityCommunication .
 _:c14n638 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:LaneSpecificationTravelDirection .
+	owl:onProperty openlabel_v2:ParticulatesMarine .
 _:c14n639 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:SignsWarning .
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:GeometryTransverse .
 _:c14n64 rdf:first openlabel_v2:V2vWifi ;
 	rdf:rest rdf:nil .
 _:c14n640 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationTravelDirection .
+_:c14n641 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:SignsWarning .
+_:c14n642 a owl:Restriction ;
 	owl:onProperty openlabel_v2:trafficAgentTypeValue ;
 	owl:someValuesFrom linkml:String .
-_:c14n641 a owl:Restriction ;
+_:c14n643 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:JunctionRoundabout .
-_:c14n642 rdf:first openlabel_v2:InformationSignsUniformFullTime ;
+_:c14n644 rdf:first openlabel_v2:InformationSignsUniformFullTime ;
 	rdf:rest _:c14n91 .
-_:c14n643 a owl:Restriction ;
+_:c14n645 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:trafficAgentDensityValue .
-_:c14n644 a owl:Restriction ;
+_:c14n646 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:SignsRegulatory .
-_:c14n645 rdf:first openlabel_v2:RainTypeOrographic ;
-	rdf:rest rdf:nil .
-_:c14n646 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:MotionLaneChangeRight .
-_:c14n647 rdf:first openlabel_v2:InformationSignsVariableTemporary ;
+_:c14n647 rdf:first openlabel_v2:RainTypeOrographic ;
 	rdf:rest rdf:nil .
 _:c14n648 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:LongitudinalUpSlope .
-_:c14n649 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty openlabel_v2:MotionCross .
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:MotionLaneChangeRight .
+_:c14n649 rdf:first openlabel_v2:InformationSignsVariableTemporary ;
+	rdf:rest rdf:nil .
 _:c14n65 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:LongitudinalDownSlope .
 _:c14n650 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:scenarioVersion .
+	owl:onProperty openlabel_v2:LongitudinalUpSlope .
 _:c14n651 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:MotionCross .
+_:c14n652 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:scenarioVersion .
+_:c14n653 a owl:Restriction ;
 	owl:onProperty openlabel_v2:weatherSnowValue ;
 	owl:someValuesFrom linkml:String .
-_:c14n652 rdf:first openlabel_v2:IntersectionYJunction ;
+_:c14n654 rdf:first openlabel_v2:IntersectionYJunction ;
 	rdf:rest rdf:nil .
-_:c14n653 a owl:Restriction ;
+_:c14n655 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:ParticulatesWater .
-_:c14n654 a owl:Restriction ;
+_:c14n656 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:JunctionIntersection .
-_:c14n655 a owl:Restriction ;
+_:c14n657 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:ConnectivityPositioning .
-_:c14n656 a owl:Restriction ;
-	owl:maxCardinality 0 ;
-	owl:onProperty openlabel_v2:weatherWindValue .
-_:c14n657 rdf:first openlabel_v2:RegulatorySignsUniformFullTime ;
-	rdf:rest _:c14n393 .
 _:c14n658 a owl:Restriction ;
 	owl:maxCardinality 0 ;
-	owl:onProperty openlabel_v2:trafficAgentDensityValue .
-_:c14n659 rdf:first openlabel_v2:TransversePavements ;
-	rdf:rest _:c14n381 .
+	owl:onProperty openlabel_v2:weatherWindValue .
+_:c14n659 rdf:first openlabel_v2:RegulatorySignsUniformFullTime ;
+	rdf:rest _:c14n394 .
 _:c14n66 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:illuminationCloudinessValue .
 _:c14n660 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:trafficAgentDensityValue .
+_:c14n661 rdf:first openlabel_v2:TransversePavements ;
+	rdf:rest _:c14n382 .
+_:c14n662 a owl:Restriction ;
 	owl:allValuesFrom openlabel_v2:DrivableAreaSurfaceCondition ;
 	owl:onProperty openlabel_v2:DrivableAreaSurfaceCondition .
-_:c14n661 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:trafficAgentDensityValue .
-_:c14n662 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:scenarioParentReference .
 _:c14n663 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:JunctionIntersection .
+	owl:onProperty openlabel_v2:trafficAgentDensityValue .
 _:c14n664 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:scenarioParentReference .
+_:c14n665 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:JunctionIntersection .
+_:c14n666 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:ParticulatesVolcanic .
-_:c14n665 a rdfs:Datatype ;
-	owl:intersectionOf _:c14n1044 .
-_:c14n666 a owl:Restriction ;
+_:c14n667 a rdfs:Datatype ;
+	owl:intersectionOf _:c14n1041 .
+_:c14n668 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:TrafficFlowRate .
-_:c14n667 a owl:Restriction ;
-	owl:allValuesFrom _:c14n993 ;
-	owl:onProperty openlabel_v2:motionDriveValue .
-_:c14n668 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty openlabel_v2:scenarioDefinitionLanguageURI .
 _:c14n669 a owl:Restriction ;
-	owl:maxCardinality 0 ;
-	owl:onProperty openlabel_v2:SceneryFixedStructure .
+	owl:allValuesFrom _:c14n969 ;
+	owl:onProperty openlabel_v2:motionDriveValue .
 _:c14n67 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:DrivableAreaSurfaceFeature .
 _:c14n670 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:scenarioDefinitionLanguageURI .
+_:c14n671 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:SceneryFixedStructure .
+_:c14n672 a owl:Restriction ;
 	owl:onProperty openlabel_v2:longitudinalUpSlopeValue ;
 	owl:someValuesFrom linkml:String .
-_:c14n671 rdf:first openlabel_v2:VehicleCar ;
-	rdf:rest _:c14n544 .
-_:c14n672 rdf:first openlabel_v2:SurfaceFeatureRut ;
-	rdf:rest _:c14n832 .
-_:c14n673 a owl:Restriction ;
+_:c14n673 rdf:first openlabel_v2:VehicleCar ;
+	rdf:rest _:c14n546 .
+_:c14n674 rdf:first openlabel_v2:SurfaceFeatureRut ;
+	rdf:rest _:c14n834 .
+_:c14n675 a owl:Restriction ;
 	owl:onProperty openlabel_v2:TrafficFlowRate ;
-	owl:someValuesFrom _:c14n1090 .
-_:c14n674 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:LaneSpecificationLaneCount .
-_:c14n675 rdf:first openlabel_v2:InformationSignsVariableFullTime ;
-	rdf:rest _:c14n647 .
+	owl:someValuesFrom _:c14n1120 .
 _:c14n676 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:IlluminationArtificial .
-_:c14n677 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:SubjectVehicleSpeed .
+	owl:onProperty openlabel_v2:LaneSpecificationLaneCount .
+_:c14n677 rdf:first openlabel_v2:InformationSignsVariableFullTime ;
+	rdf:rest _:c14n649 .
 _:c14n678 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:DrivableAreaSurfaceCondition .
-_:c14n679 a rdfs:Datatype ;
-	owl:intersectionOf _:c14n1033 .
+	owl:onProperty openlabel_v2:IlluminationArtificial .
+_:c14n679 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:SubjectVehicleSpeed .
 _:c14n68 a owl:Restriction ;
 	owl:allValuesFrom linkml:Decimal ;
 	owl:onProperty openlabel_v2:illuminationCloudinessValue .
 _:c14n680 a owl:Restriction ;
 	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceCondition .
+_:c14n681 a rdfs:Datatype ;
+	owl:intersectionOf _:c14n1036 .
+_:c14n682 a owl:Restriction ;
+	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:DrivableAreaSurfaceFeature .
-_:c14n681 a owl:Restriction ;
+_:c14n683 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:SignsWarning .
-_:c14n682 a owl:Restriction ;
+_:c14n684 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:RoadUserHuman .
-_:c14n683 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:laneSpecificationDimensionsValue .
-_:c14n684 a owl:Restriction ;
-	owl:allValuesFrom linkml:Boolean ;
-	owl:onProperty openlabel_v2:MotionTurn .
 _:c14n685 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:MotionDecelerate .
+	owl:onProperty openlabel_v2:laneSpecificationDimensionsValue .
 _:c14n686 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:MotionCross .
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:MotionTurn .
 _:c14n687 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty openlabel_v2:SignsRegulatory .
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:MotionDecelerate .
 _:c14n688 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:DaySunElevation .
+	owl:onProperty openlabel_v2:MotionCross .
 _:c14n689 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:RainType .
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:SignsRegulatory .
 _:c14n69 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:trafficVolumeValue .
 _:c14n690 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:Behaviour .
+	owl:onProperty openlabel_v2:DaySunElevation .
 _:c14n691 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:RainType .
+_:c14n692 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:Behaviour .
+_:c14n693 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:ownerName .
-_:c14n692 a owl:Restriction ;
+_:c14n694 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:JunctionIntersection .
-_:c14n693 rdf:first openlabel_v2:VehicleWheelchair ;
+_:c14n695 rdf:first openlabel_v2:VehicleWheelchair ;
 	rdf:rest rdf:nil .
-_:c14n694 a owl:Restriction ;
+_:c14n696 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:TrafficAgentDensity .
-_:c14n695 rdf:first openlabel_v2:PositioningGps ;
+_:c14n697 rdf:first openlabel_v2:PositioningGps ;
 	rdf:rest rdf:nil .
-_:c14n696 rdf:first openlabel_v2:CommunicationV2v ;
-	rdf:rest _:c14n738 .
-_:c14n697 a owl:Restriction ;
+_:c14n698 rdf:first openlabel_v2:CommunicationV2v ;
+	rdf:rest _:c14n740 .
+_:c14n699 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:LongitudinalLevelPlane .
-_:c14n698 a owl:Restriction ;
-	owl:maxCardinality 0 ;
-	owl:onProperty openlabel_v2:LongitudinalDownSlope .
-_:c14n699 rdf:first openlabel_v2:LowLightNight ;
-	rdf:rest rdf:nil .
 _:c14n7 a owl:Restriction ;
 	owl:onProperty openlabel_v2:horizontalCurvesValue ;
 	owl:someValuesFrom linkml:String .
@@ -3451,710 +3463,712 @@ _:c14n70 a owl:Restriction ;
 	owl:onProperty openlabel_v2:LaneSpecificationMarking .
 _:c14n700 a owl:Restriction ;
 	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:LongitudinalDownSlope .
+_:c14n701 rdf:first openlabel_v2:LowLightNight ;
+	rdf:rest rdf:nil .
+_:c14n702 a owl:Restriction ;
+	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:TrafficSpecialVehicle .
-_:c14n701 a owl:Restriction ;
+_:c14n703 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:DaySunPosition .
-_:c14n702 a owl:Restriction ;
+_:c14n704 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:weatherRainValue .
-_:c14n703 a owl:Restriction ;
+_:c14n705 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:LongitudinalUpSlope .
-_:c14n704 a owl:Restriction ;
+_:c14n706 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:trafficAgentTypeValue .
-_:c14n705 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:LaneSpecificationType .
-_:c14n706 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty openlabel_v2:SceneryZone .
 _:c14n707 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:SubjectVehicleSpeed .
+	owl:onProperty openlabel_v2:LaneSpecificationType .
 _:c14n708 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:LaneSpecificationDimensions .
-_:c14n709 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty openlabel_v2:SceneryFixedStructure .
+	owl:onProperty openlabel_v2:SceneryZone .
+_:c14n709 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:SubjectVehicleSpeed .
 _:c14n71 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:HorizontalStraights .
 _:c14n710 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:LaneSpecificationDimensions .
+_:c14n711 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:SceneryFixedStructure .
+_:c14n712 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:longitudinalDownSlopeValue .
-_:c14n711 rdf:first openlabel_v2:RoadTypeMinor ;
-	rdf:rest _:c14n376 .
-_:c14n712 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:MotionAway .
-_:c14n713 rdf:first openlabel_v2:SurfaceTypeLoose ;
-	rdf:rest _:c14n809 .
+_:c14n713 rdf:first openlabel_v2:RoadTypeMinor ;
+	rdf:rest _:c14n377 .
 _:c14n714 a owl:Restriction ;
 	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:MotionAway .
+_:c14n715 rdf:first openlabel_v2:SurfaceTypeLoose ;
+	rdf:rest _:c14n811 .
+_:c14n716 a owl:Restriction ;
+	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:SignsRegulatory .
-_:c14n715 a owl:Restriction ;
+_:c14n717 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:daySunElevationValue .
-_:c14n716 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:illuminationCloudinessValue .
-_:c14n717 rdf:first openlabel_v2:LaneTypeTram ;
-	rdf:rest rdf:nil .
 _:c14n718 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:TrafficAgentDensity .
-_:c14n719 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty openlabel_v2:TrafficFlowRate .
+	owl:onProperty openlabel_v2:illuminationCloudinessValue .
+_:c14n719 rdf:first openlabel_v2:LaneTypeTram ;
+	rdf:rest rdf:nil .
 _:c14n72 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:daySunElevationValue .
 _:c14n720 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:TrafficAgentDensity .
+_:c14n721 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:TrafficFlowRate .
+_:c14n722 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:LaneSpecificationTravelDirection .
-_:c14n721 a owl:Restriction ;
+_:c14n723 a owl:Restriction ;
 	owl:onProperty openlabel_v2:TrafficAgentDensity ;
-	owl:someValuesFrom _:c14n1096 .
-_:c14n722 a owl:Restriction ;
+	owl:someValuesFrom _:c14n1084 .
+_:c14n724 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:MotionTowards .
-_:c14n723 a owl:Restriction ;
+_:c14n725 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:MotionWalk .
-_:c14n724 a owl:Restriction ;
+_:c14n726 a owl:Restriction ;
 	owl:allValuesFrom openlabel_v2:SceneryTemporaryStructure ;
 	owl:onProperty openlabel_v2:SceneryTemporaryStructure .
-_:c14n725 rdf:first openlabel_v2:TransverseLanesTogether ;
-	rdf:rest _:c14n659 .
-_:c14n726 a owl:Restriction ;
+_:c14n727 rdf:first openlabel_v2:TransverseLanesTogether ;
+	rdf:rest _:c14n661 .
+_:c14n728 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:MotionCutIn .
-_:c14n727 a owl:Restriction ;
+_:c14n729 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:SceneryZone .
-_:c14n728 rdf:first openlabel_v2:RoadTypeRadial ;
-	rdf:rest _:c14n845 .
-_:c14n729 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty openlabel_v2:longitudinalUpSlopeValue .
 _:c14n73 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:MotionWalk .
-_:c14n730 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:TrafficAgentType .
+_:c14n730 rdf:first openlabel_v2:RoadTypeRadial ;
+	rdf:rest _:c14n848 .
 _:c14n731 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty openlabel_v2:LaneSpecificationLaneCount .
+	owl:onProperty openlabel_v2:longitudinalUpSlopeValue .
 _:c14n732 a owl:Restriction ;
-	owl:allValuesFrom linkml:Boolean ;
-	owl:onProperty openlabel_v2:LongitudinalUpSlope .
-_:c14n733 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:MotionReverse .
+	owl:onProperty openlabel_v2:TrafficAgentType .
+_:c14n733 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:LaneSpecificationLaneCount .
 _:c14n734 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
-	owl:onProperty openlabel_v2:MotionAccelerate .
-_:c14n735 rdf:first openlabel_v2:SunPositionLeft ;
-	rdf:rest _:c14n441 .
+	owl:onProperty openlabel_v2:LongitudinalUpSlope .
+_:c14n735 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:MotionReverse .
 _:c14n736 a owl:Restriction ;
-	owl:allValuesFrom _:c14n975 ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:MotionAccelerate .
+_:c14n737 rdf:first openlabel_v2:SunPositionLeft ;
+	rdf:rest _:c14n442 .
+_:c14n738 a owl:Restriction ;
+	owl:allValuesFrom _:c14n987 ;
 	owl:onProperty openlabel_v2:motionDecelerateValue .
-_:c14n737 a owl:Restriction ;
+_:c14n739 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:TrafficFlowRate .
-_:c14n738 rdf:first openlabel_v2:V2vCellular ;
-	rdf:rest _:c14n829 .
-_:c14n739 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:subjectVehicleSpeedValue .
 _:c14n74 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:ParticulatesPollution .
-_:c14n740 a owl:Restriction ;
+_:c14n740 rdf:first openlabel_v2:V2vCellular ;
+	rdf:rest _:c14n831 .
+_:c14n741 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:subjectVehicleSpeedValue .
+_:c14n742 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:LaneSpecificationMarking .
-_:c14n741 a owl:Restriction ;
+_:c14n743 a owl:Restriction ;
 	owl:onProperty openlabel_v2:LaneSpecificationLaneCount ;
-	owl:someValuesFrom _:c14n1111 .
-_:c14n742 a owl:Restriction ;
+	owl:someValuesFrom _:c14n1090 .
+_:c14n744 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:TrafficVolume .
-_:c14n743 a owl:Restriction ;
+_:c14n745 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:particulatesWaterValue .
-_:c14n744 a owl:Restriction ;
+_:c14n746 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:longitudinalDownSlopeValue .
-_:c14n745 a owl:Restriction ;
+_:c14n747 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:motionDecelerateValue .
-_:c14n746 a owl:Restriction ;
+_:c14n748 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:DrivableAreaSurfaceCondition .
-_:c14n747 a owl:Restriction ;
+_:c14n749 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:JunctionRoundabout .
-_:c14n748 a owl:Restriction ;
-	owl:maxCardinality 0 ;
-	owl:onProperty openlabel_v2:LaneSpecificationLaneCount .
-_:c14n749 a owl:Restriction ;
-	owl:maxCardinality 0 ;
-	owl:onProperty openlabel_v2:horizontalCurvesValue .
 _:c14n75 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:horizontalCurvesValue .
 _:c14n750 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationLaneCount .
+_:c14n751 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:horizontalCurvesValue .
+_:c14n752 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:ownerEmail .
-_:c14n751 a owl:Restriction ;
+_:c14n753 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:subjectVehicleSpeedValue .
-_:c14n752 a owl:Restriction ;
+_:c14n754 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:SignsInformation .
-_:c14n753 a owl:Restriction ;
+_:c14n755 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:trafficFlowRateValue .
-_:c14n754 a owl:Restriction ;
+_:c14n756 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:MotionOvertake .
-_:c14n755 a owl:Restriction ;
+_:c14n757 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:longitudinalDownSlopeValue .
-_:c14n756 owl:unionOf _:c14n997 .
-_:c14n757 a owl:Restriction ;
+_:c14n758 owl:unionOf _:c14n1022 .
+_:c14n759 a owl:Restriction ;
 	owl:allValuesFrom linkml:Decimal ;
 	owl:onProperty openlabel_v2:weatherSnowValue .
-_:c14n758 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty openlabel_v2:IlluminationCloudiness .
-_:c14n759 rdf:first openlabel_v2:ParticulatesVolcanic ;
-	rdf:rest _:c14n603 .
 _:c14n76 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:JunctionRoundabout .
-_:c14n760 rdf:first openlabel_v2:ZoneRegion ;
+_:c14n760 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:IlluminationCloudiness .
+_:c14n761 rdf:first openlabel_v2:ParticulatesVolcanic ;
+	rdf:rest _:c14n605 .
+_:c14n762 rdf:first openlabel_v2:ZoneRegion ;
 	rdf:rest _:c14n221 .
-_:c14n761 a owl:Restriction ;
+_:c14n763 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:longitudinalUpSlopeValue .
-_:c14n762 a owl:Restriction ;
+_:c14n764 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:ParticulatesDust .
-_:c14n763 a owl:Restriction ;
+_:c14n765 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:MotionTowards .
-_:c14n764 a owl:Restriction ;
+_:c14n766 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:illuminationCloudinessValue .
-_:c14n765 a owl:Restriction ;
+_:c14n767 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:ScenerySpecialStructure .
-_:c14n766 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:DrivableAreaSurfaceCondition .
-_:c14n767 a owl:Restriction ;
-	owl:allValuesFrom openlabel_v2:IlluminationArtificial ;
-	owl:onProperty openlabel_v2:IlluminationArtificial .
 _:c14n768 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:subjectVehicleSpeedValue .
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceCondition .
 _:c14n769 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:IlluminationArtificial ;
+	owl:onProperty openlabel_v2:IlluminationArtificial .
+_:c14n77 rdf:first openlabel_v2:LaneTypeTraffic ;
+	rdf:rest _:c14n719 .
+_:c14n770 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:subjectVehicleSpeedValue .
+_:c14n771 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:scenarioCreatedDate .
-_:c14n77 rdf:first openlabel_v2:LaneTypeTraffic ;
-	rdf:rest _:c14n717 .
-_:c14n770 a owl:Restriction ;
+_:c14n772 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:weatherWindValue .
-_:c14n771 a owl:Restriction ;
+_:c14n773 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
 	owl:onProperty openlabel_v2:MotionDecelerate .
-_:c14n772 a owl:Restriction ;
+_:c14n774 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:LongitudinalLevelPlane .
-_:c14n773 a owl:Restriction ;
+_:c14n775 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:particulatesWaterValue .
-_:c14n774 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:SignsInformation .
-_:c14n775 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty openlabel_v2:TrafficVolume .
 _:c14n776 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:laneSpecificationDimensionsValue .
+	owl:onProperty openlabel_v2:SignsInformation .
 _:c14n777 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:TrafficVolume .
+_:c14n778 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:laneSpecificationDimensionsValue .
+_:c14n779 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
 	owl:onProperty openlabel_v2:ParticulatesMarine .
-_:c14n778 a owl:Restriction ;
-	owl:onProperty openlabel_v2:weatherWindValue ;
-	owl:someValuesFrom linkml:String .
-_:c14n779 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty openlabel_v2:DrivableAreaSurfaceType .
 _:c14n78 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:ParticulatesPollution .
 _:c14n780 a owl:Restriction ;
+	owl:onProperty openlabel_v2:weatherWindValue ;
+	owl:someValuesFrom linkml:String .
+_:c14n781 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceType .
+_:c14n782 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:longitudinalDownSlopeValue .
-_:c14n781 rdf:first openlabel_v2:WarningSignsUniformFullTime ;
-	rdf:rest _:c14n442 .
-_:c14n782 a owl:Restriction ;
+_:c14n783 rdf:first openlabel_v2:WarningSignsUniformFullTime ;
+	rdf:rest _:c14n443 .
+_:c14n784 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:ScenerySpecialStructure .
-_:c14n783 a owl:Restriction ;
+_:c14n785 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:IlluminationLowLight .
-_:c14n784 a owl:Restriction ;
+_:c14n786 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:LaneSpecificationDimensions .
-_:c14n785 a owl:Restriction ;
+_:c14n787 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:GeometryTransverse .
-_:c14n786 a owl:Restriction ;
+_:c14n788 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:IlluminationLowLight .
-_:c14n787 a owl:Restriction ;
+_:c14n789 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:WeatherSnow .
-_:c14n788 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:SceneryFixedStructure .
-_:c14n789 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:licenseURI .
 _:c14n79 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:horizontalCurvesValue .
 _:c14n790 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:SceneryFixedStructure .
+_:c14n791 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:licenseURI .
+_:c14n792 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:laneSpecificationDimensionsValue .
-_:c14n791 a owl:Restriction ;
+_:c14n793 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:weatherSnowValue .
-_:c14n792 a owl:Restriction ;
+_:c14n794 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:WeatherRain .
-_:c14n793 a owl:Restriction ;
+_:c14n795 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:SignsRegulatory .
-_:c14n794 a owl:Restriction ;
+_:c14n796 a owl:Restriction ;
 	owl:minCardinality 1 ;
 	owl:onProperty openlabel_v2:maxValue .
-_:c14n795 rdf:first openlabel_v2:SpecialStructurePedestrianCrossing ;
-	rdf:rest _:c14n589 .
-_:c14n796 rdf:first openlabel_v2:CommunicationSignalRight ;
+_:c14n797 rdf:first openlabel_v2:SpecialStructurePedestrianCrossing ;
+	rdf:rest _:c14n591 .
+_:c14n798 rdf:first openlabel_v2:CommunicationSignalRight ;
 	rdf:rest _:c14n9 .
-_:c14n797 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:LongitudinalDownSlope .
-_:c14n798 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:particulatesWaterValue .
 _:c14n799 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:WeatherRain .
+	owl:onProperty openlabel_v2:LongitudinalDownSlope .
 _:c14n8 a owl:Restriction ;
 	owl:onProperty openlabel_v2:SubjectVehicleSpeed ;
-	owl:someValuesFrom _:c14n1093 .
+	owl:someValuesFrom _:c14n1099 .
 _:c14n80 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
 	owl:onProperty openlabel_v2:MotionRun .
-_:c14n800 rdf:first openlabel_v2:SurfaceFeatureCrack ;
-	rdf:rest _:c14n101 .
+_:c14n800 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:particulatesWaterValue .
 _:c14n801 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:WeatherRain .
+_:c14n802 rdf:first openlabel_v2:SurfaceFeatureCrack ;
+	rdf:rest _:c14n101 .
+_:c14n803 a owl:Restriction ;
 	owl:allValuesFrom openlabel_v2:DrivableAreaSurfaceFeature ;
 	owl:onProperty openlabel_v2:DrivableAreaSurfaceFeature .
-_:c14n802 rdf:first openlabel_v2:LowLightAmbient ;
-	rdf:rest _:c14n699 .
-_:c14n803 a owl:Restriction ;
+_:c14n804 rdf:first openlabel_v2:LowLightAmbient ;
+	rdf:rest _:c14n701 .
+_:c14n805 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:minValue .
-_:c14n804 a owl:Restriction ;
+_:c14n806 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:WeatherRain .
-_:c14n805 a owl:Restriction ;
+_:c14n807 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
 	owl:onProperty openlabel_v2:MotionReverse .
-_:c14n806 a owl:Restriction ;
+_:c14n808 a owl:Restriction ;
 	owl:onProperty openlabel_v2:motionAccelerateValue ;
 	owl:someValuesFrom linkml:String .
-_:c14n807 a owl:Restriction ;
+_:c14n809 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:laneSpecificationLaneCountValue .
-_:c14n808 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:TrafficAgentDensity .
-_:c14n809 rdf:first openlabel_v2:SurfaceTypeSegmented ;
-	rdf:rest _:c14n27 .
 _:c14n81 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:MotionSlide .
 _:c14n810 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:TrafficAgentDensity .
+_:c14n811 rdf:first openlabel_v2:SurfaceTypeSegmented ;
+	rdf:rest _:c14n27 .
+_:c14n812 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:weatherWindValue .
-_:c14n811 a owl:Restriction ;
+_:c14n813 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:ParticulatesPollution .
-_:c14n812 rdf:first openlabel_v2:SpecialStructureTollPlaza ;
-	rdf:rest _:c14n534 .
-_:c14n813 a owl:Restriction ;
+_:c14n814 rdf:first openlabel_v2:SpecialStructureTollPlaza ;
+	rdf:rest _:c14n536 .
+_:c14n815 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:scenarioDefinitionLanguageURI .
-_:c14n814 a owl:Restriction ;
+_:c14n816 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:RainType .
-_:c14n815 a owl:Restriction ;
+_:c14n817 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:SignsRegulatory .
-_:c14n816 a owl:Restriction ;
-	owl:maxCardinality 0 ;
-	owl:onProperty openlabel_v2:LongitudinalUpSlope .
-_:c14n817 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:scenarioVisualisationURL .
 _:c14n818 a owl:Restriction ;
 	owl:maxCardinality 0 ;
-	owl:onProperty openlabel_v2:DaySunElevation .
+	owl:onProperty openlabel_v2:LongitudinalUpSlope .
 _:c14n819 a owl:Restriction ;
-	owl:allValuesFrom linkml:Boolean ;
-	owl:onProperty openlabel_v2:TrafficAgentDensity .
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:scenarioVisualisationURL .
 _:c14n82 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:MotionCutOut .
-_:c14n820 rdf:first openlabel_v2:TransverseBarriers ;
-	rdf:rest _:c14n365 .
+_:c14n820 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:DaySunElevation .
 _:c14n821 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:TrafficAgentDensity .
+_:c14n822 rdf:first openlabel_v2:TransverseBarriers ;
+	rdf:rest _:c14n366 .
+_:c14n823 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:DrivableAreaType .
-_:c14n822 a owl:Restriction ;
+_:c14n824 a owl:Restriction ;
 	owl:onProperty openlabel_v2:LongitudinalUpSlope ;
-	owl:someValuesFrom _:c14n1117 .
-_:c14n823 a owl:Restriction ;
+	owl:someValuesFrom _:c14n1105 .
+_:c14n825 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:laneSpecificationLaneCountValue .
-_:c14n824 a owl:Restriction ;
+_:c14n826 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
 	owl:onProperty openlabel_v2:WeatherWind .
-_:c14n825 a owl:Restriction ;
+_:c14n827 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:particulatesWaterValue .
-_:c14n826 a owl:Restriction ;
+_:c14n828 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:JunctionIntersection .
-_:c14n827 a owl:Restriction ;
+_:c14n829 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:RoadUserAnimal .
-_:c14n828 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty openlabel_v2:HorizontalStraights .
-_:c14n829 rdf:first openlabel_v2:V2vSatellite ;
-	rdf:rest _:c14n64 .
 _:c14n83 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:LongitudinalLevelPlane .
 _:c14n830 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:HorizontalStraights .
+_:c14n831 rdf:first openlabel_v2:V2vSatellite ;
+	rdf:rest _:c14n64 .
+_:c14n832 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:scenarioDescription .
-_:c14n831 a owl:Restriction ;
+_:c14n833 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:maxValue .
-_:c14n832 rdf:first openlabel_v2:SurfaceFeatureSwell ;
+_:c14n834 rdf:first openlabel_v2:SurfaceFeatureSwell ;
 	rdf:rest rdf:nil .
-_:c14n833 a owl:Restriction ;
-	owl:maxCardinality 0 ;
-	owl:onProperty openlabel_v2:EnvironmentParticulates .
-_:c14n834 a owl:Restriction ;
+_:c14n835 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:scenarioVersion .
-_:c14n835 rdf:first openlabel_v2:TravelDirectionRight ;
-	rdf:rest rdf:nil .
+	owl:onProperty openlabel_v2:scenarioComment .
 _:c14n836 a owl:Restriction ;
 	owl:maxCardinality 0 ;
-	owl:onProperty openlabel_v2:DaySunPosition .
+	owl:onProperty openlabel_v2:EnvironmentParticulates .
 _:c14n837 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:ParticulatesVolcanic .
-_:c14n838 a owl:Restriction ;
-	owl:maxCardinality 0 ;
-	owl:onProperty openlabel_v2:WeatherSnow .
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:scenarioVersion .
+_:c14n838 rdf:first openlabel_v2:TravelDirectionRight ;
+	rdf:rest rdf:nil .
 _:c14n839 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:SceneryFixedStructure .
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:DaySunPosition .
 _:c14n84 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
 	owl:onProperty openlabel_v2:SubjectVehicleSpeed .
 _:c14n840 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:ParticulatesVolcanic .
+_:c14n841 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:WeatherSnow .
+_:c14n842 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:SceneryFixedStructure .
+_:c14n843 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:JunctionRoundabout .
-_:c14n841 rdf:first openlabel_v2:RoundaboutCompactSignal ;
-	rdf:rest _:c14n233 .
-_:c14n842 rdf:first openlabel_v2:MotorwayUnmanaged ;
-	rdf:rest _:c14n522 .
-_:c14n843 a owl:Restriction ;
+_:c14n844 rdf:first openlabel_v2:RoundaboutCompactSignal ;
+	rdf:rest _:c14n234 .
+_:c14n845 rdf:first openlabel_v2:MotorwayUnmanaged ;
+	rdf:rest _:c14n524 .
+_:c14n846 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:WeatherSnow .
-_:c14n844 a owl:Restriction ;
+_:c14n847 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:DaySunElevation .
-_:c14n845 rdf:first openlabel_v2:RoadTypeShared ;
+_:c14n848 rdf:first openlabel_v2:RoadTypeShared ;
 	rdf:rest _:c14n176 .
-_:c14n846 a owl:Restriction ;
+_:c14n849 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:DrivableAreaSurfaceCondition .
-_:c14n847 rdf:first openlabel_v2:EdgeSolidBarriers ;
-	rdf:rest _:c14n292 .
-_:c14n848 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:WeatherWind .
-_:c14n849 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:WeatherSnow .
 _:c14n85 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:LaneSpecificationType .
-_:c14n850 a owl:Restriction ;
+_:c14n850 rdf:first openlabel_v2:EdgeSolidBarriers ;
+	rdf:rest _:c14n293 .
+_:c14n851 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:WeatherWind .
+_:c14n852 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:WeatherSnow .
+_:c14n853 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
 	owl:onProperty openlabel_v2:MotionLaneChangeLeft .
-_:c14n851 a owl:Restriction ;
+_:c14n854 a owl:Restriction ;
 	owl:onProperty openlabel_v2:MotionDecelerate ;
-	owl:someValuesFrom _:c14n1072 .
-_:c14n852 a owl:Restriction ;
+	owl:someValuesFrom _:c14n1078 .
+_:c14n855 a owl:Restriction ;
 	owl:allValuesFrom openlabel_v2:EnvironmentParticulates ;
 	owl:onProperty openlabel_v2:EnvironmentParticulates .
-_:c14n853 rdf:first openlabel_v2:RoundaboutLargeNosignal ;
-	rdf:rest _:c14n525 .
-_:c14n854 a owl:Restriction ;
+_:c14n856 rdf:first openlabel_v2:RoundaboutLargeNosignal ;
+	rdf:rest _:c14n527 .
+_:c14n857 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:DaySunPosition .
-_:c14n855 a owl:Restriction ;
+_:c14n858 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:particulatesWaterValue .
-_:c14n856 rdf:first openlabel_v2:MotorwayManaged ;
-	rdf:rest _:c14n842 .
-_:c14n857 a owl:Restriction ;
-	owl:allValuesFrom _:c14n966 ;
-	owl:onProperty openlabel_v2:laneSpecificationLaneCountValue .
-_:c14n858 a owl:Restriction ;
-	owl:allValuesFrom openlabel_v2:ConnectivityPositioning ;
-	owl:onProperty openlabel_v2:ConnectivityPositioning .
-_:c14n859 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:TrafficSpecialVehicle .
+_:c14n859 rdf:first openlabel_v2:MotorwayManaged ;
+	rdf:rest _:c14n845 .
 _:c14n86 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:daySunElevationValue .
 _:c14n860 a owl:Restriction ;
+	owl:allValuesFrom _:c14n975 ;
+	owl:onProperty openlabel_v2:laneSpecificationLaneCountValue .
+_:c14n861 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:ConnectivityPositioning ;
+	owl:onProperty openlabel_v2:ConnectivityPositioning .
+_:c14n862 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:TrafficSpecialVehicle .
+_:c14n863 a owl:Restriction ;
 	owl:allValuesFrom openlabel_v2:LaneSpecificationTravelDirection ;
 	owl:onProperty openlabel_v2:LaneSpecificationTravelDirection .
-_:c14n861 a owl:Restriction ;
+_:c14n864 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
 	owl:onProperty openlabel_v2:ParticulatesPollution .
-_:c14n862 rdf:first openlabel_v2:RoundaboutNormalNosignal ;
-	rdf:rest _:c14n593 .
-_:c14n863 rdf:first openlabel_v2:SunPositionBehind ;
-	rdf:rest _:c14n496 .
-_:c14n864 a owl:Restriction ;
+_:c14n865 rdf:first openlabel_v2:RoundaboutNormalNosignal ;
+	rdf:rest _:c14n595 .
+_:c14n866 rdf:first openlabel_v2:SunPositionBehind ;
+	rdf:rest _:c14n498 .
+_:c14n867 a owl:Restriction ;
 	owl:allValuesFrom linkml:Decimal ;
 	owl:onProperty openlabel_v2:maxValue .
-_:c14n865 a owl:Restriction ;
+_:c14n868 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:ParticulatesMarine .
-_:c14n866 a owl:Restriction ;
+_:c14n869 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:LongitudinalDownSlope .
-_:c14n867 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty openlabel_v2:MotionTurnRight .
-_:c14n868 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:SignsWarning .
-_:c14n869 a owl:Restriction ;
-	owl:maxCardinality 0 ;
-	owl:onProperty openlabel_v2:weatherRainValue .
 _:c14n87 rdf:first openlabel_v2:CommunicationSignalHazard ;
-	rdf:rest _:c14n615 .
+	rdf:rest _:c14n617 .
 _:c14n870 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty openlabel_v2:motionDriveValue .
+	owl:onProperty openlabel_v2:MotionTurnRight .
 _:c14n871 a owl:Restriction ;
-	owl:onProperty openlabel_v2:laneSpecificationDimensionsValue ;
-	owl:someValuesFrom linkml:String .
-_:c14n872 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:ParticulatesDust .
+	owl:onProperty openlabel_v2:SignsWarning .
+_:c14n872 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:weatherRainValue .
 _:c14n873 a owl:Restriction ;
 	owl:maxCardinality 1 ;
-	owl:onProperty openlabel_v2:scenarioDescription .
+	owl:onProperty openlabel_v2:motionDriveValue .
 _:c14n874 a owl:Restriction ;
+	owl:onProperty openlabel_v2:laneSpecificationDimensionsValue ;
+	owl:someValuesFrom linkml:String .
+_:c14n875 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:ParticulatesDust .
+_:c14n876 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:scenarioDescription .
+_:c14n877 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:DrivableAreaSurfaceFeature .
-_:c14n875 a owl:Restriction ;
+_:c14n878 a owl:Restriction ;
 	owl:maxCardinality 0 ;
 	owl:onProperty openlabel_v2:TrafficVolume .
-_:c14n876 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:ParticulatesDust .
-_:c14n877 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty openlabel_v2:DrivableAreaSurfaceFeature .
-_:c14n878 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:IlluminationCloudiness .
 _:c14n879 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:trafficVolumeValue .
+	owl:onProperty openlabel_v2:ParticulatesDust .
 _:c14n88 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:weatherWindValue .
 _:c14n880 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceFeature .
+_:c14n881 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:IlluminationCloudiness .
+_:c14n882 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:trafficVolumeValue .
+_:c14n883 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:LongitudinalDownSlope .
-_:c14n881 a owl:Restriction ;
+_:c14n884 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
 	owl:onProperty openlabel_v2:ParticulatesDust .
-_:c14n882 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:TrafficAgentDensity .
-_:c14n883 a owl:Restriction ;
-	owl:allValuesFrom linkml:Boolean ;
-	owl:onProperty openlabel_v2:RoadUserAnimal .
-_:c14n884 a owl:Restriction ;
-	owl:allValuesFrom _:c14n990 ;
-	owl:onProperty openlabel_v2:laneSpecificationDimensionsValue .
 _:c14n885 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:ParticulatesVolcanic .
+	owl:onProperty openlabel_v2:TrafficAgentDensity .
 _:c14n886 a owl:Restriction ;
-	owl:onProperty openlabel_v2:IlluminationCloudiness ;
-	owl:someValuesFrom _:c14n1087 .
-_:c14n887 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
-	owl:onProperty openlabel_v2:MotionTurnLeft .
+	owl:onProperty openlabel_v2:RoadUserAnimal .
+_:c14n887 a owl:Restriction ;
+	owl:allValuesFrom _:c14n984 ;
+	owl:onProperty openlabel_v2:laneSpecificationDimensionsValue .
 _:c14n888 a owl:Restriction ;
-	owl:maxCardinality 0 ;
-	owl:onProperty openlabel_v2:LaneSpecificationTravelDirection .
-_:c14n889 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:weatherSnowValue .
+	owl:onProperty openlabel_v2:ParticulatesVolcanic .
+_:c14n889 a owl:Restriction ;
+	owl:onProperty openlabel_v2:IlluminationCloudiness ;
+	owl:someValuesFrom _:c14n1108 .
 _:c14n89 a owl:Restriction ;
-	owl:allValuesFrom _:c14n1023 ;
+	owl:allValuesFrom _:c14n1026 ;
 	owl:onProperty openlabel_v2:trafficVolumeValue .
 _:c14n890 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty openlabel_v2:MotionAccelerate .
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:MotionTurnLeft .
 _:c14n891 a owl:Restriction ;
-	owl:allValuesFrom linkml:Decimal ;
-	owl:onProperty openlabel_v2:hasLowerBound .
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationTravelDirection .
 _:c14n892 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:scenarioVisualisationURL .
+	owl:onProperty openlabel_v2:weatherSnowValue .
 _:c14n893 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:MotionAccelerate .
+_:c14n894 a owl:Restriction ;
+	owl:allValuesFrom linkml:Decimal ;
+	owl:onProperty openlabel_v2:hasLowerBound .
+_:c14n895 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:scenarioVisualisationURL .
+_:c14n896 a owl:Restriction ;
 	owl:allValuesFrom linkml:Boolean ;
 	owl:onProperty openlabel_v2:MotionStop .
-_:c14n894 a owl:Restriction ;
+_:c14n897 a owl:Restriction ;
 	owl:allValuesFrom openlabel_v2:RoadUserVehicle ;
 	owl:onProperty openlabel_v2:RoadUserVehicle .
-_:c14n895 a owl:Restriction ;
+_:c14n898 a owl:Restriction ;
 	owl:allValuesFrom linkml:Decimal ;
 	owl:onProperty openlabel_v2:minValue .
-_:c14n896 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:laneSpecificationLaneCountValue .
-_:c14n897 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty openlabel_v2:laneSpecificationDimensionsValue .
-_:c14n898 a owl:Restriction ;
-	owl:maxCardinality 0 ;
-	owl:onProperty openlabel_v2:DrivableAreaType .
 _:c14n899 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:JunctionRoundabout .
+	owl:onProperty openlabel_v2:laneSpecificationLaneCountValue .
 _:c14n9 rdf:first openlabel_v2:CommunicationSignalSlowing ;
-	rdf:rest _:c14n476 .
+	rdf:rest _:c14n478 .
 _:c14n90 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:JunctionRoundabout .
 _:c14n900 a owl:Restriction ;
-	owl:allValuesFrom linkml:Boolean ;
-	owl:onProperty openlabel_v2:LaneSpecificationMarking .
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:laneSpecificationDimensionsValue .
 _:c14n901 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:IlluminationArtificial .
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:DrivableAreaType .
 _:c14n902 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:HorizontalCurves .
+	owl:onProperty openlabel_v2:JunctionRoundabout .
 _:c14n903 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:LaneSpecificationMarking .
+_:c14n904 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:IlluminationArtificial .
+_:c14n905 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:HorizontalCurves .
+_:c14n906 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
 	owl:onProperty openlabel_v2:weatherRainValue .
-_:c14n904 rdf:first openlabel_v2:CommunicationV2i ;
+_:c14n907 rdf:first openlabel_v2:CommunicationV2i ;
 	rdf:rest _:c14n96 .
-_:c14n905 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:scenarioName .
-_:c14n906 a owl:Restriction ;
-	owl:maxCardinality 1 ;
-	owl:onProperty openlabel_v2:RoadUser .
-_:c14n907 a owl:Restriction ;
-	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:ownerURL .
 _:c14n908 a owl:Restriction ;
 	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:longitudinalUpSlopeValue .
+	owl:onProperty openlabel_v2:scenarioName .
 _:c14n909 a owl:Restriction ;
-	owl:minCardinality 0 ;
-	owl:onProperty openlabel_v2:LaneSpecificationType .
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:RoadUser .
 _:c14n91 rdf:first openlabel_v2:InformationSignsUniformTemporary ;
-	rdf:rest _:c14n675 .
+	rdf:rest _:c14n677 .
 _:c14n910 a owl:Restriction ;
 	owl:allValuesFrom linkml:String ;
-	owl:onProperty openlabel_v2:ownerName .
+	owl:onProperty openlabel_v2:ownerURL .
 _:c14n911 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:longitudinalUpSlopeValue .
+_:c14n912 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationType .
+_:c14n913 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:ownerName .
+_:c14n914 a owl:Restriction ;
 	owl:maxCardinality 1 ;
 	owl:onProperty openlabel_v2:Odd .
-_:c14n912 rdf:first openlabel_v2:Odd ;
-	rdf:rest rdf:nil .
-_:c14n913 rdf:first _:c14n670 ;
-	rdf:rest _:c14n912 .
-_:c14n914 rdfs:subClassOf _:c14n822 ;
-	owl:intersectionOf _:c14n913 .
 _:c14n915 rdf:first openlabel_v2:Odd ;
 	rdf:rest rdf:nil .
-_:c14n916 rdf:first _:c14n871 ;
+_:c14n916 rdf:first _:c14n349 ;
 	rdf:rest _:c14n915 .
-_:c14n917 rdfs:subClassOf _:c14n214 ;
+_:c14n917 rdfs:subClassOf _:c14n743 ;
 	owl:intersectionOf _:c14n916 .
 _:c14n918 rdf:first openlabel_v2:Odd ;
 	rdf:rest rdf:nil .
-_:c14n919 rdf:first _:c14n7 ;
+_:c14n919 rdf:first _:c14n490 ;
 	rdf:rest _:c14n918 .
 _:c14n92 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:SceneryTemporaryStructure .
-_:c14n920 rdfs:subClassOf _:c14n473 ;
+_:c14n920 rdfs:subClassOf _:c14n202 ;
 	owl:intersectionOf _:c14n919 .
 _:c14n921 rdf:first openlabel_v2:Odd ;
 	rdf:rest rdf:nil .
-_:c14n922 rdf:first _:c14n465 ;
+_:c14n922 rdf:first _:c14n584 ;
 	rdf:rest _:c14n921 .
-_:c14n923 rdfs:subClassOf _:c14n673 ;
+_:c14n923 rdfs:subClassOf _:c14n287 ;
 	owl:intersectionOf _:c14n922 .
 _:c14n924 rdf:first openlabel_v2:Odd ;
 	rdf:rest rdf:nil .
-_:c14n925 rdf:first _:c14n152 ;
+_:c14n925 rdf:first _:c14n7 ;
 	rdf:rest _:c14n924 .
-_:c14n926 rdfs:subClassOf _:c14n449 ;
+_:c14n926 rdfs:subClassOf _:c14n475 ;
 	owl:intersectionOf _:c14n925 .
 _:c14n927 rdf:first openlabel_v2:Odd ;
 	rdf:rest rdf:nil .
-_:c14n928 rdf:first _:c14n640 ;
+_:c14n928 rdf:first _:c14n642 ;
 	rdf:rest _:c14n927 .
 _:c14n929 rdfs:subClassOf _:c14n133 ;
 	owl:intersectionOf _:c14n928 .
@@ -4163,148 +4177,148 @@ _:c14n93 a owl:Restriction ;
 	owl:onProperty openlabel_v2:GeometryTransverse .
 _:c14n930 rdf:first openlabel_v2:Odd ;
 	rdf:rest rdf:nil .
-_:c14n931 rdf:first _:c14n106 ;
+_:c14n931 rdf:first _:c14n653 ;
 	rdf:rest _:c14n930 .
-_:c14n932 rdfs:subClassOf _:c14n8 ;
+_:c14n932 rdfs:subClassOf _:c14n6 ;
 	owl:intersectionOf _:c14n931 .
 _:c14n933 rdf:first openlabel_v2:Odd ;
 	rdf:rest rdf:nil .
-_:c14n934 rdf:first _:c14n651 ;
+_:c14n934 rdf:first _:c14n185 ;
 	rdf:rest _:c14n933 .
-_:c14n935 rdfs:subClassOf _:c14n6 ;
+_:c14n935 rdfs:subClassOf _:c14n889 ;
 	owl:intersectionOf _:c14n934 .
 _:c14n936 rdf:first openlabel_v2:Odd ;
 	rdf:rest rdf:nil .
-_:c14n937 rdf:first _:c14n502 ;
+_:c14n937 rdf:first _:c14n418 ;
 	rdf:rest _:c14n936 .
-_:c14n938 rdfs:subClassOf _:c14n721 ;
+_:c14n938 rdfs:subClassOf _:c14n172 ;
 	owl:intersectionOf _:c14n937 .
 _:c14n939 rdf:first openlabel_v2:Odd ;
 	rdf:rest rdf:nil .
 _:c14n94 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:TrafficVolume .
-_:c14n940 rdf:first _:c14n417 ;
+_:c14n940 rdf:first _:c14n106 ;
 	rdf:rest _:c14n939 .
-_:c14n941 rdfs:subClassOf _:c14n172 ;
+_:c14n941 rdfs:subClassOf _:c14n8 ;
 	owl:intersectionOf _:c14n940 .
 _:c14n942 rdf:first openlabel_v2:Odd ;
 	rdf:rest rdf:nil .
-_:c14n943 rdf:first _:c14n488 ;
+_:c14n943 rdf:first _:c14n780 ;
 	rdf:rest _:c14n942 .
-_:c14n944 rdfs:subClassOf _:c14n202 ;
+_:c14n944 rdfs:subClassOf _:c14n332 ;
 	owl:intersectionOf _:c14n943 .
 _:c14n945 rdf:first openlabel_v2:Odd ;
 	rdf:rest rdf:nil .
-_:c14n946 rdf:first _:c14n582 ;
+_:c14n946 rdf:first _:c14n874 ;
 	rdf:rest _:c14n945 .
-_:c14n947 rdfs:subClassOf _:c14n286 ;
+_:c14n947 rdfs:subClassOf _:c14n214 ;
 	owl:intersectionOf _:c14n946 .
 _:c14n948 rdf:first openlabel_v2:Odd ;
 	rdf:rest rdf:nil .
-_:c14n949 rdf:first _:c14n168 ;
+_:c14n949 rdf:first _:c14n504 ;
 	rdf:rest _:c14n948 .
 _:c14n95 rdf:first openlabel_v2:LaneTypeEmergency ;
-	rdf:rest _:c14n564 .
-_:c14n950 rdfs:subClassOf _:c14n118 ;
+	rdf:rest _:c14n566 .
+_:c14n950 rdfs:subClassOf _:c14n723 ;
 	owl:intersectionOf _:c14n949 .
 _:c14n951 rdf:first openlabel_v2:Odd ;
 	rdf:rest rdf:nil .
-_:c14n952 rdf:first _:c14n185 ;
+_:c14n952 rdf:first _:c14n168 ;
 	rdf:rest _:c14n951 .
-_:c14n953 rdfs:subClassOf _:c14n886 ;
+_:c14n953 rdfs:subClassOf _:c14n118 ;
 	owl:intersectionOf _:c14n952 .
 _:c14n954 rdf:first openlabel_v2:Odd ;
 	rdf:rest rdf:nil .
-_:c14n955 rdf:first _:c14n778 ;
+_:c14n955 rdf:first _:c14n152 ;
 	rdf:rest _:c14n954 .
-_:c14n956 rdfs:subClassOf _:c14n331 ;
+_:c14n956 rdfs:subClassOf _:c14n450 ;
 	owl:intersectionOf _:c14n955 .
 _:c14n957 rdf:first openlabel_v2:Odd ;
 	rdf:rest rdf:nil .
-_:c14n958 rdf:first _:c14n348 ;
+_:c14n958 rdf:first _:c14n672 ;
 	rdf:rest _:c14n957 .
-_:c14n959 rdfs:subClassOf _:c14n741 ;
+_:c14n959 rdfs:subClassOf _:c14n824 ;
 	owl:intersectionOf _:c14n958 .
 _:c14n96 rdf:first openlabel_v2:V2iCellular ;
-	rdf:rest _:c14n443 .
-_:c14n960 owl:unionOf _:c14n961 .
-_:c14n961 rdf:first openlabel_v2:RoadUserHuman ;
-	rdf:rest _:c14n962 .
-_:c14n962 rdf:first openlabel_v2:RoadUserVehicle ;
+	rdf:rest _:c14n444 .
+_:c14n960 rdf:first openlabel_v2:Odd ;
 	rdf:rest rdf:nil .
+_:c14n961 rdf:first _:c14n467 ;
+	rdf:rest _:c14n960 .
+_:c14n962 rdfs:subClassOf _:c14n675 ;
+	owl:intersectionOf _:c14n961 .
 _:c14n963 owl:unionOf _:c14n964 .
 _:c14n964 rdf:first linkml:Decimal ;
 	rdf:rest _:c14n965 .
 _:c14n965 rdf:first openlabel_v2:QuantitativeValue ;
 	rdf:rest rdf:nil .
 _:c14n966 owl:unionOf _:c14n967 .
-_:c14n967 rdf:first _:c14n968 ;
-	rdf:rest _:c14n974 .
-_:c14n968 a rdfs:Datatype ;
-	owl:intersectionOf _:c14n969 .
-_:c14n969 rdf:first linkml:Integer ;
-	rdf:rest _:c14n970 .
+_:c14n967 rdf:first linkml:Decimal ;
+	rdf:rest _:c14n968 .
+_:c14n968 rdf:first openlabel_v2:QuantitativeValue ;
+	rdf:rest rdf:nil .
+_:c14n969 owl:unionOf _:c14n970 .
 _:c14n97 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:weatherRainValue .
-_:c14n970 rdf:first _:c14n971 ;
+_:c14n970 rdf:first linkml:Decimal ;
+	rdf:rest _:c14n971 .
+_:c14n971 rdf:first openlabel_v2:QuantitativeValue ;
 	rdf:rest rdf:nil .
-_:c14n971 a rdfs:Datatype ;
-	owl:onDatatype xsd:integer ;
-	owl:withRestrictions _:c14n972 .
-_:c14n972 rdf:first _:c14n973 ;
-	rdf:rest rdf:nil .
-_:c14n973 xsd:minInclusive 1 .
-_:c14n974 rdf:first openlabel_v2:QuantitativeValue ;
+_:c14n972 owl:unionOf _:c14n973 .
+_:c14n973 rdf:first openlabel_v2:RoadUserHuman ;
+	rdf:rest _:c14n974 .
+_:c14n974 rdf:first openlabel_v2:RoadUserVehicle ;
 	rdf:rest rdf:nil .
 _:c14n975 owl:unionOf _:c14n976 .
-_:c14n976 rdf:first linkml:Decimal ;
-	rdf:rest _:c14n977 .
-_:c14n977 rdf:first openlabel_v2:QuantitativeValue ;
+_:c14n976 rdf:first _:c14n977 ;
+	rdf:rest _:c14n983 .
+_:c14n977 a rdfs:Datatype ;
+	owl:intersectionOf _:c14n978 .
+_:c14n978 rdf:first linkml:Integer ;
+	rdf:rest _:c14n979 .
+_:c14n979 rdf:first _:c14n980 ;
 	rdf:rest rdf:nil .
-_:c14n978 owl:unionOf _:c14n979 .
-_:c14n979 rdf:first linkml:Decimal ;
-	rdf:rest _:c14n980 .
 _:c14n98 rdf:first openlabel_v2:LaneTypeBus ;
-	rdf:rest _:c14n621 .
-_:c14n980 rdf:first openlabel_v2:QuantitativeValue ;
-	rdf:rest rdf:nil .
-_:c14n981 owl:unionOf _:c14n982 .
-_:c14n982 rdf:first _:c14n983 ;
-	rdf:rest _:c14n989 .
-_:c14n983 a rdfs:Datatype ;
-	owl:intersectionOf _:c14n984 .
-_:c14n984 rdf:first linkml:Integer ;
-	rdf:rest _:c14n985 .
-_:c14n985 rdf:first _:c14n986 ;
-	rdf:rest rdf:nil .
-_:c14n986 a rdfs:Datatype ;
+	rdf:rest _:c14n623 .
+_:c14n980 a rdfs:Datatype ;
 	owl:onDatatype xsd:integer ;
-	owl:withRestrictions _:c14n987 .
-_:c14n987 rdf:first _:c14n988 ;
+	owl:withRestrictions _:c14n981 .
+_:c14n981 rdf:first _:c14n982 ;
 	rdf:rest rdf:nil .
-_:c14n988 xsd:minInclusive 0 .
+_:c14n982 xsd:minInclusive 1 .
+_:c14n983 rdf:first openlabel_v2:QuantitativeValue ;
+	rdf:rest rdf:nil .
+_:c14n984 owl:unionOf _:c14n985 .
+_:c14n985 rdf:first linkml:Decimal ;
+	rdf:rest _:c14n986 .
+_:c14n986 rdf:first openlabel_v2:QuantitativeValue ;
+	rdf:rest rdf:nil .
+_:c14n987 owl:unionOf _:c14n988 .
+_:c14n988 rdf:first linkml:Decimal ;
+	rdf:rest _:c14n989 .
 _:c14n989 rdf:first openlabel_v2:QuantitativeValue ;
 	rdf:rest rdf:nil .
 _:c14n99 a owl:Restriction ;
 	owl:minCardinality 0 ;
 	owl:onProperty openlabel_v2:subjectVehicleSpeedValue .
 _:c14n990 owl:unionOf _:c14n991 .
-_:c14n991 rdf:first linkml:Decimal ;
-	rdf:rest _:c14n992 .
-_:c14n992 rdf:first openlabel_v2:QuantitativeValue ;
+_:c14n991 rdf:first _:c14n992 ;
+	rdf:rest _:c14n998 .
+_:c14n992 a rdfs:Datatype ;
+	owl:intersectionOf _:c14n993 .
+_:c14n993 rdf:first linkml:Integer ;
+	rdf:rest _:c14n994 .
+_:c14n994 rdf:first _:c14n995 ;
 	rdf:rest rdf:nil .
-_:c14n993 owl:unionOf _:c14n994 .
-_:c14n994 rdf:first linkml:Decimal ;
-	rdf:rest _:c14n995 .
-_:c14n995 rdf:first openlabel_v2:QuantitativeValue ;
+_:c14n995 a rdfs:Datatype ;
+	owl:onDatatype xsd:integer ;
+	owl:withRestrictions _:c14n996 .
+_:c14n996 rdf:first _:c14n997 ;
 	rdf:rest rdf:nil .
-_:c14n996 rdf:first openlabel_v2:QuantitativeValue ;
-	rdf:rest rdf:nil .
-_:c14n997 rdf:first linkml:Decimal ;
-	rdf:rest _:c14n996 .
+_:c14n997 xsd:minInclusive 0 .
 _:c14n998 rdf:first openlabel_v2:QuantitativeValue ;
 	rdf:rest rdf:nil .
-_:c14n999 rdf:first linkml:Decimal ;
-	rdf:rest _:c14n998 .
+_:c14n999 rdf:first openlabel_v2:QuantitativeValue ;
+	rdf:rest rdf:nil .

--- a/artifacts/openlabel-v2/openlabel-v2.owl.ttl
+++ b/artifacts/openlabel-v2/openlabel-v2.owl.ttl
@@ -1,4131 +1,4310 @@
-@prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix linkml: <https://w3id.org/linkml/> .
 @prefix openlabel_v2: <https://w3id.org/ascs-ev/envited-x/openlabel/v2/> .
-@prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix pav: <http://purl.org/pav/> .
+@prefix OIO: <http://www.geneontology.org/formats/oboInOwl#> .
+@prefix cmns-q: <https://www.omg.org/spec/Commons/Quantities/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix wgs: <https://www.w3.org/2003/01/geo/wgs84_pos#> .
+@prefix brick: <https://brickschema.org/schema/Brick#> .
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix schema: <https://schema.org/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix qb: <http://purl.org/linked-data/cube#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-
-openlabel_v2:OddDynamicElements a owl:Class ;
-    rdfs:label "OddDynamicElements"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:horizontalCurvesValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:HorizontalStraights ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:ParticulatesMarine ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:LaneSpecificationMarking ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:SignsWarning ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:SignsInformation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:WeatherSnow ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:horizontalCurvesValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:HorizontalCurves ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:weatherRainValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:LaneSpecificationDimensions ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:RainType ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:DrivableAreaEdge ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:SceneryFixedStructure ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:weatherSnowValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:LongitudinalDownSlope ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:DaySunElevation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:SignsRegulatory ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:RainType ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:longitudinalUpSlopeValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:LongitudinalLevelPlane ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:SceneryTemporaryStructure ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:WeatherRain ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:ParticulatesVolcanic ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:LongitudinalDownSlope ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:ParticulatesDust ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:LaneSpecificationLaneCount ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:weatherWindValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:LaneSpecificationLaneCount ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:WeatherRain ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:DrivableAreaSurfaceType ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:GeometryTransverse ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:ParticulatesWater ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:LongitudinalDownSlope ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:LongitudinalUpSlope ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:ScenerySpecialStructure ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:WeatherSnow ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:ConnectivityCommunication ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:illuminationCloudinessValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:EnvironmentParticulates ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:LongitudinalLevelPlane ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:SceneryZone ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:EnvironmentParticulates ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:laneSpecificationDimensionsValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:ConnectivityCommunication ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:daySunElevationValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:JunctionRoundabout ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:SignsInformation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:DrivableAreaSurfaceFeature ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:SceneryTemporaryStructure ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:DrivableAreaSurfaceType ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:SignsRegulatory ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:HorizontalStraights ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:ParticulatesMarine ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:horizontalCurvesValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:LongitudinalLevelPlane ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:ParticulatesWater ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:GeometryTransverse ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:ParticulatesPollution ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:SceneryZone ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:JunctionIntersection ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:WeatherWind ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:RainType ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:DrivableAreaSurfaceFeature ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:LaneSpecificationMarking ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:DaySunPosition ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:DrivableAreaEdge ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:illuminationCloudinessValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:SceneryZone ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:EnvironmentParticulates ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:DaySunElevation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:weatherRainValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:JunctionRoundabout ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:laneSpecificationLaneCountValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:longitudinalUpSlopeValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:WeatherRain ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:GeometryTransverse ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:ParticulatesMarine ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:LaneSpecificationType ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:laneSpecificationDimensionsValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:laneSpecificationDimensionsValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:HorizontalCurves ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:WeatherWind ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:IlluminationArtificial ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:ScenerySpecialStructure ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:ConnectivityPositioning ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:ConnectivityPositioning ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:IlluminationLowLight ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:LongitudinalUpSlope ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:ConnectivityPositioning ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:LaneSpecificationType ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:HorizontalCurves ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:laneSpecificationLaneCountValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:LaneSpecificationLaneCount ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:DrivableAreaType ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:DrivableAreaSurfaceCondition ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:particulatesWaterValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:ParticulatesDust ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:LaneSpecificationTravelDirection ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:DrivableAreaSurfaceType ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:LaneSpecificationType ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:particulatesWaterValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:SignsInformation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:IlluminationCloudiness ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:LaneSpecificationTravelDirection ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:DaySunPosition ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:ParticulatesWater ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:longitudinalDownSlopeValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:weatherWindValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:JunctionIntersection ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:SignsRegulatory ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:IlluminationCloudiness ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:laneSpecificationLaneCountValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:longitudinalDownSlopeValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:SceneryFixedStructure ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:HorizontalStraights ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:DrivableAreaSurfaceFeature ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:ParticulatesPollution ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:daySunElevationValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:illuminationCloudinessValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:DrivableAreaEdge ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:IlluminationLowLight ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:ParticulatesVolcanic ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:IlluminationLowLight ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:ConnectivityCommunication ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:DaySunPosition ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:weatherSnowValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:DrivableAreaType ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:daySunElevationValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:ScenerySpecialStructure ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:IlluminationArtificial ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:IlluminationArtificial ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:IlluminationCloudiness ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:weatherRainValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:ParticulatesPollution ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:LaneSpecificationMarking ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:weatherWindValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:weatherSnowValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:SceneryTemporaryStructure ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:JunctionRoundabout ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:DrivableAreaSurfaceCondition ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:LaneSpecificationDimensions ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:longitudinalUpSlopeValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:ParticulatesDust ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:particulatesWaterValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:ParticulatesVolcanic ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:LaneSpecificationDimensions ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:SignsWarning ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:SignsWarning ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:LongitudinalUpSlope ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:SceneryFixedStructure ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:WeatherWind ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:DaySunElevation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:longitudinalDownSlopeValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:JunctionIntersection ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:DrivableAreaSurfaceCondition ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:WeatherSnow ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:LaneSpecificationTravelDirection ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:DrivableAreaType ],
-        openlabel_v2:Odd ;
-    skos:definition "Dynamic elements subset of the Operational Design Domain. Covers traffic agents, flow rates, volume, and subject vehicle speed. Refer to BSI PAS-1883 Section 5.4."@en ;
-    skos:exactMatch openlabel_v2:OddDynamicElements ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:OddEnvironment a owl:Class ;
-    rdfs:label "OddEnvironment"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:ScenerySpecialStructure ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:longitudinalDownSlopeValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:HorizontalCurves ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:LongitudinalUpSlope ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:LaneSpecificationMarking ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:trafficVolumeValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:LaneSpecificationDimensions ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:TrafficFlowRate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:HorizontalStraights ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:DrivableAreaSurfaceFeature ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:longitudinalDownSlopeValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:SceneryFixedStructure ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:trafficAgentDensityValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:LongitudinalLevelPlane ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:LongitudinalDownSlope ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:SceneryZone ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:SubjectVehicleSpeed ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:SceneryFixedStructure ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:TrafficFlowRate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:DrivableAreaSurfaceFeature ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:HorizontalCurves ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:laneSpecificationLaneCountValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:subjectVehicleSpeedValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:TrafficAgentType ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:LaneSpecificationMarking ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:laneSpecificationDimensionsValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:TrafficSpecialVehicle ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:GeometryTransverse ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:JunctionIntersection ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:TrafficAgentDensity ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:trafficVolumeValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:DrivableAreaSurfaceType ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:DrivableAreaSurfaceCondition ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:LongitudinalDownSlope ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:DrivableAreaEdge ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:HorizontalCurves ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:GeometryTransverse ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:longitudinalUpSlopeValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:SignsRegulatory ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:TrafficSpecialVehicle ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:DrivableAreaSurfaceCondition ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:LaneSpecificationTravelDirection ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:trafficAgentTypeValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:JunctionIntersection ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:LaneSpecificationLaneCount ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:DrivableAreaSurfaceType ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:laneSpecificationDimensionsValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:LaneSpecificationDimensions ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:ScenerySpecialStructure ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:longitudinalUpSlopeValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:DrivableAreaSurfaceFeature ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:DrivableAreaEdge ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:laneSpecificationLaneCountValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:LongitudinalLevelPlane ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:TrafficVolume ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:subjectVehicleSpeedValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:subjectVehicleSpeedValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:TrafficVolume ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:longitudinalUpSlopeValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:TrafficAgentType ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:JunctionRoundabout ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:LaneSpecificationTravelDirection ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:horizontalCurvesValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:trafficFlowRateValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:trafficVolumeValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:TrafficAgentType ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:trafficFlowRateValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:LongitudinalDownSlope ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:horizontalCurvesValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:DrivableAreaType ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:DrivableAreaType ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:TrafficSpecialVehicle ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:SceneryFixedStructure ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:DrivableAreaEdge ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:trafficAgentDensityValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:TrafficFlowRate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:TrafficAgentDensity ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:JunctionIntersection ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:SubjectVehicleSpeed ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:SignsInformation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:LaneSpecificationType ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:HorizontalStraights ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:SignsWarning ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:SignsWarning ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:SceneryZone ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:LongitudinalUpSlope ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:LongitudinalLevelPlane ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:JunctionRoundabout ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:LongitudinalUpSlope ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:JunctionRoundabout ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:SceneryTemporaryStructure ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:SignsInformation ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:horizontalCurvesValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:LaneSpecificationTravelDirection ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:longitudinalDownSlopeValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:LaneSpecificationLaneCount ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:DrivableAreaSurfaceCondition ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:LaneSpecificationMarking ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:HorizontalStraights ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:trafficAgentTypeValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:SubjectVehicleSpeed ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:LaneSpecificationDimensions ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:SceneryTemporaryStructure ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:GeometryTransverse ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:DrivableAreaSurfaceType ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:laneSpecificationLaneCountValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:LaneSpecificationType ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:SignsWarning ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:SignsInformation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:SceneryTemporaryStructure ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:TrafficVolume ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:trafficAgentDensityValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:LaneSpecificationType ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:DrivableAreaType ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:TrafficAgentDensity ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:SignsRegulatory ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:SceneryZone ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:ScenerySpecialStructure ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:trafficAgentTypeValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:SignsRegulatory ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:LaneSpecificationLaneCount ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:laneSpecificationDimensionsValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:trafficFlowRateValue ],
-        openlabel_v2:Odd ;
-    skos:definition "Environment-related subset of the Operational Design Domain. Covers weather, illumination, connectivity, and particulates. Refer to BSI PAS-1883 Section 5.3."@en ;
-    skos:exactMatch openlabel_v2:OddEnvironment ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:OddScenery a owl:Class ;
-    rdfs:label "OddScenery"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:WeatherWind ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:ParticulatesPollution ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:TrafficAgentDensity ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:TrafficVolume ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:ParticulatesWater ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:weatherSnowValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:ParticulatesVolcanic ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:TrafficSpecialVehicle ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:trafficFlowRateValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:SubjectVehicleSpeed ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:IlluminationArtificial ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:subjectVehicleSpeedValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:weatherSnowValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:ConnectivityPositioning ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:IlluminationArtificial ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:ParticulatesMarine ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:EnvironmentParticulates ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:WeatherWind ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:ParticulatesMarine ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:WeatherRain ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:trafficFlowRateValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:daySunElevationValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:illuminationCloudinessValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:TrafficAgentType ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:DaySunElevation ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:RainType ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:ParticulatesVolcanic ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:WeatherSnow ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:TrafficFlowRate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:IlluminationLowLight ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:ConnectivityPositioning ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:daySunElevationValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:particulatesWaterValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:EnvironmentParticulates ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:IlluminationCloudiness ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:TrafficVolume ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:illuminationCloudinessValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:WeatherSnow ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:weatherWindValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:trafficFlowRateValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:TrafficFlowRate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:IlluminationLowLight ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:TrafficVolume ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:weatherWindValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:trafficVolumeValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:TrafficFlowRate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:ParticulatesVolcanic ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:ConnectivityCommunication ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:IlluminationLowLight ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:TrafficAgentType ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:ParticulatesDust ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:ConnectivityPositioning ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:SubjectVehicleSpeed ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:ParticulatesMarine ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:subjectVehicleSpeedValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:WeatherRain ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:IlluminationCloudiness ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:WeatherSnow ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:TrafficAgentDensity ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:weatherRainValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:trafficAgentTypeValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:IlluminationArtificial ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:trafficVolumeValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:weatherSnowValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:RainType ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:trafficAgentDensityValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:TrafficSpecialVehicle ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:WeatherWind ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:ParticulatesPollution ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:ConnectivityCommunication ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:SubjectVehicleSpeed ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:ParticulatesPollution ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:ParticulatesDust ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:trafficAgentTypeValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:daySunElevationValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:DaySunElevation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:DaySunElevation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:trafficAgentTypeValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:TrafficSpecialVehicle ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:EnvironmentParticulates ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:TrafficAgentType ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:DaySunPosition ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:DaySunPosition ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:TrafficAgentDensity ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:DaySunPosition ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:weatherRainValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:illuminationCloudinessValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:trafficAgentDensityValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:trafficAgentDensityValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:subjectVehicleSpeedValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:ParticulatesWater ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:weatherRainValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:trafficVolumeValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:WeatherRain ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:weatherWindValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 0 ;
-            owl:onProperty openlabel_v2:ParticulatesWater ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:particulatesWaterValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:RainType ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:IlluminationCloudiness ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:ConnectivityCommunication ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:ParticulatesDust ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:particulatesWaterValue ],
-        openlabel_v2:Odd ;
-    skos:definition "Scenery-related subset of the Operational Design Domain. Covers drivable area, geometry, lane specifications, junctions, signs, and structures. Refer to BSI PAS-1883 Section 5.2."@en ;
-    skos:exactMatch openlabel_v2:OddScenery ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:Scenario a owl:Class ;
-    rdfs:label "Scenario"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:hasTag ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:hasTag ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom openlabel_v2:Tag ;
-            owl:onProperty openlabel_v2:hasTag ] ;
-    skos:definition "A scenario that can be tagged with OpenLABEL tags."@en ;
-    skos:exactMatch openlabel_v2:Scenario ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:ArtificialStreetLighting a owl:Class ;
-    rdfs:label "ArtificialStreetLighting"@en ;
-    rdfs:subClassOf openlabel_v2:IlluminationArtificial ;
-    skos:definition "Streetlights."@en .
-
-openlabel_v2:ArtificialVehicleLighting a owl:Class ;
-    rdfs:label "ArtificialVehicleLighting"@en ;
-    rdfs:subClassOf openlabel_v2:IlluminationArtificial ;
-    skos:definition "Oncoming vehicle lights."@en .
-
-openlabel_v2:CommunicationHeadlightFlash a owl:Class ;
-    rdfs:label "CommunicationHeadlightFlash"@en ;
-    rdfs:subClassOf openlabel_v2:BehaviourCommunication ;
-    skos:definition "Flash headlight."@en .
-
-openlabel_v2:CommunicationHorn a owl:Class ;
-    rdfs:label "CommunicationHorn"@en ;
-    rdfs:subClassOf openlabel_v2:BehaviourCommunication ;
-    skos:definition "Sound horn."@en .
-
-openlabel_v2:CommunicationSignalEmergency a owl:Class ;
-    rdfs:label "CommunicationSignalEmergency"@en ;
-    rdfs:subClassOf openlabel_v2:BehaviourCommunication ;
-    skos:definition "Signal emergency."@en .
-
-openlabel_v2:CommunicationSignalHazard a owl:Class ;
-    rdfs:label "CommunicationSignalHazard"@en ;
-    rdfs:subClassOf openlabel_v2:BehaviourCommunication ;
-    skos:definition "Signal hazard."@en .
-
-openlabel_v2:CommunicationSignalLeft a owl:Class ;
-    rdfs:label "CommunicationSignalLeft"@en ;
-    rdfs:subClassOf openlabel_v2:BehaviourCommunication ;
-    skos:definition "Signal left."@en .
-
-openlabel_v2:CommunicationSignalRight a owl:Class ;
-    rdfs:label "CommunicationSignalRight"@en ;
-    rdfs:subClassOf openlabel_v2:BehaviourCommunication ;
-    skos:definition "Signal right."@en .
-
-openlabel_v2:CommunicationSignalSlowing a owl:Class ;
-    rdfs:label "CommunicationSignalSlowing"@en ;
-    rdfs:subClassOf openlabel_v2:BehaviourCommunication ;
-    skos:definition "Signal slowing."@en .
-
-openlabel_v2:CommunicationV2i a owl:Class ;
-    rdfs:label "CommunicationV2i"@en ;
-    rdfs:subClassOf openlabel_v2:ConnectivityCommunication ;
-    skos:definition "Vehicle to infrastructure communication (V2I)."@en .
-
-openlabel_v2:CommunicationV2v a owl:Class ;
-    rdfs:label "CommunicationV2v"@en ;
-    rdfs:subClassOf openlabel_v2:ConnectivityCommunication ;
-    skos:definition "Vehicle to vehicle communication (V2V)."@en .
-
-openlabel_v2:CommunicationWave a owl:Class ;
-    rdfs:label "CommunicationWave"@en ;
-    rdfs:subClassOf openlabel_v2:BehaviourCommunication ;
-    skos:definition "Wave."@en .
-
-openlabel_v2:EdgeLineMarkers a owl:Class ;
-    rdfs:label "EdgeLineMarkers"@en ;
-    rdfs:subClassOf openlabel_v2:DrivableAreaEdge ;
-    skos:definition "Line markers."@en .
-
-openlabel_v2:EdgeNone a owl:Class ;
-    rdfs:label "EdgeNone"@en ;
-    rdfs:subClassOf openlabel_v2:DrivableAreaEdge ;
-    skos:definition "None."@en .
-
-openlabel_v2:EdgeShoulderGrass a owl:Class ;
-    rdfs:label "EdgeShoulderGrass"@en ;
-    rdfs:subClassOf openlabel_v2:DrivableAreaEdge ;
-    skos:definition "Shoulder (grass)."@en .
-
-openlabel_v2:EdgeShoulderPavedOrGravel a owl:Class ;
-    rdfs:label "EdgeShoulderPavedOrGravel"@en ;
-    rdfs:subClassOf openlabel_v2:DrivableAreaEdge ;
-    skos:definition "Shoulder (paved or gravel)."@en .
-
-openlabel_v2:EdgeSolidBarriers a owl:Class ;
-    rdfs:label "EdgeSolidBarriers"@en ;
-    rdfs:subClassOf openlabel_v2:DrivableAreaEdge ;
-    skos:definition "Solid barriers (e.g. grating, rails, curb, cones)."@en .
-
-openlabel_v2:EdgeTemporaryLineMarkers a owl:Class ;
-    rdfs:label "EdgeTemporaryLineMarkers"@en ;
-    rdfs:subClassOf openlabel_v2:DrivableAreaEdge ;
-    skos:definition "Temporary line markers."@en .
-
-openlabel_v2:FixedStructureBuilding a owl:Class ;
-    rdfs:label "FixedStructureBuilding"@en ;
-    rdfs:subClassOf openlabel_v2:SceneryFixedStructure ;
-    skos:definition "Buildings."@en .
-
-openlabel_v2:FixedStructureStreetFurniture a owl:Class ;
-    rdfs:label "FixedStructureStreetFurniture"@en ;
-    rdfs:subClassOf openlabel_v2:SceneryFixedStructure ;
-    skos:definition "Street furniture (e.g. bollards)."@en .
-
-openlabel_v2:FixedStructureStreetlight a owl:Class ;
-    rdfs:label "FixedStructureStreetlight"@en ;
-    rdfs:subClassOf openlabel_v2:SceneryFixedStructure ;
-    skos:definition "Street lights."@en .
-
-openlabel_v2:FixedStructureVegetation a owl:Class ;
-    rdfs:label "FixedStructureVegetation"@en ;
-    rdfs:subClassOf openlabel_v2:SceneryFixedStructure ;
-    skos:definition "Vegetation."@en .
-
-openlabel_v2:HumanAnimalRider a owl:Class ;
-    rdfs:label "HumanAnimalRider"@en ;
-    rdfs:subClassOf openlabel_v2:RoadUserHuman ;
-    skos:definition "Animal rider (e.g. horse rider)."@en .
-
-openlabel_v2:HumanCyclist a owl:Class ;
-    rdfs:label "HumanCyclist"@en ;
-    rdfs:subClassOf openlabel_v2:RoadUserHuman ;
-    skos:definition "Cyclist."@en .
-
-openlabel_v2:HumanDriver a owl:Class ;
-    rdfs:label "HumanDriver"@en ;
-    rdfs:subClassOf openlabel_v2:RoadUserHuman ;
-    skos:definition "Driver."@en .
-
-openlabel_v2:HumanMotorcyclist a owl:Class ;
-    rdfs:label "HumanMotorcyclist"@en ;
-    rdfs:subClassOf openlabel_v2:RoadUserHuman ;
-    skos:definition "Motorcyclist."@en .
-
-openlabel_v2:HumanPassenger a owl:Class ;
-    rdfs:label "HumanPassenger"@en ;
-    rdfs:subClassOf openlabel_v2:RoadUserHuman ;
-    skos:definition "Passenger."@en .
-
-openlabel_v2:HumanPedestrian a owl:Class ;
-    rdfs:label "HumanPedestrian"@en ;
-    rdfs:subClassOf openlabel_v2:RoadUserHuman ;
-    skos:definition "Pedestrian."@en .
-
-openlabel_v2:HumanWheelchairUser a owl:Class ;
-    rdfs:label "HumanWheelchairUser"@en ;
-    rdfs:subClassOf openlabel_v2:RoadUserHuman ;
-    skos:definition "Wheelchair user."@en .
-
-openlabel_v2:InformationSignsUniformFullTime a owl:Class ;
-    rdfs:label "InformationSignsUniformFullTime"@en ;
-    rdfs:subClassOf openlabel_v2:SignsInformation ;
-    skos:definition "Uniform full-time."@en .
-
-openlabel_v2:InformationSignsUniformTemporary a owl:Class ;
-    rdfs:label "InformationSignsUniformTemporary"@en ;
-    rdfs:subClassOf openlabel_v2:SignsInformation ;
-    skos:definition "Uniform temporary."@en .
-
-openlabel_v2:InformationSignsVariableFullTime a owl:Class ;
-    rdfs:label "InformationSignsVariableFullTime"@en ;
-    rdfs:subClassOf openlabel_v2:SignsInformation ;
-    skos:definition "Variable full-time."@en .
-
-openlabel_v2:InformationSignsVariableTemporary a owl:Class ;
-    rdfs:label "InformationSignsVariableTemporary"@en ;
-    rdfs:subClassOf openlabel_v2:SignsInformation ;
-    skos:definition "Variable temporary."@en .
-
-openlabel_v2:IntersectionCrossroad a owl:Class ;
-    rdfs:label "IntersectionCrossroad"@en ;
-    rdfs:subClassOf openlabel_v2:JunctionIntersection ;
-    skos:definition "Crossroads."@en .
-
-openlabel_v2:IntersectionGradeSeperated a owl:Class ;
-    rdfs:label "IntersectionGradeSeperated"@en ;
-    rdfs:subClassOf openlabel_v2:JunctionIntersection ;
-    skos:definition "Grade separated."@en .
-
-openlabel_v2:IntersectionStaggered a owl:Class ;
-    rdfs:label "IntersectionStaggered"@en ;
-    rdfs:subClassOf openlabel_v2:JunctionIntersection ;
-    skos:definition "Staggered."@en .
-
-openlabel_v2:IntersectionTJunction a owl:Class ;
-    rdfs:label "IntersectionTJunction"@en ;
-    rdfs:subClassOf openlabel_v2:JunctionIntersection ;
-    skos:definition "T-Junctions."@en .
-
-openlabel_v2:IntersectionYJunction a owl:Class ;
-    rdfs:label "IntersectionYJunction"@en ;
-    rdfs:subClassOf openlabel_v2:JunctionIntersection ;
-    skos:definition "Y-Junction."@en .
-
-openlabel_v2:LaneTypeBus a owl:Class ;
-    rdfs:label "LaneTypeBus"@en ;
-    rdfs:subClassOf openlabel_v2:LaneSpecificationType ;
-    skos:definition "Bus lane."@en .
-
-openlabel_v2:LaneTypeCycle a owl:Class ;
-    rdfs:label "LaneTypeCycle"@en ;
-    rdfs:subClassOf openlabel_v2:LaneSpecificationType ;
-    skos:definition "Cycle lane."@en .
-
-openlabel_v2:LaneTypeEmergency a owl:Class ;
-    rdfs:label "LaneTypeEmergency"@en ;
-    rdfs:subClassOf openlabel_v2:LaneSpecificationType ;
-    skos:definition "Emergency lane."@en .
-
-openlabel_v2:LaneTypeSpecial a owl:Class ;
-    rdfs:label "LaneTypeSpecial"@en ;
-    rdfs:subClassOf openlabel_v2:LaneSpecificationType ;
-    skos:definition "Special purpose lane."@en .
-
-openlabel_v2:LaneTypeTraffic a owl:Class ;
-    rdfs:label "LaneTypeTraffic"@en ;
-    rdfs:subClassOf openlabel_v2:LaneSpecificationType ;
-    skos:definition "Traffic lane."@en .
-
-openlabel_v2:LaneTypeTram a owl:Class ;
-    rdfs:label "LaneTypeTram"@en ;
-    rdfs:subClassOf openlabel_v2:LaneSpecificationType ;
-    skos:definition "Tram lane."@en .
-
-openlabel_v2:LowLightAmbient a owl:Class ;
-    rdfs:label "LowLightAmbient"@en ;
-    rdfs:subClassOf openlabel_v2:IlluminationLowLight ;
-    skos:definition "Low ambient lighting."@en .
-
-openlabel_v2:LowLightNight a owl:Class ;
-    rdfs:label "LowLightNight"@en ;
-    rdfs:subClassOf openlabel_v2:IlluminationLowLight ;
-    skos:definition "Night."@en .
-
-openlabel_v2:MotorwayManaged a owl:Class ;
-    rdfs:label "MotorwayManaged"@en ;
-    rdfs:subClassOf openlabel_v2:DrivableAreaType ;
-    skos:definition "Managed motorways."@en .
-
-openlabel_v2:MotorwayUnmanaged a owl:Class ;
-    rdfs:label "MotorwayUnmanaged"@en ;
-    rdfs:subClassOf openlabel_v2:DrivableAreaType ;
-    skos:definition "Unmanaged motorways."@en .
-
-openlabel_v2:PositioningGalileo a owl:Class ;
-    rdfs:label "PositioningGalileo"@en ;
-    rdfs:subClassOf openlabel_v2:ConnectivityPositioning ;
-    skos:definition "Galileo."@en .
-
-openlabel_v2:PositioningGlonass a owl:Class ;
-    rdfs:label "PositioningGlonass"@en ;
-    rdfs:subClassOf openlabel_v2:ConnectivityPositioning ;
-    skos:definition "GLObal NAvigation Satellite System (GLONASS)."@en .
-
-openlabel_v2:PositioningGps a owl:Class ;
-    rdfs:label "PositioningGps"@en ;
-    rdfs:subClassOf openlabel_v2:ConnectivityPositioning ;
-    skos:definition "Global Positioning System (GPS)."@en .
-
-openlabel_v2:RainTypeConvective a owl:Class ;
-    rdfs:label "RainTypeConvective"@en ;
-    rdfs:subClassOf openlabel_v2:RainType ;
-    skos:definition "Convective."@en .
-
-openlabel_v2:RainTypeDynamic a owl:Class ;
-    rdfs:label "RainTypeDynamic"@en ;
-    rdfs:subClassOf openlabel_v2:RainType ;
-    skos:definition "Dynamic."@en .
-
-openlabel_v2:RainTypeOrographic a owl:Class ;
-    rdfs:label "RainTypeOrographic"@en ;
-    rdfs:subClassOf openlabel_v2:RainType ;
-    skos:definition "Orographic."@en .
-
-openlabel_v2:RegulatorySignsUniformFullTime a owl:Class ;
-    rdfs:label "RegulatorySignsUniformFullTime"@en ;
-    rdfs:subClassOf openlabel_v2:SignsRegulatory ;
-    skos:definition "Uniform full-time."@en .
-
-openlabel_v2:RegulatorySignsUniformTemporary a owl:Class ;
-    rdfs:label "RegulatorySignsUniformTemporary"@en ;
-    rdfs:subClassOf openlabel_v2:SignsRegulatory ;
-    skos:definition "Uniform temporary."@en .
-
-openlabel_v2:RegulatorySignsVariableFullTime a owl:Class ;
-    rdfs:label "RegulatorySignsVariableFullTime"@en ;
-    rdfs:subClassOf openlabel_v2:SignsRegulatory ;
-    skos:definition "Variable full-time."@en .
-
-openlabel_v2:RegulatorySignsVariableTemporary a owl:Class ;
-    rdfs:label "RegulatorySignsVariableTemporary"@en ;
-    rdfs:subClassOf openlabel_v2:SignsRegulatory ;
-    skos:definition "Variable temporary."@en .
-
-openlabel_v2:RoadTypeDistributor a owl:Class ;
-    rdfs:label "RoadTypeDistributor"@en ;
-    rdfs:subClassOf openlabel_v2:DrivableAreaType ;
-    skos:definition "Distributor roads."@en .
-
-openlabel_v2:RoadTypeMinor a owl:Class ;
-    rdfs:label "RoadTypeMinor"@en ;
-    rdfs:subClassOf openlabel_v2:DrivableAreaType ;
-    skos:definition "Minor roads."@en .
-
-openlabel_v2:RoadTypeMotorway a owl:Class ;
-    rdfs:label "RoadTypeMotorway"@en ;
-    rdfs:subClassOf openlabel_v2:DrivableAreaType ;
-    skos:definition "Motorways."@en .
-
-openlabel_v2:RoadTypeParking a owl:Class ;
-    rdfs:label "RoadTypeParking"@en ;
-    rdfs:subClassOf openlabel_v2:DrivableAreaType ;
-    skos:definition "Parking."@en .
-
-openlabel_v2:RoadTypeRadial a owl:Class ;
-    rdfs:label "RoadTypeRadial"@en ;
-    rdfs:subClassOf openlabel_v2:DrivableAreaType ;
-    skos:definition "Radial roads."@en .
-
-openlabel_v2:RoadTypeShared a owl:Class ;
-    rdfs:label "RoadTypeShared"@en ;
-    rdfs:subClassOf openlabel_v2:DrivableAreaType ;
-    skos:definition "Shared space."@en .
-
-openlabel_v2:RoadTypeSlip a owl:Class ;
-    rdfs:label "RoadTypeSlip"@en ;
-    rdfs:subClassOf openlabel_v2:DrivableAreaType ;
-    skos:definition "Slip roads."@en .
-
-openlabel_v2:RoundaboutCompactNosignal a owl:Class ;
-    rdfs:label "RoundaboutCompactNosignal"@en ;
-    rdfs:subClassOf openlabel_v2:JunctionRoundabout ;
-    skos:definition "Compact non-signalised."@en .
-
-openlabel_v2:RoundaboutCompactSignal a owl:Class ;
-    rdfs:label "RoundaboutCompactSignal"@en ;
-    rdfs:subClassOf openlabel_v2:JunctionRoundabout ;
-    skos:definition "Compact signalised."@en .
-
-openlabel_v2:RoundaboutDoubleNosignal a owl:Class ;
-    rdfs:label "RoundaboutDoubleNosignal"@en ;
-    rdfs:subClassOf openlabel_v2:JunctionRoundabout ;
-    skos:definition "Double non-signalised."@en .
-
-openlabel_v2:RoundaboutDoubleSignal a owl:Class ;
-    rdfs:label "RoundaboutDoubleSignal"@en ;
-    rdfs:subClassOf openlabel_v2:JunctionRoundabout ;
-    skos:definition "Double signalised."@en .
-
-openlabel_v2:RoundaboutLargeNosignal a owl:Class ;
-    rdfs:label "RoundaboutLargeNosignal"@en ;
-    rdfs:subClassOf openlabel_v2:JunctionRoundabout ;
-    skos:definition "Large non-signalised."@en .
-
-openlabel_v2:RoundaboutLargeSignal a owl:Class ;
-    rdfs:label "RoundaboutLargeSignal"@en ;
-    rdfs:subClassOf openlabel_v2:JunctionRoundabout ;
-    skos:definition "Large signalised."@en .
-
-openlabel_v2:RoundaboutMiniNosignal a owl:Class ;
-    rdfs:label "RoundaboutMiniNosignal"@en ;
-    rdfs:subClassOf openlabel_v2:JunctionRoundabout ;
-    skos:definition "Mini non-signalised."@en .
-
-openlabel_v2:RoundaboutMiniSignal a owl:Class ;
-    rdfs:label "RoundaboutMiniSignal"@en ;
-    rdfs:subClassOf openlabel_v2:JunctionRoundabout ;
-    skos:definition "Mini signalised."@en .
-
-openlabel_v2:RoundaboutNormalNosignal a owl:Class ;
-    rdfs:label "RoundaboutNormalNosignal"@en ;
-    rdfs:subClassOf openlabel_v2:JunctionRoundabout ;
-    skos:definition "Normal non-signalised."@en .
-
-openlabel_v2:RoundaboutNormalSignal a owl:Class ;
-    rdfs:label "RoundaboutNormalSignal"@en ;
-    rdfs:subClassOf openlabel_v2:JunctionRoundabout ;
-    skos:definition "Normal signalised."@en .
-
-openlabel_v2:SpecialStructureAutoAccess a owl:Class ;
-    rdfs:label "SpecialStructureAutoAccess"@en ;
-    rdfs:subClassOf openlabel_v2:ScenerySpecialStructure ;
-    skos:definition "Automatic access control."@en .
-
-openlabel_v2:SpecialStructureBridge a owl:Class ;
-    rdfs:label "SpecialStructureBridge"@en ;
-    rdfs:subClassOf openlabel_v2:ScenerySpecialStructure ;
-    skos:definition "Bridges."@en .
-
-openlabel_v2:SpecialStructurePedestrianCrossing a owl:Class ;
-    rdfs:label "SpecialStructurePedestrianCrossing"@en ;
-    rdfs:subClassOf openlabel_v2:ScenerySpecialStructure ;
-    skos:definition "Pedestrian crossings."@en .
-
-openlabel_v2:SpecialStructureRailCrossing a owl:Class ;
-    rdfs:label "SpecialStructureRailCrossing"@en ;
-    rdfs:subClassOf openlabel_v2:ScenerySpecialStructure ;
-    skos:definition "Rail crossings."@en .
-
-openlabel_v2:SpecialStructureTollPlaza a owl:Class ;
-    rdfs:label "SpecialStructureTollPlaza"@en ;
-    rdfs:subClassOf openlabel_v2:ScenerySpecialStructure ;
-    skos:definition "Toll plaza."@en .
-
-openlabel_v2:SpecialStructureTunnel a owl:Class ;
-    rdfs:label "SpecialStructureTunnel"@en ;
-    rdfs:subClassOf openlabel_v2:ScenerySpecialStructure ;
-    skos:definition "Tunnels."@en .
-
-openlabel_v2:SunPositionBehind a owl:Class ;
-    rdfs:label "SunPositionBehind"@en ;
-    rdfs:subClassOf openlabel_v2:DaySunPosition ;
-    skos:definition "Sun behind."@en .
-
-openlabel_v2:SunPositionFront a owl:Class ;
-    rdfs:label "SunPositionFront"@en ;
-    rdfs:subClassOf openlabel_v2:DaySunPosition ;
-    skos:definition "Sun in front."@en .
-
-openlabel_v2:SunPositionLeft a owl:Class ;
-    rdfs:label "SunPositionLeft"@en ;
-    rdfs:subClassOf openlabel_v2:DaySunPosition ;
-    skos:definition "Sun on the left."@en .
-
-openlabel_v2:SunPositionRight a owl:Class ;
-    rdfs:label "SunPositionRight"@en ;
-    rdfs:subClassOf openlabel_v2:DaySunPosition ;
-    skos:definition "Sun on the right."@en .
-
-openlabel_v2:SurfaceConditionContamination a owl:Class ;
-    rdfs:label "SurfaceConditionContamination"@en ;
-    rdfs:subClassOf openlabel_v2:DrivableAreaSurfaceCondition ;
-    skos:definition "Surface contamination."@en .
-
-openlabel_v2:SurfaceConditionFlooded a owl:Class ;
-    rdfs:label "SurfaceConditionFlooded"@en ;
-    rdfs:subClassOf openlabel_v2:DrivableAreaSurfaceCondition ;
-    skos:definition "Flooded roadways."@en .
-
-openlabel_v2:SurfaceConditionIcy a owl:Class ;
-    rdfs:label "SurfaceConditionIcy"@en ;
-    rdfs:subClassOf openlabel_v2:DrivableAreaSurfaceCondition ;
-    skos:definition "Icy."@en .
-
-openlabel_v2:SurfaceConditionMirage a owl:Class ;
-    rdfs:label "SurfaceConditionMirage"@en ;
-    rdfs:subClassOf openlabel_v2:DrivableAreaSurfaceCondition ;
-    skos:definition "Mirage."@en .
-
-openlabel_v2:SurfaceConditionSnow a owl:Class ;
-    rdfs:label "SurfaceConditionSnow"@en ;
-    rdfs:subClassOf openlabel_v2:DrivableAreaSurfaceCondition ;
-    skos:definition "Snow on drivable area."@en .
-
-openlabel_v2:SurfaceConditionStandingWater a owl:Class ;
-    rdfs:label "SurfaceConditionStandingWater"@en ;
-    rdfs:subClassOf openlabel_v2:DrivableAreaSurfaceCondition ;
-    skos:definition "Standing water."@en .
-
-openlabel_v2:SurfaceConditionWet a owl:Class ;
-    rdfs:label "SurfaceConditionWet"@en ;
-    rdfs:subClassOf openlabel_v2:DrivableAreaSurfaceCondition ;
-    skos:definition "Wet road."@en .
-
-openlabel_v2:SurfaceFeatureCrack a owl:Class ;
-    rdfs:label "SurfaceFeatureCrack"@en ;
-    rdfs:subClassOf openlabel_v2:DrivableAreaSurfaceFeature ;
-    skos:definition "Cracks."@en .
-
-openlabel_v2:SurfaceFeaturePothole a owl:Class ;
-    rdfs:label "SurfaceFeaturePothole"@en ;
-    rdfs:subClassOf openlabel_v2:DrivableAreaSurfaceFeature ;
-    skos:definition "Potholes."@en .
-
-openlabel_v2:SurfaceFeatureRut a owl:Class ;
-    rdfs:label "SurfaceFeatureRut"@en ;
-    rdfs:subClassOf openlabel_v2:DrivableAreaSurfaceFeature ;
-    skos:definition "Ruts."@en .
-
-openlabel_v2:SurfaceFeatureSwell a owl:Class ;
-    rdfs:label "SurfaceFeatureSwell"@en ;
-    rdfs:subClassOf openlabel_v2:DrivableAreaSurfaceFeature ;
-    skos:definition "Swells."@en .
-
-openlabel_v2:SurfaceTypeLoose a owl:Class ;
-    rdfs:label "SurfaceTypeLoose"@en ;
-    rdfs:subClassOf openlabel_v2:DrivableAreaSurfaceType ;
-    skos:definition "Loose (e.g. gravel, earth, sand)."@en .
-
-openlabel_v2:SurfaceTypeSegmented a owl:Class ;
-    rdfs:label "SurfaceTypeSegmented"@en ;
-    rdfs:subClassOf openlabel_v2:DrivableAreaSurfaceType ;
-    skos:definition "Segmented (e.g. concrete slabs, granite setts, cobblestones)."@en .
-
-openlabel_v2:SurfaceTypeUniform a owl:Class ;
-    rdfs:label "SurfaceTypeUniform"@en ;
-    rdfs:subClassOf openlabel_v2:DrivableAreaSurfaceType ;
-    skos:definition "Uniform (e.g. asphalt)."@en .
-
-openlabel_v2:TemporaryStructureConstructionDetour a owl:Class ;
-    rdfs:label "TemporaryStructureConstructionDetour"@en ;
-    rdfs:subClassOf openlabel_v2:SceneryTemporaryStructure ;
-    skos:definition "Construction site detours."@en .
-
-openlabel_v2:TemporaryStructureRefuseCollection a owl:Class ;
-    rdfs:label "TemporaryStructureRefuseCollection"@en ;
-    rdfs:subClassOf openlabel_v2:SceneryTemporaryStructure ;
-    skos:definition "Refuse collection."@en .
-
-openlabel_v2:TemporaryStructureRoadSignage a owl:Class ;
-    rdfs:label "TemporaryStructureRoadSignage"@en ;
-    rdfs:subClassOf openlabel_v2:SceneryTemporaryStructure ;
-    skos:definition "Road signage."@en .
-
-openlabel_v2:TemporaryStructureRoadWorks a owl:Class ;
-    rdfs:label "TemporaryStructureRoadWorks"@en ;
-    rdfs:subClassOf openlabel_v2:SceneryTemporaryStructure ;
-    skos:definition "Road works."@en .
-
-openlabel_v2:TransverseBarriers a owl:Class ;
-    rdfs:label "TransverseBarriers"@en ;
-    rdfs:subClassOf openlabel_v2:GeometryTransverse ;
-    skos:definition "Barriers on edges."@en .
-
-openlabel_v2:TransverseDivided a owl:Class ;
-    rdfs:label "TransverseDivided"@en ;
-    rdfs:subClassOf openlabel_v2:GeometryTransverse ;
-    skos:definition "Divided."@en .
-
-openlabel_v2:TransverseLanesTogether a owl:Class ;
-    rdfs:label "TransverseLanesTogether"@en ;
-    rdfs:subClassOf openlabel_v2:GeometryTransverse ;
-    skos:definition "Types of lanes together."@en .
-
-openlabel_v2:TransversePavements a owl:Class ;
-    rdfs:label "TransversePavements"@en ;
-    rdfs:subClassOf openlabel_v2:GeometryTransverse ;
-    skos:definition "Pavements."@en .
-
-openlabel_v2:TransverseUndivided a owl:Class ;
-    rdfs:label "TransverseUndivided"@en ;
-    rdfs:subClassOf openlabel_v2:GeometryTransverse ;
-    skos:definition "Undivided."@en .
-
-openlabel_v2:TravelDirectionLeft a owl:Class ;
-    rdfs:label "TravelDirectionLeft"@en ;
-    rdfs:subClassOf openlabel_v2:LaneSpecificationTravelDirection ;
-    skos:definition "Left."@en .
-
-openlabel_v2:TravelDirectionRight a owl:Class ;
-    rdfs:label "TravelDirectionRight"@en ;
-    rdfs:subClassOf openlabel_v2:LaneSpecificationTravelDirection ;
-    skos:definition "Right."@en .
-
-openlabel_v2:V2iCellular a owl:Class ;
-    rdfs:label "V2iCellular"@en ;
-    rdfs:subClassOf openlabel_v2:ConnectivityCommunication ;
-    skos:definition "V2I via cellular network."@en .
-
-openlabel_v2:V2iSatellite a owl:Class ;
-    rdfs:label "V2iSatellite"@en ;
-    rdfs:subClassOf openlabel_v2:ConnectivityCommunication ;
-    skos:definition "V2I via satellite."@en .
-
-openlabel_v2:V2iWifi a owl:Class ;
-    rdfs:label "V2iWifi"@en ;
-    rdfs:subClassOf openlabel_v2:ConnectivityCommunication ;
-    skos:definition "V2I via WiFi."@en .
-
-openlabel_v2:V2vCellular a owl:Class ;
-    rdfs:label "V2vCellular"@en ;
-    rdfs:subClassOf openlabel_v2:ConnectivityCommunication ;
-    skos:definition "V2V via cellular network."@en .
-
-openlabel_v2:V2vSatellite a owl:Class ;
-    rdfs:label "V2vSatellite"@en ;
-    rdfs:subClassOf openlabel_v2:ConnectivityCommunication ;
-    skos:definition "V2V via satellite."@en .
-
-openlabel_v2:V2vWifi a owl:Class ;
-    rdfs:label "V2vWifi"@en ;
-    rdfs:subClassOf openlabel_v2:ConnectivityCommunication ;
-    skos:definition "V2V via WiFi."@en .
-
-openlabel_v2:VehicleAgricultural a owl:Class ;
-    rdfs:label "VehicleAgricultural"@en ;
-    rdfs:subClassOf openlabel_v2:RoadUserVehicle ;
-    skos:definition "Agricultural vehicle."@en .
-
-openlabel_v2:VehicleBus a owl:Class ;
-    rdfs:label "VehicleBus"@en ;
-    rdfs:subClassOf openlabel_v2:RoadUserVehicle ;
-    skos:definition "Bus."@en .
-
-openlabel_v2:VehicleCar a owl:Class ;
-    rdfs:label "VehicleCar"@en ;
-    rdfs:subClassOf openlabel_v2:RoadUserVehicle ;
-    skos:definition "Car."@en .
-
-openlabel_v2:VehicleConstruction a owl:Class ;
-    rdfs:label "VehicleConstruction"@en ;
-    rdfs:subClassOf openlabel_v2:RoadUserVehicle ;
-    skos:definition "Construction vehicle."@en .
-
-openlabel_v2:VehicleCycle a owl:Class ;
-    rdfs:label "VehicleCycle"@en ;
-    rdfs:subClassOf openlabel_v2:RoadUserVehicle ;
-    skos:definition "Cycle."@en .
-
-openlabel_v2:VehicleEmergency a owl:Class ;
-    rdfs:label "VehicleEmergency"@en ;
-    rdfs:subClassOf openlabel_v2:RoadUserVehicle ;
-    skos:definition "Emergency vehicle."@en .
-
-openlabel_v2:VehicleMotorcycle a owl:Class ;
-    rdfs:label "VehicleMotorcycle"@en ;
-    rdfs:subClassOf openlabel_v2:RoadUserVehicle ;
-    skos:definition "Motorcycle."@en .
-
-openlabel_v2:VehicleTrailer a owl:Class ;
-    rdfs:label "VehicleTrailer"@en ;
-    rdfs:subClassOf openlabel_v2:RoadUserVehicle ;
-    skos:definition "Trailer."@en .
-
-openlabel_v2:VehicleTruck a owl:Class ;
-    rdfs:label "VehicleTruck"@en ;
-    rdfs:subClassOf openlabel_v2:RoadUserVehicle ;
-    skos:definition "Truck."@en .
-
-openlabel_v2:VehicleVan a owl:Class ;
-    rdfs:label "VehicleVan"@en ;
-    rdfs:subClassOf openlabel_v2:RoadUserVehicle ;
-    skos:definition "Van."@en .
-
-openlabel_v2:VehicleWheelchair a owl:Class ;
-    rdfs:label "VehicleWheelchair"@en ;
-    rdfs:subClassOf openlabel_v2:RoadUserVehicle ;
-    skos:definition "Wheelchair."@en .
-
-openlabel_v2:WarningSignsUniform a owl:Class ;
-    rdfs:label "WarningSignsUniform"@en ;
-    rdfs:subClassOf openlabel_v2:SignsWarning ;
-    skos:definition "Uniform."@en .
-
-openlabel_v2:WarningSignsUniformFullTime a owl:Class ;
-    rdfs:label "WarningSignsUniformFullTime"@en ;
-    rdfs:subClassOf openlabel_v2:SignsWarning ;
-    skos:definition "Uniform full-time."@en .
-
-openlabel_v2:WarningSignsUniformTemporary a owl:Class ;
-    rdfs:label "WarningSignsUniformTemporary"@en ;
-    rdfs:subClassOf openlabel_v2:SignsWarning ;
-    skos:definition "Uniform temporary."@en .
-
-openlabel_v2:WarningSignsVariableFullTime a owl:Class ;
-    rdfs:label "WarningSignsVariableFullTime"@en ;
-    rdfs:subClassOf openlabel_v2:SignsWarning ;
-    skos:definition "Variable full-time."@en .
-
-openlabel_v2:WarningSignsVariableTemporary a owl:Class ;
-    rdfs:label "WarningSignsVariableTemporary"@en ;
-    rdfs:subClassOf openlabel_v2:SignsWarning ;
-    skos:definition "Variable temporary."@en .
-
-openlabel_v2:ZoneGeoFenced a owl:Class ;
-    rdfs:label "ZoneGeoFenced"@en ;
-    rdfs:subClassOf openlabel_v2:SceneryZone ;
-    skos:definition "GeoFenced areas."@en .
-
-openlabel_v2:ZoneInterference a owl:Class ;
-    rdfs:label "ZoneInterference"@en ;
-    rdfs:subClassOf openlabel_v2:SceneryZone ;
-    skos:definition "Interference zones."@en .
-
-openlabel_v2:ZoneRegion a owl:Class ;
-    rdfs:label "ZoneRegion"@en ;
-    rdfs:subClassOf openlabel_v2:SceneryZone ;
-    skos:definition "Regions or states."@en .
-
-openlabel_v2:ZoneSchool a owl:Class ;
-    rdfs:label "ZoneSchool"@en ;
-    rdfs:subClassOf openlabel_v2:SceneryZone ;
-    skos:definition "School zones."@en .
-
-openlabel_v2:ZoneTrafficManagement a owl:Class ;
-    rdfs:label "ZoneTrafficManagement"@en ;
-    rdfs:subClassOf openlabel_v2:SceneryZone ;
-    skos:definition "Traffic management zones."@en .
-
-openlabel_v2:MotionAway a owl:DatatypeProperty ;
-    rdfs:label "MotionAway"@en ;
-    rdfs:range xsd:boolean ;
-    skos:definition "An activity where the road user is further away from the object by the end."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:MotionCross a owl:DatatypeProperty ;
-    rdfs:label "MotionCross"@en ;
-    rdfs:range xsd:boolean ;
-    skos:definition "An activity where the trajectory of the road user crosses the trajectory of the object."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:MotionCutIn a owl:DatatypeProperty ;
-    rdfs:label "MotionCutIn"@en ;
-    rdfs:range xsd:boolean ;
-    skos:definition "An activity where the subject vehicle ends up directly in front of the object vehicle."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:MotionCutOut a owl:DatatypeProperty ;
-    rdfs:label "MotionCutOut"@en ;
-    rdfs:range xsd:boolean ;
-    skos:definition "An activity where the object vehicle suddenly moves out of the lane."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:MotionLaneChangeLeft a owl:DatatypeProperty ;
-    rdfs:label "MotionLaneChangeLeft"@en ;
-    rdfs:range xsd:boolean ;
-    skos:definition "An activity where the subject vehicle is in a lane left of the original."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:MotionLaneChangeRight a owl:DatatypeProperty ;
-    rdfs:label "MotionLaneChangeRight"@en ;
-    rdfs:range xsd:boolean ;
-    skos:definition "An activity where the subject vehicle is in a lane right of the original."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:MotionOvertake a owl:DatatypeProperty ;
-    rdfs:label "MotionOvertake"@en ;
-    rdfs:range xsd:boolean ;
-    skos:definition "An activity where the subject starts behind and ends up in front by changing lanes."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:MotionReverse a owl:DatatypeProperty ;
-    rdfs:label "MotionReverse"@en ;
-    rdfs:range xsd:boolean ;
-    skos:definition "An activity where the subject vehicle is moving in the opposite direction to which it is facing."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:MotionRun a owl:DatatypeProperty ;
-    rdfs:label "MotionRun"@en ;
-    rdfs:range xsd:boolean ;
-    skos:definition "Locomotion mode where at a specific point no foot touches the ground."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:MotionSlide a owl:DatatypeProperty ;
-    rdfs:label "MotionSlide"@en ;
-    rdfs:range xsd:boolean ;
-    skos:definition "An activity where a pedestrian is slipping/sliding on the road."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:MotionStop a owl:DatatypeProperty ;
-    rdfs:label "MotionStop"@en ;
-    rdfs:range xsd:boolean ;
-    skos:definition "An activity where the road user is stationary."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:MotionTowards a owl:DatatypeProperty ;
-    rdfs:label "MotionTowards"@en ;
-    rdfs:range xsd:boolean ;
-    skos:definition "An activity where the road user is closer to the object by the end."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:MotionTurn a owl:DatatypeProperty ;
-    rdfs:label "MotionTurn"@en ;
-    rdfs:range xsd:boolean ;
-    skos:definition "An activity where the road user changes their heading."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:MotionTurnLeft a owl:DatatypeProperty ;
-    rdfs:label "MotionTurnLeft"@en ;
-    rdfs:range xsd:boolean ;
-    skos:definition "Subject exits the intersection on a road to the left of the original."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:MotionTurnRight a owl:DatatypeProperty ;
-    rdfs:label "MotionTurnRight"@en ;
-    rdfs:range xsd:boolean ;
-    skos:definition "Subject exits the intersection on a road to the right of the original."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:MotionUTurn a owl:DatatypeProperty ;
-    rdfs:label "MotionUTurn"@en ;
-    rdfs:range xsd:boolean ;
-    skos:definition "Subject performs a turn resulting in heading in the opposite direction."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:MotionWalk a owl:DatatypeProperty ;
-    rdfs:label "MotionWalk"@en ;
-    rdfs:range xsd:boolean ;
-    skos:definition "Locomotion mode where at least one foot is always on the ground."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:RoadUserAnimal a owl:DatatypeProperty ;
-    rdfs:label "RoadUserAnimal"@en ;
-    rdfs:range xsd:boolean ;
-    skos:definition "Animal road user flag."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:Tag a owl:Class ;
-    rdfs:label "Tag"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:AdminTag ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:RoadUser ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:Behaviour ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:Odd ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom openlabel_v2:AdminTag ;
-            owl:onProperty openlabel_v2:AdminTag ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:Behaviour ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom openlabel_v2:Behaviour ;
-            owl:onProperty openlabel_v2:Behaviour ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom openlabel_v2:RoadUser ;
-            owl:onProperty openlabel_v2:RoadUser ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:AdminTag ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:RoadUser ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:Odd ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom openlabel_v2:Odd ;
-            owl:onProperty openlabel_v2:Odd ] ;
-    skos:definition "The base tag."@en ;
-    skos:exactMatch openlabel_v2:Tag ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:hasLowerBound a owl:DatatypeProperty ;
-    rdfs:label "hasLowerBound"@en ;
-    rdfs:range xsd:decimal ;
-    skos:definition "Lower bound inferred via RDFS from schema:minValue being a subPropertyOf cmns-q:hasLowerBound in schema.org OWL."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:hasTag a owl:ObjectProperty ;
-    rdfs:label "hasTag"@en ;
-    rdfs:range openlabel_v2:Tag ;
-    skos:definition "A tag associated with a scenario."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:hasUpperBound a owl:DatatypeProperty ;
-    rdfs:label "hasUpperBound"@en ;
-    rdfs:range xsd:decimal ;
-    skos:definition "Upper bound inferred via RDFS from schema:maxValue being a subPropertyOf cmns-q:hasUpperBound in schema.org OWL."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:licenseURI a owl:DatatypeProperty ;
-    rdfs:label "licenseURI"@en ;
-    rdfs:range xsd:string ;
-    skos:definition "The type of license which governs usage of the scenario."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:maxValue a owl:DatatypeProperty ;
-    rdfs:label "maxValue"@en ;
-    rdfs:range xsd:decimal ;
-    skos:definition "Maximum value of the range."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:minValue a owl:DatatypeProperty ;
-    rdfs:label "minValue"@en ;
-    rdfs:range xsd:decimal ;
-    skos:definition "Minimum value of the range."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:ownerEmail a owl:DatatypeProperty ;
-    rdfs:label "ownerEmail"@en ;
-    rdfs:range xsd:string ;
-    skos:definition "The email address of the legal entity who owns the rights to the scenario."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:ownerName a owl:DatatypeProperty ;
-    rdfs:label "ownerName"@en ;
-    rdfs:range xsd:string ;
-    skos:definition "The name of the legal entity who owns the rights to the scenario."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:ownerURL a owl:DatatypeProperty ;
-    rdfs:label "ownerURL"@en ;
-    rdfs:range xsd:string ;
-    skos:definition "The URL of the legal entity who owns the rights to the scenario."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:scenarioCreatedDate a owl:DatatypeProperty ;
-    rdfs:label "scenarioCreatedDate"@en ;
-    rdfs:range xsd:dateTime ;
-    skos:definition "The date that the scenario was created/published."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:scenarioDefinition a owl:DatatypeProperty ;
-    rdfs:label "scenarioDefinition"@en ;
-    rdfs:range xsd:string ;
-    skos:definition "SDL definition of the scenario."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:scenarioDefinitionLanguageURI a owl:DatatypeProperty ;
-    rdfs:label "scenarioDefinitionLanguageURI"@en ;
-    rdfs:range xsd:string ;
-    skos:definition "URI of SDL language used for the definition of the scenario."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:scenarioDescription a owl:DatatypeProperty ;
-    rdfs:label "scenarioDescription"@en ;
-    rdfs:range xsd:string ;
-    skos:definition "A description of the scenario."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:scenarioName a owl:DatatypeProperty ;
-    rdfs:label "scenarioName"@en ;
-    rdfs:range xsd:string ;
-    skos:definition "The name of the scenario."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:scenarioParentReference a owl:DatatypeProperty ;
-    rdfs:label "scenarioParentReference"@en ;
-    rdfs:range xsd:string ;
-    skos:definition "Universally unique identifier (UUID) which identifies the scenario which this one has been derived from."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:scenarioUniqueReference a owl:DatatypeProperty ;
-    rdfs:label "scenarioUniqueReference"@en ;
-    rdfs:range xsd:string ;
-    skos:definition "Universally unique identifier (UUID) assigned to the scenario which allows the scenario to be identified."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:scenarioVersion a owl:DatatypeProperty ;
-    rdfs:label "scenarioVersion"@en ;
-    rdfs:range xsd:string ;
-    skos:definition "The version number of the scenario."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:scenarioVisualisationURL a owl:DatatypeProperty ;
-    rdfs:label "scenarioVisualisationURL"@en ;
-    rdfs:range xsd:string ;
-    skos:definition "Relative or absolute URL of a static image or animation of the scenario to allow users to easily see what the scenario represents."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:MotionAccelerate a owl:DatatypeProperty ;
-    rdfs:label "MotionAccelerate"@en ;
-    rdfs:range xsd:boolean ;
-    skos:definition "An activity where the road user increases their velocity."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:MotionDecelerate a owl:DatatypeProperty ;
-    rdfs:label "MotionDecelerate"@en ;
-    rdfs:range xsd:boolean ;
-    skos:definition "An activity where the road user decreases their velocity."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:MotionDrive a owl:DatatypeProperty ;
-    rdfs:label "MotionDrive"@en ;
-    rdfs:range xsd:boolean ;
-    skos:definition "An activity where the subject vehicle is moving in the direction it is facing."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:motionAccelerateValue a owl:DatatypeProperty ;
-    rdfs:label "motionAccelerateValue"@en ;
-    rdfs:range [ owl:unionOf ( openlabel_v2:QuantitativeValue xsd:decimal ) ] ;
-    skos:definition "Rate of acceleration (ms-2)."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:motionDecelerateValue a owl:DatatypeProperty ;
-    rdfs:label "motionDecelerateValue"@en ;
-    rdfs:range [ owl:unionOf ( openlabel_v2:QuantitativeValue xsd:decimal ) ] ;
-    skos:definition "Rate of deceleration (ms-2)."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:AdminTag a owl:Class,
-        owl:ObjectProperty ;
-    rdfs:label "AdminTag"@en ;
-    rdfs:range openlabel_v2:AdminTag ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:scenarioName ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:scenarioUniqueReference ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:scenarioDefinition ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:scenarioDefinition ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:ownerEmail ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:ownerURL ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:licenseURI ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:scenarioUniqueReference ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:scenarioDefinitionLanguageURI ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:scenarioVisualisationURL ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:scenarioCreatedDate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:scenarioVisualisationURL ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:scenarioParentReference ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:ownerEmail ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:scenarioDefinitionLanguageURI ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:dateTime ;
-            owl:onProperty openlabel_v2:scenarioCreatedDate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:scenarioDefinition ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:ownerEmail ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:ownerName ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:scenarioVersion ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:scenarioDescription ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:scenarioCreatedDate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:scenarioDescription ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:scenarioParentReference ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:scenarioDescription ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:scenarioUniqueReference ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:ownerName ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:scenarioName ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:scenarioVersion ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:licenseURI ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:licenseURI ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:scenarioParentReference ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:ownerURL ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:scenarioDefinitionLanguageURI ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:ownerName ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:scenarioVisualisationURL ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:ownerURL ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:scenarioName ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty openlabel_v2:scenarioVersion ] ;
-    skos:definition "Administration tag."@en,
-        "The base tag to use when extending the Administration tags with new classes."@en ;
-    skos:exactMatch openlabel_v2:AdminTag ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:RoadUser a owl:Class,
-        owl:ObjectProperty ;
-    rdfs:label "RoadUser"@en ;
-    rdfs:range openlabel_v2:RoadUser ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:unionOf ( openlabel_v2:QuantitativeValue xsd:decimal ) ] ;
-            owl:onProperty openlabel_v2:motionDriveValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:motionDriveValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:RoadUserHuman ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:RoadUserAnimal ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom openlabel_v2:RoadUserHuman ;
-            owl:onProperty openlabel_v2:RoadUserHuman ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:RoadUserAnimal ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:RoadUserVehicle ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:RoadUserAnimal ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:motionDriveValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:RoadUserHuman ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:RoadUserVehicle ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom openlabel_v2:RoadUserVehicle ;
-            owl:onProperty openlabel_v2:RoadUserVehicle ] ;
-    skos:definition "Road user tag."@en,
-        "Something which uses a road to travel."@en ;
-    skos:exactMatch openlabel_v2:RoadUser ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:motionDriveValue a owl:DatatypeProperty ;
-    rdfs:label "motionDriveValue"@en ;
-    rdfs:range [ owl:unionOf ( openlabel_v2:QuantitativeValue xsd:decimal ) ] ;
-    skos:definition "Speed (km/h)."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:Behaviour a owl:Class,
-        owl:ObjectProperty ;
-    rdfs:label "Behaviour"@en ;
-    rdfs:range openlabel_v2:Behaviour ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:MotionTurnRight ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:motionDecelerateValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:MotionCutOut ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:motionDriveValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:motionAccelerateValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:MotionOvertake ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:MotionUTurn ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:MotionAway ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:MotionAccelerate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:MotionDecelerate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:MotionAway ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:MotionCutIn ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:MotionSlide ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:MotionRun ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:MotionSlide ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:MotionOvertake ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:MotionTurnLeft ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:MotionLaneChangeLeft ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:MotionWalk ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:MotionCutIn ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:MotionTurnLeft ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:MotionTowards ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:BehaviourCommunication ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:MotionTurnRight ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:MotionRun ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:MotionCross ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:MotionLaneChangeLeft ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:MotionSlide ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:MotionCutOut ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:MotionTowards ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:MotionStop ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:unionOf ( openlabel_v2:QuantitativeValue xsd:decimal ) ] ;
-            owl:onProperty openlabel_v2:motionDriveValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:MotionCross ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:MotionWalk ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:MotionAccelerate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:unionOf ( openlabel_v2:QuantitativeValue xsd:decimal ) ] ;
-            owl:onProperty openlabel_v2:motionAccelerateValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:MotionOvertake ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:MotionDrive ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:MotionReverse ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:MotionDrive ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:MotionTurnRight ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:MotionLaneChangeRight ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:MotionReverse ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:MotionReverse ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:MotionUTurn ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:MotionCutOut ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:MotionAccelerate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:MotionDecelerate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:MotionUTurn ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:MotionTurn ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:motionDriveValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:unionOf ( openlabel_v2:QuantitativeValue xsd:decimal ) ] ;
-            owl:onProperty openlabel_v2:motionDecelerateValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:motionAccelerateValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:MotionAway ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:MotionLaneChangeRight ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:MotionTowards ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:motionDecelerateValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:MotionWalk ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:MotionCross ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:MotionRun ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:MotionStop ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:MotionTurnLeft ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:MotionTurn ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:MotionStop ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:MotionLaneChangeLeft ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:MotionDecelerate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom openlabel_v2:BehaviourCommunication ;
-            owl:onProperty openlabel_v2:BehaviourCommunication ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:MotionTurn ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:MotionDrive ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:MotionLaneChangeRight ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:MotionCutIn ] ;
-    skos:definition "An activity performed by a road user."@en,
-        "Behaviour tag."@en ;
-    skos:exactMatch openlabel_v2:Behaviour ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:HorizontalStraights a owl:DatatypeProperty ;
-    rdfs:label "HorizontalStraights"@en ;
-    rdfs:range xsd:boolean ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Straight lines flag. Refer to BSI PAS-1883 Section 5.2.3.3."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:LaneSpecificationMarking a owl:DatatypeProperty ;
-    rdfs:label "LaneSpecificationMarking"@en ;
-    rdfs:range xsd:boolean ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Lane marking flag. Refer to BSI PAS-1883 Section 5.2.3.4.b."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:LongitudinalLevelPlane a owl:DatatypeProperty ;
-    rdfs:label "LongitudinalLevelPlane"@en ;
-    rdfs:range xsd:boolean ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Level plane flag. Refer to BSI PAS-1883 Section 5.2.3.3.iii."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:TrafficSpecialVehicle a owl:DatatypeProperty ;
-    rdfs:label "TrafficSpecialVehicle"@en ;
-    rdfs:range xsd:boolean ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Presence of special vehicles flag. Refer to BSI PAS-1883 Section 5.4.a.5."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:trafficAgentTypeValue a owl:DatatypeProperty ;
-    rdfs:label "trafficAgentTypeValue"@en ;
-    rdfs:range [ owl:unionOf ( openlabel_v2:RoadUserHuman openlabel_v2:RoadUserVehicle ) ] ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Agent type. Refer to BSI PAS-1883 Section 5.4.a.4."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:DaySunElevation a owl:DatatypeProperty ;
-    rdfs:label "DaySunElevation"@en ;
-    rdfs:range xsd:boolean ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Elevation of the sun above the horizon flag. Refer to BSI PAS-1883 Section 5.3.3.a.1."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:HorizontalCurves a owl:DatatypeProperty ;
-    rdfs:label "HorizontalCurves"@en ;
-    rdfs:range xsd:boolean ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Curves flag. Refer to BSI PAS-1883 Section 5.2.3.3."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:IlluminationCloudiness a owl:DatatypeProperty ;
-    rdfs:label "IlluminationCloudiness"@en ;
-    rdfs:range xsd:boolean ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Cloudiness flag. Refer to BSI PAS-1883 Section 5.3.3.c."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:LaneSpecificationDimensions a owl:DatatypeProperty ;
-    rdfs:label "LaneSpecificationDimensions"@en ;
-    rdfs:range xsd:boolean ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Lane dimensions flag. Refer to BSI PAS-1883 Section 5.2.3.4.a."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:LaneSpecificationLaneCount a owl:DatatypeProperty ;
-    rdfs:label "LaneSpecificationLaneCount"@en ;
-    rdfs:range xsd:boolean ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Number of lanes flag. Refer to BSI PAS-1883 Section 5.2.3.4.d."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:LongitudinalDownSlope a owl:DatatypeProperty ;
-    rdfs:label "LongitudinalDownSlope"@en ;
-    rdfs:range xsd:boolean ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Down-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.ii."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:LongitudinalUpSlope a owl:DatatypeProperty ;
-    rdfs:label "LongitudinalUpSlope"@en ;
-    rdfs:range xsd:boolean ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Up-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.i."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:SubjectVehicleSpeed a owl:DatatypeProperty ;
-    rdfs:label "SubjectVehicleSpeed"@en ;
-    rdfs:range xsd:boolean ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Subject vehicle speed flag. Refer to BSI PAS-1883 Section 5.4.b."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:TrafficAgentDensity a owl:DatatypeProperty ;
-    rdfs:label "TrafficAgentDensity"@en ;
-    rdfs:range xsd:boolean ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Traffic agent density flag. Refer to BSI PAS-1883 Section 5.4.a.1."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:TrafficAgentType a owl:DatatypeProperty ;
-    rdfs:label "TrafficAgentType"@en ;
-    rdfs:range xsd:boolean ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Traffic agent type classification flag. Refer to BSI PAS-1883 Section 5.4.a.4."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:TrafficFlowRate a owl:DatatypeProperty ;
-    rdfs:label "TrafficFlowRate"@en ;
-    rdfs:range xsd:boolean ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Traffic flow rate flag. Refer to BSI PAS-1883 Section 5.4.a.3."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:TrafficVolume a owl:DatatypeProperty ;
-    rdfs:label "TrafficVolume"@en ;
-    rdfs:range xsd:boolean ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Traffic volume flag. Refer to BSI PAS-1883 Section 5.4.a.2."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:WeatherRain a owl:DatatypeProperty ;
-    rdfs:label "WeatherRain"@en ;
-    rdfs:range xsd:boolean ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Rainfall flag. Refer to BSI PAS-1883 Section 5.3.1.2."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:WeatherSnow a owl:DatatypeProperty ;
-    rdfs:label "WeatherSnow"@en ;
-    rdfs:range xsd:boolean ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Snowfall flag. Refer to BSI PAS-1883 Section 5.3.1.3."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:WeatherWind a owl:DatatypeProperty ;
-    rdfs:label "WeatherWind"@en ;
-    rdfs:range xsd:boolean ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Wind flag. Refer to BSI PAS-1883 Section 5.3.1.1."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:daySunElevationValue a owl:DatatypeProperty ;
-    rdfs:label "daySunElevationValue"@en ;
-    rdfs:range xsd:decimal ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Sun elevation (degrees). Refer to BSI PAS-1883 Section 5.3.3.a.1."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:horizontalCurvesValue a owl:DatatypeProperty ;
-    rdfs:label "horizontalCurvesValue"@en ;
-    rdfs:range xsd:decimal ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Curve radius (m). Refer to BSI PAS-1883 Section 5.2.3.3."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:illuminationCloudinessValue a owl:DatatypeProperty ;
-    rdfs:label "illuminationCloudinessValue"@en ;
-    rdfs:range xsd:decimal ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Cloud cover (okta). Refer to BSI PAS-1883 Section 5.3.3.c."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:laneSpecificationDimensionsValue a owl:DatatypeProperty ;
-    rdfs:label "laneSpecificationDimensionsValue"@en ;
-    rdfs:range [ owl:unionOf ( openlabel_v2:QuantitativeValue xsd:decimal ) ] ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Lane width (m). Refer to BSI PAS-1883 Section 5.2.3.4.a."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:laneSpecificationLaneCountValue a owl:DatatypeProperty ;
-    rdfs:label "laneSpecificationLaneCountValue"@en ;
-    rdfs:range [ owl:unionOf ( openlabel_v2:QuantitativeValue [ a rdfs:Datatype ;
-                        owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
-                                    owl:onDatatype xsd:integer ;
-                                    owl:withRestrictions ( [ xsd:minInclusive 1 ] ) ] ) ] ) ] ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Number of lanes (unit). Refer to BSI PAS-1883 Section 5.2.3.4.d."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:longitudinalDownSlopeValue a owl:DatatypeProperty ;
-    rdfs:label "longitudinalDownSlopeValue"@en ;
-    rdfs:range xsd:decimal ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.ii."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:longitudinalUpSlopeValue a owl:DatatypeProperty ;
-    rdfs:label "longitudinalUpSlopeValue"@en ;
-    rdfs:range xsd:decimal ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.i."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:particulatesWaterValue a owl:DatatypeProperty ;
-    rdfs:label "particulatesWaterValue"@en ;
-    rdfs:range xsd:decimal ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Meteorological Optical Range (MOR) (m). Refer to BSI PAS-1883 Section 5.3.2.b."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:subjectVehicleSpeedValue a owl:DatatypeProperty ;
-    rdfs:label "subjectVehicleSpeedValue"@en ;
-    rdfs:range [ owl:unionOf ( openlabel_v2:QuantitativeValue [ a rdfs:Datatype ;
-                        owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
-                                    owl:onDatatype xsd:integer ;
-                                    owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ) ] ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Speed (km/h). Refer to BSI PAS-1883 Section 5.4.b."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:trafficAgentDensityValue a owl:DatatypeProperty ;
-    rdfs:label "trafficAgentDensityValue"@en ;
-    rdfs:range [ a rdfs:Datatype ;
-            owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
-                        owl:onDatatype xsd:integer ;
-                        owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Density (vehicles/km). Refer to BSI PAS-1883 Section 5.4.a.1."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:trafficFlowRateValue a owl:DatatypeProperty ;
-    rdfs:label "trafficFlowRateValue"@en ;
-    rdfs:range [ a rdfs:Datatype ;
-            owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
-                        owl:onDatatype xsd:integer ;
-                        owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Rate (vehicles/h). Refer to BSI PAS-1883 Section 5.4.a.3."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:trafficVolumeValue a owl:DatatypeProperty ;
-    rdfs:label "trafficVolumeValue"@en ;
-    rdfs:range [ a rdfs:Datatype ;
-            owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
-                        owl:onDatatype xsd:integer ;
-                        owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Volume (vehicle km). Refer to BSI PAS-1883 Section 5.4.a.2."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:weatherRainValue a owl:DatatypeProperty ;
-    rdfs:label "weatherRainValue"@en ;
-    rdfs:range xsd:decimal ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Rainfall intensity (mm/h). Refer to BSI PAS-1883 Section 5.3.1.2."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:weatherSnowValue a owl:DatatypeProperty ;
-    rdfs:label "weatherSnowValue"@en ;
-    rdfs:range xsd:decimal ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Visibility (km). Refer to BSI PAS-1883 Section 5.3.1.3."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:weatherWindValue a owl:DatatypeProperty ;
-    rdfs:label "weatherWindValue"@en ;
-    rdfs:range xsd:decimal ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    skos:definition "Wind speed (m/s). Refer to BSI PAS-1883 Section 5.3.1.1."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:ParticulatesDust a owl:Class,
-        owl:DatatypeProperty ;
-    rdfs:label "ParticulatesDust"@en ;
-    rdfs:range xsd:boolean ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    rdfs:subClassOf openlabel_v2:EnvironmentParticulates ;
-    skos:definition "Sand and dust flag. Refer to BSI PAS-1883 Section 5.3.2.c."@en,
-        "Sand and dust."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:ParticulatesMarine a owl:Class,
-        owl:DatatypeProperty ;
-    rdfs:label "ParticulatesMarine"@en ;
-    rdfs:range xsd:boolean ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    rdfs:subClassOf openlabel_v2:EnvironmentParticulates ;
-    skos:definition "Marine (coastal areas only) flag. Refer to BSI PAS-1883 Section 5.3.2.a."@en,
-        "Marine (coastal areas only)."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:ParticulatesPollution a owl:Class,
-        owl:DatatypeProperty ;
-    rdfs:label "ParticulatesPollution"@en ;
-    rdfs:range xsd:boolean ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    rdfs:subClassOf openlabel_v2:EnvironmentParticulates ;
-    skos:definition "Smoke and pollution flag. Refer to BSI PAS-1883 Section 5.3.2.d."@en,
-        "Smoke and pollution."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:ParticulatesVolcanic a owl:Class,
-        owl:DatatypeProperty ;
-    rdfs:label "ParticulatesVolcanic"@en ;
-    rdfs:range xsd:boolean ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    rdfs:subClassOf openlabel_v2:EnvironmentParticulates ;
-    skos:definition "Volcanic ash flag. Refer to BSI PAS-1883 Section 5.3.2.e."@en,
-        "Volcanic ash."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:BehaviourCommunication a owl:Class,
-        owl:ObjectProperty ;
-    rdfs:label "BehaviourCommunication"@en,
-        "BehaviourCommunicationEnum"@en ;
-    rdfs:range openlabel_v2:BehaviourCommunication ;
-    owl:unionOf ( openlabel_v2:CommunicationHeadlightFlash openlabel_v2:CommunicationHorn openlabel_v2:CommunicationSignalEmergency openlabel_v2:CommunicationSignalHazard openlabel_v2:CommunicationSignalLeft openlabel_v2:CommunicationSignalRight openlabel_v2:CommunicationSignalSlowing openlabel_v2:CommunicationWave ) ;
-    skos:definition "Communication type of road user behaviour."@en,
-        "Types of communication behaviours by road users."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
-    linkml:permissible_values openlabel_v2:CommunicationHeadlightFlash,
-        openlabel_v2:CommunicationHorn,
-        openlabel_v2:CommunicationSignalEmergency,
-        openlabel_v2:CommunicationSignalHazard,
-        openlabel_v2:CommunicationSignalLeft,
-        openlabel_v2:CommunicationSignalRight,
-        openlabel_v2:CommunicationSignalSlowing,
-        openlabel_v2:CommunicationWave .
-
-openlabel_v2:ParticulatesWater a owl:Class,
-        owl:DatatypeProperty ;
-    rdfs:label "ParticulatesWater"@en ;
-    rdfs:range xsd:boolean ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    rdfs:subClassOf openlabel_v2:EnvironmentParticulates ;
-    skos:definition "Non-precipitating water droplets or ice crystals (i.e. mist/fog)."@en,
-        "Non-precipitating water droplets or ice crystals (mist/fog) flag. Refer to BSI PAS-1883 Section 5.3.2.b."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:IlluminationArtificial a owl:Class,
-        owl:ObjectProperty ;
-    rdfs:label "IlluminationArtificial"@en,
-        "IlluminationArtificialEnum"@en ;
-    rdfs:range openlabel_v2:IlluminationArtificial ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    owl:unionOf ( openlabel_v2:ArtificialStreetLighting openlabel_v2:ArtificialVehicleLighting ) ;
-    skos:definition "Artificial illumination type. Refer to BSI PAS-1883 Section 5.3.3.d."@en,
-        "Types of artificial illumination. Refer to BSI PAS-1883 Section 5.3.3.d."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
-    linkml:permissible_values openlabel_v2:ArtificialStreetLighting,
-        openlabel_v2:ArtificialVehicleLighting .
-
-openlabel_v2:IlluminationLowLight a owl:Class,
-        owl:ObjectProperty ;
-    rdfs:label "IlluminationLowLight"@en,
-        "IlluminationLowLightEnum"@en ;
-    rdfs:range openlabel_v2:IlluminationLowLight ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    owl:unionOf ( openlabel_v2:LowLightAmbient openlabel_v2:LowLightNight ) ;
-    skos:definition "Low light condition. Refer to BSI PAS-1883 Section 5.3.3.b."@en,
-        "Types of low light conditions. Refer to BSI PAS-1883 Section 5.3.3.b."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
-    linkml:permissible_values openlabel_v2:LowLightAmbient,
-        openlabel_v2:LowLightNight .
-
-openlabel_v2:LaneSpecificationTravelDirection a owl:Class,
-        owl:ObjectProperty ;
-    rdfs:label "LaneSpecificationTravelDirection"@en,
-        "LaneSpecificationTravelDirectionEnum"@en ;
-    rdfs:range openlabel_v2:LaneSpecificationTravelDirection ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    owl:unionOf ( openlabel_v2:TravelDirectionLeft openlabel_v2:TravelDirectionRight ) ;
-    skos:definition "Direction of travel. Refer to BSI PAS-1883 Section 5.2.3.4.e."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
-    linkml:permissible_values openlabel_v2:TravelDirectionLeft,
-        openlabel_v2:TravelDirectionRight .
-
-openlabel_v2:QuantitativeValue a owl:Class ;
-    rdfs:label "QuantitativeValue"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom xsd:decimal ;
-            owl:onProperty openlabel_v2:hasUpperBound ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:decimal ;
-            owl:onProperty openlabel_v2:hasLowerBound ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty openlabel_v2:minValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:hasUpperBound ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:hasUpperBound ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:decimal ;
-            owl:onProperty openlabel_v2:maxValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:minValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty openlabel_v2:maxValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:hasLowerBound ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:decimal ;
-            owl:onProperty openlabel_v2:minValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:hasLowerBound ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:maxValue ] ;
-    skos:definition "A point value or interval for quantitative measurements. Requires minValue and maxValue."@en ;
-    skos:exactMatch schema:QuantitativeValue ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-openlabel_v2:ConnectivityPositioning a owl:Class,
-        owl:ObjectProperty ;
-    rdfs:label "ConnectivityPositioning"@en,
-        "ConnectivityPositioningEnum"@en ;
-    rdfs:range openlabel_v2:ConnectivityPositioning ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    owl:unionOf ( openlabel_v2:PositioningGalileo openlabel_v2:PositioningGlonass openlabel_v2:PositioningGps ) ;
-    skos:definition "Positioning system type. Refer to BSI PAS-1883 Section 5.3.4.b."@en,
-        "Types of positioning systems. Refer to BSI PAS-1883 Section 5.3.4.b."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
-    linkml:permissible_values openlabel_v2:PositioningGalileo,
-        openlabel_v2:PositioningGlonass,
-        openlabel_v2:PositioningGps .
-
-openlabel_v2:DrivableAreaSurfaceType a owl:Class,
-        owl:ObjectProperty ;
-    rdfs:label "DrivableAreaSurfaceType"@en,
-        "DrivableAreaSurfaceTypeEnum"@en ;
-    rdfs:range openlabel_v2:DrivableAreaSurfaceType ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    owl:unionOf ( openlabel_v2:SurfaceTypeLoose openlabel_v2:SurfaceTypeSegmented openlabel_v2:SurfaceTypeUniform ) ;
-    skos:definition "Road surface type. Refer to BSI PAS-1883 Section 5.2.3.7.a."@en,
-        "Road surface types. Refer to BSI PAS-1883 Section 5.2.3.7.a."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
-    linkml:permissible_values openlabel_v2:SurfaceTypeLoose,
-        openlabel_v2:SurfaceTypeSegmented,
-        openlabel_v2:SurfaceTypeUniform .
-
-openlabel_v2:RainType a owl:Class,
-        owl:ObjectProperty ;
-    rdfs:label "RainType"@en,
-        "RainTypeEnum"@en ;
-    rdfs:range openlabel_v2:RainType ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    owl:unionOf ( openlabel_v2:RainTypeConvective openlabel_v2:RainTypeDynamic openlabel_v2:RainTypeOrographic ) ;
-    skos:definition "Rainfall type. Refer to BSI PAS-1883 Section 5.3.1.2."@en,
-        "Types of rainfall. Refer to BSI PAS-1883 Section 5.3.1.2."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
-    linkml:permissible_values openlabel_v2:RainTypeConvective,
-        openlabel_v2:RainTypeDynamic,
-        openlabel_v2:RainTypeOrographic .
-
-openlabel_v2:RoadUserHuman a owl:Class,
-        owl:ObjectProperty ;
-    rdfs:label "RoadUserHuman"@en,
-        "RoadUserHumanEnum"@en ;
-    rdfs:range openlabel_v2:RoadUserHuman ;
-    owl:unionOf ( openlabel_v2:HumanAnimalRider openlabel_v2:HumanCyclist openlabel_v2:HumanDriver openlabel_v2:HumanMotorcyclist openlabel_v2:HumanPassenger openlabel_v2:HumanPedestrian openlabel_v2:HumanWheelchairUser ) ;
-    skos:definition "Human road user type."@en,
-        "Types of human road users."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
-    linkml:permissible_values openlabel_v2:HumanAnimalRider,
-        openlabel_v2:HumanCyclist,
-        openlabel_v2:HumanDriver,
-        openlabel_v2:HumanMotorcyclist,
-        openlabel_v2:HumanPassenger,
-        openlabel_v2:HumanPedestrian,
-        openlabel_v2:HumanWheelchairUser .
-
-openlabel_v2:DaySunPosition a owl:Class,
-        owl:ObjectProperty ;
-    rdfs:label "DaySunPosition"@en,
-        "DaySunPositionEnum"@en ;
-    rdfs:range openlabel_v2:DaySunPosition ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    owl:unionOf ( openlabel_v2:SunPositionBehind openlabel_v2:SunPositionFront openlabel_v2:SunPositionLeft openlabel_v2:SunPositionRight ) ;
-    skos:definition "Position of the sun relative to direction of travel. Refer to BSI PAS-1883 Section 5.3.3.a.2."@en,
-        "Position of the sun. Refer to BSI PAS-1883 Section 5.3.3.a.2."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
-    linkml:permissible_values openlabel_v2:SunPositionBehind,
-        openlabel_v2:SunPositionFront,
-        openlabel_v2:SunPositionLeft,
-        openlabel_v2:SunPositionRight .
-
-openlabel_v2:DrivableAreaSurfaceFeature a owl:Class,
-        owl:ObjectProperty ;
-    rdfs:label "DrivableAreaSurfaceFeature"@en,
-        "DrivableAreaSurfaceFeatureEnum"@en ;
-    rdfs:range openlabel_v2:DrivableAreaSurfaceFeature ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    owl:unionOf ( openlabel_v2:SurfaceFeatureCrack openlabel_v2:SurfaceFeaturePothole openlabel_v2:SurfaceFeatureRut openlabel_v2:SurfaceFeatureSwell ) ;
-    skos:definition "Road surface feature. Refer to BSI PAS-1883 Section 5.2.3.7.b."@en,
-        "Road surface features. Refer to BSI PAS-1883 Section 5.2.3.7.b."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
-    linkml:permissible_values openlabel_v2:SurfaceFeatureCrack,
-        openlabel_v2:SurfaceFeaturePothole,
-        openlabel_v2:SurfaceFeatureRut,
-        openlabel_v2:SurfaceFeatureSwell .
-
-openlabel_v2:SceneryFixedStructure a owl:Class,
-        owl:ObjectProperty ;
-    rdfs:label "SceneryFixedStructure"@en,
-        "SceneryFixedStructureEnum"@en ;
-    rdfs:range openlabel_v2:SceneryFixedStructure ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    owl:unionOf ( openlabel_v2:FixedStructureBuilding openlabel_v2:FixedStructureStreetFurniture openlabel_v2:FixedStructureStreetlight openlabel_v2:FixedStructureVegetation ) ;
-    skos:definition "Fixed road structure. Refer to BSI PAS-1883 Section 5.2.1.e."@en,
-        "Types of fixed road structures. Refer to BSI PAS-1883 Section 5.2.6."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
-    linkml:permissible_values openlabel_v2:FixedStructureBuilding,
-        openlabel_v2:FixedStructureStreetFurniture,
-        openlabel_v2:FixedStructureStreetlight,
-        openlabel_v2:FixedStructureVegetation .
-
-openlabel_v2:SceneryTemporaryStructure a owl:Class,
-        owl:ObjectProperty ;
-    rdfs:label "SceneryTemporaryStructure"@en,
-        "SceneryTemporaryStructureEnum"@en ;
-    rdfs:range openlabel_v2:SceneryTemporaryStructure ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    owl:unionOf ( openlabel_v2:TemporaryStructureConstructionDetour openlabel_v2:TemporaryStructureRefuseCollection openlabel_v2:TemporaryStructureRoadSignage openlabel_v2:TemporaryStructureRoadWorks ) ;
-    skos:definition "Temporary road structure. Refer to BSI PAS-1883 Section 5.2.1.f."@en,
-        "Types of temporary road structures. Refer to BSI PAS-1883 Section 5.2.7."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
-    linkml:permissible_values openlabel_v2:TemporaryStructureConstructionDetour,
-        openlabel_v2:TemporaryStructureRefuseCollection,
-        openlabel_v2:TemporaryStructureRoadSignage,
-        openlabel_v2:TemporaryStructureRoadWorks .
-
-openlabel_v2:SignsInformation a owl:Class,
-        owl:ObjectProperty ;
-    rdfs:label "SignsInformation"@en,
-        "SignsInformationEnum"@en ;
-    rdfs:range openlabel_v2:SignsInformation ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    owl:unionOf ( openlabel_v2:InformationSignsUniformFullTime openlabel_v2:InformationSignsUniformTemporary openlabel_v2:InformationSignsVariableFullTime openlabel_v2:InformationSignsVariableTemporary ) ;
-    skos:definition "Information sign type. Refer to BSI PAS-1883 Section 5.2.3.5.a."@en,
-        "Types of information signs. Refer to BSI PAS-1883 Section 5.2.3.5.a."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
-    linkml:permissible_values openlabel_v2:InformationSignsUniformFullTime,
-        openlabel_v2:InformationSignsUniformTemporary,
-        openlabel_v2:InformationSignsVariableFullTime,
-        openlabel_v2:InformationSignsVariableTemporary .
-
-openlabel_v2:SignsRegulatory a owl:Class,
-        owl:ObjectProperty ;
-    rdfs:label "SignsRegulatory"@en,
-        "SignsRegulatoryEnum"@en ;
-    rdfs:range openlabel_v2:SignsRegulatory ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    owl:unionOf ( openlabel_v2:RegulatorySignsUniformFullTime openlabel_v2:RegulatorySignsUniformTemporary openlabel_v2:RegulatorySignsVariableFullTime openlabel_v2:RegulatorySignsVariableTemporary ) ;
-    skos:definition "Regulatory sign type. Refer to BSI PAS-1883 Section 5.2.3.5.b."@en,
-        "Types of regulatory signs. Refer to BSI PAS-1883 Section 5.2.3.5.b."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
-    linkml:permissible_values openlabel_v2:RegulatorySignsUniformFullTime,
-        openlabel_v2:RegulatorySignsUniformTemporary,
-        openlabel_v2:RegulatorySignsVariableFullTime,
-        openlabel_v2:RegulatorySignsVariableTemporary .
-
-openlabel_v2:DrivableAreaEdge a owl:Class,
-        owl:ObjectProperty ;
-    rdfs:label "DrivableAreaEdge"@en,
-        "DrivableAreaEdgeEnum"@en ;
-    rdfs:range openlabel_v2:DrivableAreaEdge ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    owl:unionOf ( openlabel_v2:EdgeLineMarkers openlabel_v2:EdgeNone openlabel_v2:EdgeShoulderGrass openlabel_v2:EdgeShoulderPavedOrGravel openlabel_v2:EdgeSolidBarriers openlabel_v2:EdgeTemporaryLineMarkers ) ;
-    skos:definition "Drivable area edge type. Refer to BSI PAS-1883 Section 5.2.3.1.e."@en,
-        "Types of drivable area edges. Refer to BSI PAS-1883 Section 5.2.3.6."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
-    linkml:permissible_values openlabel_v2:EdgeLineMarkers,
-        openlabel_v2:EdgeNone,
-        openlabel_v2:EdgeShoulderGrass,
-        openlabel_v2:EdgeShoulderPavedOrGravel,
-        openlabel_v2:EdgeSolidBarriers,
-        openlabel_v2:EdgeTemporaryLineMarkers .
-
-openlabel_v2:EnvironmentParticulates a owl:Class,
-        owl:ObjectProperty ;
-    rdfs:label "EnvironmentParticulates"@en,
-        "EnvironmentParticulatesEnum"@en ;
-    rdfs:range openlabel_v2:EnvironmentParticulates ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    owl:unionOf ( openlabel_v2:ParticulatesDust openlabel_v2:ParticulatesMarine openlabel_v2:ParticulatesPollution openlabel_v2:ParticulatesVolcanic openlabel_v2:ParticulatesWater ) ;
-    skos:definition "Particulate type. Refer to BSI PAS-1883 Section 5.3.2."@en,
-        "Types of particulates. Refer to BSI PAS-1883 Section 5.3.2."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
-    linkml:permissible_values openlabel_v2:ParticulatesDust,
-        openlabel_v2:ParticulatesMarine,
-        openlabel_v2:ParticulatesPollution,
-        openlabel_v2:ParticulatesVolcanic,
-        openlabel_v2:ParticulatesWater .
-
-openlabel_v2:GeometryTransverse a owl:Class,
-        owl:ObjectProperty ;
-    rdfs:label "GeometryTransverse"@en,
-        "GeometryTransverseEnum"@en ;
-    rdfs:range openlabel_v2:GeometryTransverse ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    owl:unionOf ( openlabel_v2:TransverseBarriers openlabel_v2:TransverseDivided openlabel_v2:TransverseLanesTogether openlabel_v2:TransversePavements openlabel_v2:TransverseUndivided ) ;
-    skos:definition "Transverse geometry type. Refer to BSI PAS-1883 Section 5.2.3.3.b."@en,
-        "Types of transverse geometry. Refer to BSI PAS-1883 Section 5.2.3.3.b."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
-    linkml:permissible_values openlabel_v2:TransverseBarriers,
-        openlabel_v2:TransverseDivided,
-        openlabel_v2:TransverseLanesTogether,
-        openlabel_v2:TransversePavements,
-        openlabel_v2:TransverseUndivided .
-
-openlabel_v2:JunctionIntersection a owl:Class,
-        owl:ObjectProperty ;
-    rdfs:label "JunctionIntersection"@en,
-        "JunctionIntersectionEnum"@en ;
-    rdfs:range openlabel_v2:JunctionIntersection ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    owl:unionOf ( openlabel_v2:IntersectionCrossroad openlabel_v2:IntersectionGradeSeperated openlabel_v2:IntersectionStaggered openlabel_v2:IntersectionTJunction openlabel_v2:IntersectionYJunction ) ;
-    skos:definition "Intersection type. Refer to BSI PAS-1883 Section 5.2.4."@en,
-        "Types of intersections. Refer to BSI PAS-1883 Section 5.2.4."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
-    linkml:permissible_values openlabel_v2:IntersectionCrossroad,
-        openlabel_v2:IntersectionGradeSeperated,
-        openlabel_v2:IntersectionStaggered,
-        openlabel_v2:IntersectionTJunction,
-        openlabel_v2:IntersectionYJunction .
-
-openlabel_v2:LaneSpecificationType a owl:Class,
-        owl:ObjectProperty ;
-    rdfs:label "LaneSpecificationType"@en,
-        "LaneSpecificationTypeEnum"@en ;
-    rdfs:range openlabel_v2:LaneSpecificationType ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    owl:unionOf ( openlabel_v2:LaneTypeBus openlabel_v2:LaneTypeCycle openlabel_v2:LaneTypeEmergency openlabel_v2:LaneTypeSpecial openlabel_v2:LaneTypeTraffic openlabel_v2:LaneTypeTram ) ;
-    skos:definition "Lane type. Refer to BSI PAS-1883 Section 5.2.3.4.c."@en,
-        "Types of lanes. Refer to BSI PAS-1883 Section 5.2.3.4.c."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
-    linkml:permissible_values openlabel_v2:LaneTypeBus,
-        openlabel_v2:LaneTypeCycle,
-        openlabel_v2:LaneTypeEmergency,
-        openlabel_v2:LaneTypeSpecial,
-        openlabel_v2:LaneTypeTraffic,
-        openlabel_v2:LaneTypeTram .
-
-openlabel_v2:SceneryZone a owl:Class,
-        owl:ObjectProperty ;
-    rdfs:label "SceneryZone"@en,
-        "SceneryZoneEnum"@en ;
-    rdfs:range openlabel_v2:SceneryZone ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    owl:unionOf ( openlabel_v2:ZoneGeoFenced openlabel_v2:ZoneInterference openlabel_v2:ZoneRegion openlabel_v2:ZoneSchool openlabel_v2:ZoneTrafficManagement ) ;
-    skos:definition "Types of zones. Refer to BSI PAS-1883 Section 5.2.2."@en,
-        "Zone type. Refer to BSI PAS-1883 Section 5.2.1.a."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
-    linkml:permissible_values openlabel_v2:ZoneGeoFenced,
-        openlabel_v2:ZoneInterference,
-        openlabel_v2:ZoneRegion,
-        openlabel_v2:ZoneSchool,
-        openlabel_v2:ZoneTrafficManagement .
-
-openlabel_v2:SignsWarning a owl:Class,
-        owl:ObjectProperty ;
-    rdfs:label "SignsWarning"@en,
-        "SignsWarningEnum"@en ;
-    rdfs:range openlabel_v2:SignsWarning ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    owl:unionOf ( openlabel_v2:WarningSignsUniform openlabel_v2:WarningSignsUniformFullTime openlabel_v2:WarningSignsUniformTemporary openlabel_v2:WarningSignsVariableFullTime openlabel_v2:WarningSignsVariableTemporary ) ;
-    skos:definition "Types of warning signs. Refer to BSI PAS-1883 Section 5.2.3.5.c."@en,
-        "Warning sign type. Refer to BSI PAS-1883 Section 5.2.3.5.c."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
-    linkml:permissible_values openlabel_v2:WarningSignsUniform,
-        openlabel_v2:WarningSignsUniformFullTime,
-        openlabel_v2:WarningSignsUniformTemporary,
-        openlabel_v2:WarningSignsVariableFullTime,
-        openlabel_v2:WarningSignsVariableTemporary .
-
-openlabel_v2:ScenerySpecialStructure a owl:Class,
-        owl:ObjectProperty ;
-    rdfs:label "ScenerySpecialStructure"@en,
-        "ScenerySpecialStructureEnum"@en ;
-    rdfs:range openlabel_v2:ScenerySpecialStructure ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    owl:unionOf ( openlabel_v2:SpecialStructureAutoAccess openlabel_v2:SpecialStructureBridge openlabel_v2:SpecialStructurePedestrianCrossing openlabel_v2:SpecialStructureRailCrossing openlabel_v2:SpecialStructureTollPlaza openlabel_v2:SpecialStructureTunnel ) ;
-    skos:definition "Special road structure. Refer to BSI PAS-1883 Section 5.2.1.d."@en,
-        "Types of special road structures. Refer to BSI PAS-1883 Section 5.2.5."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
-    linkml:permissible_values openlabel_v2:SpecialStructureAutoAccess,
-        openlabel_v2:SpecialStructureBridge,
-        openlabel_v2:SpecialStructurePedestrianCrossing,
-        openlabel_v2:SpecialStructureRailCrossing,
-        openlabel_v2:SpecialStructureTollPlaza,
-        openlabel_v2:SpecialStructureTunnel .
-
-openlabel_v2:DrivableAreaSurfaceCondition a owl:Class,
-        owl:ObjectProperty ;
-    rdfs:label "DrivableAreaSurfaceCondition"@en,
-        "DrivableAreaSurfaceConditionEnum"@en ;
-    rdfs:range openlabel_v2:DrivableAreaSurfaceCondition ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    owl:unionOf ( openlabel_v2:SurfaceConditionContamination openlabel_v2:SurfaceConditionFlooded openlabel_v2:SurfaceConditionIcy openlabel_v2:SurfaceConditionMirage openlabel_v2:SurfaceConditionSnow openlabel_v2:SurfaceConditionStandingWater openlabel_v2:SurfaceConditionWet ) ;
-    skos:definition "Road surface condition. Refer to BSI PAS-1883 Section 5.2.3.7.c."@en,
-        "Road surface conditions. Refer to BSI PAS-1883 Section 5.2.3.7.c."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
-    linkml:permissible_values openlabel_v2:SurfaceConditionContamination,
-        openlabel_v2:SurfaceConditionFlooded,
-        openlabel_v2:SurfaceConditionIcy,
-        openlabel_v2:SurfaceConditionMirage,
-        openlabel_v2:SurfaceConditionSnow,
-        openlabel_v2:SurfaceConditionStandingWater,
-        openlabel_v2:SurfaceConditionWet .
-
-openlabel_v2:RoadUserVehicle a owl:Class,
-        owl:ObjectProperty ;
-    rdfs:label "RoadUserVehicle"@en,
-        "RoadUserVehicleEnum"@en ;
-    rdfs:range openlabel_v2:RoadUserVehicle ;
-    owl:unionOf ( openlabel_v2:VehicleAgricultural openlabel_v2:VehicleBus openlabel_v2:VehicleCar openlabel_v2:VehicleConstruction openlabel_v2:VehicleCycle openlabel_v2:VehicleEmergency openlabel_v2:VehicleMotorcycle openlabel_v2:VehicleTrailer openlabel_v2:VehicleTruck openlabel_v2:VehicleVan openlabel_v2:VehicleWheelchair ) ;
-    skos:definition "Types of vehicles."@en,
-        "Vehicle type."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
-    linkml:permissible_values openlabel_v2:VehicleAgricultural,
-        openlabel_v2:VehicleBus,
-        openlabel_v2:VehicleCar,
-        openlabel_v2:VehicleConstruction,
-        openlabel_v2:VehicleCycle,
-        openlabel_v2:VehicleEmergency,
-        openlabel_v2:VehicleMotorcycle,
-        openlabel_v2:VehicleTrailer,
-        openlabel_v2:VehicleTruck,
-        openlabel_v2:VehicleVan,
-        openlabel_v2:VehicleWheelchair .
-
-openlabel_v2:ConnectivityCommunication a owl:Class,
-        owl:ObjectProperty ;
-    rdfs:label "ConnectivityCommunication"@en,
-        "ConnectivityCommunicationEnum"@en ;
-    rdfs:range openlabel_v2:ConnectivityCommunication ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    owl:unionOf ( openlabel_v2:CommunicationV2i openlabel_v2:CommunicationV2v openlabel_v2:V2iCellular openlabel_v2:V2iSatellite openlabel_v2:V2iWifi openlabel_v2:V2vCellular openlabel_v2:V2vSatellite openlabel_v2:V2vWifi ) ;
-    skos:definition "Communication connectivity type. Refer to BSI PAS-1883 Section 5.3.4.a."@en,
-        "Types of communication connectivity. Refer to BSI PAS-1883 Section 5.3.4.a."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
-    linkml:permissible_values openlabel_v2:CommunicationV2i,
-        openlabel_v2:CommunicationV2v,
-        openlabel_v2:V2iCellular,
-        openlabel_v2:V2iSatellite,
-        openlabel_v2:V2iWifi,
-        openlabel_v2:V2vCellular,
-        openlabel_v2:V2vSatellite,
-        openlabel_v2:V2vWifi .
-
-openlabel_v2:DrivableAreaType a owl:Class,
-        owl:ObjectProperty ;
-    rdfs:label "DrivableAreaType"@en,
-        "DrivableAreaTypeEnum"@en ;
-    rdfs:range openlabel_v2:DrivableAreaType ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    owl:unionOf ( openlabel_v2:MotorwayManaged openlabel_v2:MotorwayUnmanaged openlabel_v2:RoadTypeDistributor openlabel_v2:RoadTypeMinor openlabel_v2:RoadTypeMotorway openlabel_v2:RoadTypeParking openlabel_v2:RoadTypeRadial openlabel_v2:RoadTypeShared openlabel_v2:RoadTypeSlip ) ;
-    skos:definition "Road type. Refer to BSI PAS-1883 Section 5.2.3.2."@en,
-        "Road types. Refer to BSI PAS-1883 Section 5.2.3.2."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
-    linkml:permissible_values openlabel_v2:MotorwayManaged,
-        openlabel_v2:MotorwayUnmanaged,
-        openlabel_v2:RoadTypeDistributor,
-        openlabel_v2:RoadTypeMinor,
-        openlabel_v2:RoadTypeMotorway,
-        openlabel_v2:RoadTypeParking,
-        openlabel_v2:RoadTypeRadial,
-        openlabel_v2:RoadTypeShared,
-        openlabel_v2:RoadTypeSlip .
-
-openlabel_v2:JunctionRoundabout a owl:Class,
-        owl:ObjectProperty ;
-    rdfs:label "JunctionRoundabout"@en,
-        "JunctionRoundaboutEnum"@en ;
-    rdfs:range openlabel_v2:JunctionRoundabout ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    owl:unionOf ( openlabel_v2:RoundaboutCompactNosignal openlabel_v2:RoundaboutCompactSignal openlabel_v2:RoundaboutDoubleNosignal openlabel_v2:RoundaboutDoubleSignal openlabel_v2:RoundaboutLargeNosignal openlabel_v2:RoundaboutLargeSignal openlabel_v2:RoundaboutMiniNosignal openlabel_v2:RoundaboutMiniSignal openlabel_v2:RoundaboutNormalNosignal openlabel_v2:RoundaboutNormalSignal ) ;
-    skos:definition "Roundabout type. Refer to BSI PAS-1883 Section 5.2.4."@en,
-        "Types of roundabouts. Refer to BSI PAS-1883 Section 5.2.4."@en ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
-    linkml:permissible_values openlabel_v2:RoundaboutCompactNosignal,
-        openlabel_v2:RoundaboutCompactSignal,
-        openlabel_v2:RoundaboutDoubleNosignal,
-        openlabel_v2:RoundaboutDoubleSignal,
-        openlabel_v2:RoundaboutLargeNosignal,
-        openlabel_v2:RoundaboutLargeSignal,
-        openlabel_v2:RoundaboutMiniNosignal,
-        openlabel_v2:RoundaboutMiniSignal,
-        openlabel_v2:RoundaboutNormalNosignal,
-        openlabel_v2:RoundaboutNormalSignal .
-
-openlabel_v2:Odd a owl:Class,
-        owl:ObjectProperty ;
-    rdfs:label "Odd"@en ;
-    rdfs:range openlabel_v2:Odd ;
-    rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:weatherWindValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:ParticulatesPollution ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:LongitudinalLevelPlane ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom openlabel_v2:SignsInformation ;
-            owl:onProperty openlabel_v2:SignsInformation ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:particulatesWaterValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:TrafficVolume ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:TrafficAgentType ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:ParticulatesVolcanic ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:SignsRegulatory ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:ParticulatesWater ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
-                                owl:onDatatype xsd:integer ;
-                                owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ;
-            owl:onProperty openlabel_v2:trafficFlowRateValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:decimal ;
-            owl:onProperty openlabel_v2:daySunElevationValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:TrafficSpecialVehicle ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
-                                owl:onDatatype xsd:integer ;
-                                owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ;
-            owl:onProperty openlabel_v2:trafficVolumeValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:trafficFlowRateValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:trafficFlowRateValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:WeatherRain ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:decimal ;
-            owl:onProperty openlabel_v2:weatherSnowValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:HorizontalStraights ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:trafficVolumeValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:ParticulatesPollution ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:DrivableAreaSurfaceFeature ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:TrafficFlowRate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:unionOf ( openlabel_v2:QuantitativeValue [ a rdfs:Datatype ;
-                                owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
-                                            owl:onDatatype xsd:integer ;
-                                            owl:withRestrictions ( [ xsd:minInclusive 1 ] ) ] ) ] ) ] ;
-            owl:onProperty openlabel_v2:laneSpecificationLaneCountValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:SceneryTemporaryStructure ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:laneSpecificationDimensionsValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:LaneSpecificationDimensions ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom openlabel_v2:IlluminationLowLight ;
-            owl:onProperty openlabel_v2:IlluminationLowLight ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:WeatherRain ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:trafficVolumeValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:SubjectVehicleSpeed ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:daySunElevationValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom openlabel_v2:DrivableAreaSurfaceType ;
-            owl:onProperty openlabel_v2:DrivableAreaSurfaceType ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:ParticulatesDust ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:LaneSpecificationTravelDirection ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom openlabel_v2:JunctionIntersection ;
-            owl:onProperty openlabel_v2:JunctionIntersection ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom openlabel_v2:ScenerySpecialStructure ;
-            owl:onProperty openlabel_v2:ScenerySpecialStructure ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:illuminationCloudinessValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:trafficAgentDensityValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:TrafficFlowRate ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:DaySunElevation ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:longitudinalUpSlopeValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:horizontalCurvesValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:GeometryTransverse ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:DrivableAreaSurfaceCondition ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:TrafficVolume ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:unionOf ( openlabel_v2:QuantitativeValue [ a rdfs:Datatype ;
-                                owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
-                                            owl:onDatatype xsd:integer ;
-                                            owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ) ] ;
-            owl:onProperty openlabel_v2:subjectVehicleSpeedValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:daySunElevationValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:ParticulatesMarine ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:SceneryFixedStructure ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:LaneSpecificationMarking ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom openlabel_v2:JunctionRoundabout ;
-            owl:onProperty openlabel_v2:JunctionRoundabout ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:DaySunElevation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom openlabel_v2:IlluminationArtificial ;
-            owl:onProperty openlabel_v2:IlluminationArtificial ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:decimal ;
-            owl:onProperty openlabel_v2:weatherWindValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:WeatherWind ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:IlluminationLowLight ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:SceneryZone ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:TrafficAgentDensity ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:decimal ;
-            owl:onProperty openlabel_v2:weatherRainValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:TrafficFlowRate ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:EnvironmentParticulates ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:DrivableAreaSurfaceCondition ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:GeometryTransverse ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:unionOf ( openlabel_v2:RoadUserHuman openlabel_v2:RoadUserVehicle ) ] ;
-            owl:onProperty openlabel_v2:trafficAgentTypeValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom openlabel_v2:SignsWarning ;
-            owl:onProperty openlabel_v2:SignsWarning ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:weatherSnowValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:IlluminationCloudiness ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:WeatherWind ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:LaneSpecificationLaneCount ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:LongitudinalUpSlope ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:DrivableAreaEdge ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:weatherRainValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:SceneryZone ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:HorizontalStraights ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:weatherSnowValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:DrivableAreaSurfaceFeature ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:LaneSpecificationMarking ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:SignsRegulatory ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:ConnectivityPositioning ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:RainType ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:SceneryFixedStructure ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:laneSpecificationLaneCountValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:ParticulatesDust ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:IlluminationCloudiness ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:ParticulatesMarine ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:IlluminationArtificial ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom openlabel_v2:DrivableAreaSurfaceFeature ;
-            owl:onProperty openlabel_v2:DrivableAreaSurfaceFeature ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:weatherRainValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:JunctionRoundabout ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:LongitudinalDownSlope ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:TrafficAgentType ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom openlabel_v2:DrivableAreaEdge ;
-            owl:onProperty openlabel_v2:DrivableAreaEdge ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:TrafficSpecialVehicle ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:LaneSpecificationDimensions ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:SignsWarning ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:illuminationCloudinessValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:ConnectivityPositioning ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:trafficAgentTypeValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:SubjectVehicleSpeed ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom openlabel_v2:LaneSpecificationTravelDirection ;
-            owl:onProperty openlabel_v2:LaneSpecificationTravelDirection ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
-                                owl:onDatatype xsd:integer ;
-                                owl:withRestrictions ( [ xsd:minInclusive 0 ] ) ] ) ] ;
-            owl:onProperty openlabel_v2:trafficAgentDensityValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:LaneSpecificationDimensions ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:decimal ;
-            owl:onProperty openlabel_v2:longitudinalDownSlopeValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:TrafficSpecialVehicle ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:ParticulatesWater ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:LaneSpecificationTravelDirection ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:TrafficAgentType ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:decimal ;
-            owl:onProperty openlabel_v2:illuminationCloudinessValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:RainType ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:HorizontalCurves ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:WeatherSnow ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:ScenerySpecialStructure ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:IlluminationCloudiness ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom openlabel_v2:EnvironmentParticulates ;
-            owl:onProperty openlabel_v2:EnvironmentParticulates ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:WeatherSnow ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:IlluminationLowLight ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:TrafficAgentDensity ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:JunctionIntersection ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom openlabel_v2:LaneSpecificationType ;
-            owl:onProperty openlabel_v2:LaneSpecificationType ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom openlabel_v2:SignsRegulatory ;
-            owl:onProperty openlabel_v2:SignsRegulatory ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:ParticulatesVolcanic ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:ConnectivityCommunication ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:longitudinalDownSlopeValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:ParticulatesPollution ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:DrivableAreaSurfaceType ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:SubjectVehicleSpeed ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom openlabel_v2:ConnectivityPositioning ;
-            owl:onProperty openlabel_v2:ConnectivityPositioning ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:IlluminationArtificial ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:SignsInformation ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:ParticulatesVolcanic ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:TrafficVolume ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:LongitudinalDownSlope ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:decimal ;
-            owl:onProperty openlabel_v2:longitudinalUpSlopeValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom openlabel_v2:RainType ;
-            owl:onProperty openlabel_v2:RainType ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:longitudinalDownSlopeValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:LongitudinalUpSlope ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:horizontalCurvesValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:LongitudinalUpSlope ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:DrivableAreaType ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom openlabel_v2:SceneryTemporaryStructure ;
-            owl:onProperty openlabel_v2:SceneryTemporaryStructure ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:ParticulatesMarine ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom openlabel_v2:SceneryFixedStructure ;
-            owl:onProperty openlabel_v2:SceneryFixedStructure ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:LaneSpecificationMarking ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:trafficAgentDensityValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:WeatherRain ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom openlabel_v2:DrivableAreaType ;
-            owl:onProperty openlabel_v2:DrivableAreaType ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:HorizontalStraights ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:decimal ;
-            owl:onProperty openlabel_v2:horizontalCurvesValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:WeatherSnow ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:DrivableAreaSurfaceType ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:subjectVehicleSpeedValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:weatherWindValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:SceneryTemporaryStructure ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:particulatesWaterValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:TrafficAgentDensity ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:DaySunPosition ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:LongitudinalLevelPlane ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:LaneSpecificationLaneCount ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:JunctionRoundabout ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom openlabel_v2:SceneryZone ;
-            owl:onProperty openlabel_v2:SceneryZone ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom openlabel_v2:GeometryTransverse ;
-            owl:onProperty openlabel_v2:GeometryTransverse ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:laneSpecificationLaneCountValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:LongitudinalDownSlope ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:JunctionIntersection ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:ParticulatesDust ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:LongitudinalLevelPlane ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ owl:unionOf ( openlabel_v2:QuantitativeValue xsd:decimal ) ] ;
-            owl:onProperty openlabel_v2:laneSpecificationDimensionsValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:decimal ;
-            owl:onProperty openlabel_v2:particulatesWaterValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:DaySunElevation ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:ConnectivityCommunication ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:SignsInformation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom openlabel_v2:DrivableAreaSurfaceCondition ;
-            owl:onProperty openlabel_v2:DrivableAreaSurfaceCondition ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:ParticulatesWater ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:LaneSpecificationType ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:longitudinalUpSlopeValue ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:HorizontalCurves ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:SignsWarning ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:WeatherWind ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:boolean ;
-            owl:onProperty openlabel_v2:LaneSpecificationLaneCount ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom openlabel_v2:DaySunPosition ;
-            owl:onProperty openlabel_v2:DaySunPosition ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:DaySunPosition ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:laneSpecificationDimensionsValue ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:ScenerySpecialStructure ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:DrivableAreaType ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:subjectVehicleSpeedValue ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty openlabel_v2:HorizontalCurves ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty openlabel_v2:EnvironmentParticulates ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom openlabel_v2:ConnectivityCommunication ;
-            owl:onProperty openlabel_v2:ConnectivityCommunication ] ;
-    skos:definition "Operational Design Domain tag."@en,
-        "Operational Design Domain. Refer to BSI PAS-1883 Section 5."@en ;
-    skos:exactMatch openlabel_v2:Odd ;
-    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
-
-<https://w3id.org/ascs-ev/envited-x/openlabel/v2> a owl:Ontology ;
-    rdfs:label "openlabel-v2"@en ;
-    dcterms:license "https://www.eclipse.org/legal/epl-2.0/"@en ;
-    dcterms:title "ASAM OpenLABEL Scenario Tagging Ontology"@en ;
-    pav:version "2.0.0"@en ;
-    skos:definition "Ontology for scenario tagging based on the ASAM OpenLABEL standard and BSI PAS-1883 Operational Design Domain taxonomy."@en .
-
-[] rdfs:subClassOf [ a owl:Restriction ;
-            owl:onProperty openlabel_v2:HorizontalCurves ;
-            owl:someValuesFrom [ a rdfs:Datatype ;
-                    owl:onDatatype xsd:string ;
-                    owl:withRestrictions ( [ xsd:pattern "true" ] ) ] ] ;
-    owl:intersectionOf ( [ a owl:Restriction ;
-                owl:onProperty openlabel_v2:horizontalCurvesValue ;
-                owl:someValuesFrom xsd:string ] openlabel_v2:Odd ) .
-
-[] rdfs:subClassOf [ a owl:Restriction ;
-            owl:onProperty openlabel_v2:TrafficFlowRate ;
-            owl:someValuesFrom [ a rdfs:Datatype ;
-                    owl:onDatatype xsd:string ;
-                    owl:withRestrictions ( [ xsd:pattern "true" ] ) ] ] ;
-    owl:intersectionOf ( [ a owl:Restriction ;
-                owl:onProperty openlabel_v2:trafficFlowRateValue ;
-                owl:someValuesFrom xsd:string ] openlabel_v2:Odd ) .
-
-[] rdfs:subClassOf [ a owl:Restriction ;
-            owl:onProperty openlabel_v2:SubjectVehicleSpeed ;
-            owl:someValuesFrom [ a rdfs:Datatype ;
-                    owl:onDatatype xsd:string ;
-                    owl:withRestrictions ( [ xsd:pattern "true" ] ) ] ] ;
-    owl:intersectionOf ( [ a owl:Restriction ;
-                owl:onProperty openlabel_v2:subjectVehicleSpeedValue ;
-                owl:someValuesFrom xsd:string ] openlabel_v2:Odd ) .
-
-[] rdfs:subClassOf [ a owl:Restriction ;
-            owl:onProperty openlabel_v2:TrafficAgentType ;
-            owl:someValuesFrom [ a rdfs:Datatype ;
-                    owl:onDatatype xsd:string ;
-                    owl:withRestrictions ( [ xsd:pattern "true" ] ) ] ] ;
-    owl:intersectionOf ( [ a owl:Restriction ;
-                owl:onProperty openlabel_v2:trafficAgentTypeValue ;
-                owl:someValuesFrom xsd:string ] openlabel_v2:Odd ) .
-
-[] rdfs:subClassOf [ a owl:Restriction ;
-            owl:onProperty openlabel_v2:MotionAccelerate ;
-            owl:someValuesFrom [ a rdfs:Datatype ;
-                    owl:onDatatype xsd:string ;
-                    owl:withRestrictions ( [ xsd:pattern "true" ] ) ] ] ;
-    owl:intersectionOf ( [ a owl:Restriction ;
-                owl:onProperty openlabel_v2:motionAccelerateValue ;
-                owl:someValuesFrom xsd:string ] openlabel_v2:Behaviour ) .
-
-[] rdfs:subClassOf [ a owl:Restriction ;
-            owl:onProperty openlabel_v2:TrafficAgentDensity ;
-            owl:someValuesFrom [ a rdfs:Datatype ;
-                    owl:onDatatype xsd:string ;
-                    owl:withRestrictions ( [ xsd:pattern "true" ] ) ] ] ;
-    owl:intersectionOf ( [ a owl:Restriction ;
-                owl:onProperty openlabel_v2:trafficAgentDensityValue ;
-                owl:someValuesFrom xsd:string ] openlabel_v2:Odd ) .
-
-[] rdfs:subClassOf [ a owl:Restriction ;
-            owl:onProperty openlabel_v2:LaneSpecificationLaneCount ;
-            owl:someValuesFrom [ a rdfs:Datatype ;
-                    owl:onDatatype xsd:string ;
-                    owl:withRestrictions ( [ xsd:pattern "true" ] ) ] ] ;
-    owl:intersectionOf ( [ a owl:Restriction ;
-                owl:onProperty openlabel_v2:laneSpecificationLaneCountValue ;
-                owl:someValuesFrom xsd:string ] openlabel_v2:Odd ) .
-
-[] rdfs:subClassOf [ a owl:Restriction ;
-            owl:onProperty openlabel_v2:WeatherSnow ;
-            owl:someValuesFrom [ a rdfs:Datatype ;
-                    owl:onDatatype xsd:string ;
-                    owl:withRestrictions ( [ xsd:pattern "true" ] ) ] ] ;
-    owl:intersectionOf ( [ a owl:Restriction ;
-                owl:onProperty openlabel_v2:weatherSnowValue ;
-                owl:someValuesFrom xsd:string ] openlabel_v2:Odd ) .
-
-[] rdfs:subClassOf [ a owl:Restriction ;
-            owl:onProperty openlabel_v2:MotionDecelerate ;
-            owl:someValuesFrom [ a rdfs:Datatype ;
-                    owl:onDatatype xsd:string ;
-                    owl:withRestrictions ( [ xsd:pattern "true" ] ) ] ] ;
-    owl:intersectionOf ( [ a owl:Restriction ;
-                owl:onProperty openlabel_v2:motionDecelerateValue ;
-                owl:someValuesFrom xsd:string ] openlabel_v2:Behaviour ) .
-
-[] rdfs:subClassOf [ a owl:Restriction ;
-            owl:onProperty openlabel_v2:LaneSpecificationDimensions ;
-            owl:someValuesFrom [ a rdfs:Datatype ;
-                    owl:onDatatype xsd:string ;
-                    owl:withRestrictions ( [ xsd:pattern "true" ] ) ] ] ;
-    owl:intersectionOf ( [ a owl:Restriction ;
-                owl:onProperty openlabel_v2:laneSpecificationDimensionsValue ;
-                owl:someValuesFrom xsd:string ] openlabel_v2:Odd ) .
-
-[] rdfs:subClassOf [ a owl:Restriction ;
-            owl:onProperty openlabel_v2:WeatherWind ;
-            owl:someValuesFrom [ a rdfs:Datatype ;
-                    owl:onDatatype xsd:string ;
-                    owl:withRestrictions ( [ xsd:pattern "true" ] ) ] ] ;
-    owl:intersectionOf ( [ a owl:Restriction ;
-                owl:onProperty openlabel_v2:weatherWindValue ;
-                owl:someValuesFrom xsd:string ] openlabel_v2:Odd ) .
-
-[] rdfs:subClassOf [ a owl:Restriction ;
-            owl:onProperty openlabel_v2:WeatherRain ;
-            owl:someValuesFrom [ a rdfs:Datatype ;
-                    owl:onDatatype xsd:string ;
-                    owl:withRestrictions ( [ xsd:pattern "true" ] ) ] ] ;
-    owl:intersectionOf ( [ a owl:Restriction ;
-                owl:onProperty openlabel_v2:weatherRainValue ;
-                owl:someValuesFrom xsd:string ] openlabel_v2:Odd ) .
-
-[] rdfs:subClassOf [ a owl:Restriction ;
-            owl:onProperty openlabel_v2:TrafficVolume ;
-            owl:someValuesFrom [ a rdfs:Datatype ;
-                    owl:onDatatype xsd:string ;
-                    owl:withRestrictions ( [ xsd:pattern "true" ] ) ] ] ;
-    owl:intersectionOf ( [ a owl:Restriction ;
-                owl:onProperty openlabel_v2:trafficVolumeValue ;
-                owl:someValuesFrom xsd:string ] openlabel_v2:Odd ) .
-
-[] rdfs:subClassOf [ a owl:Restriction ;
-            owl:onProperty openlabel_v2:MotionDrive ;
-            owl:someValuesFrom [ a rdfs:Datatype ;
-                    owl:onDatatype xsd:string ;
-                    owl:withRestrictions ( [ xsd:pattern "true" ] ) ] ] ;
-    owl:intersectionOf ( [ a owl:Restriction ;
-                owl:onProperty openlabel_v2:motionDriveValue ;
-                owl:someValuesFrom xsd:string ] openlabel_v2:Behaviour ) .
-
-[] rdfs:subClassOf [ a owl:Restriction ;
-            owl:onProperty openlabel_v2:IlluminationCloudiness ;
-            owl:someValuesFrom [ a rdfs:Datatype ;
-                    owl:onDatatype xsd:string ;
-                    owl:withRestrictions ( [ xsd:pattern "true" ] ) ] ] ;
-    owl:intersectionOf ( [ a owl:Restriction ;
-                owl:onProperty openlabel_v2:illuminationCloudinessValue ;
-                owl:someValuesFrom xsd:string ] openlabel_v2:Odd ) .
-
-[] rdfs:subClassOf [ a owl:Restriction ;
-            owl:onProperty openlabel_v2:LongitudinalDownSlope ;
-            owl:someValuesFrom [ a rdfs:Datatype ;
-                    owl:onDatatype xsd:string ;
-                    owl:withRestrictions ( [ xsd:pattern "true" ] ) ] ] ;
-    owl:intersectionOf ( [ a owl:Restriction ;
-                owl:onProperty openlabel_v2:longitudinalDownSlopeValue ;
-                owl:someValuesFrom xsd:string ] openlabel_v2:Odd ) .
-
-[] rdfs:subClassOf [ a owl:Restriction ;
-            owl:onProperty openlabel_v2:DaySunElevation ;
-            owl:someValuesFrom [ a rdfs:Datatype ;
-                    owl:onDatatype xsd:string ;
-                    owl:withRestrictions ( [ xsd:pattern "true" ] ) ] ] ;
-    owl:intersectionOf ( [ a owl:Restriction ;
-                owl:onProperty openlabel_v2:daySunElevationValue ;
-                owl:someValuesFrom xsd:string ] openlabel_v2:Odd ) .
-
-[] rdfs:subClassOf [ a owl:Restriction ;
-            owl:onProperty openlabel_v2:ParticulatesWater ;
-            owl:someValuesFrom [ a rdfs:Datatype ;
-                    owl:onDatatype xsd:string ;
-                    owl:withRestrictions ( [ xsd:pattern "true" ] ) ] ] ;
-    owl:intersectionOf ( [ a owl:Restriction ;
-                owl:onProperty openlabel_v2:particulatesWaterValue ;
-                owl:someValuesFrom xsd:string ] openlabel_v2:Odd ) .
-
-[] rdfs:subClassOf [ a owl:Restriction ;
-            owl:onProperty openlabel_v2:LongitudinalUpSlope ;
-            owl:someValuesFrom [ a rdfs:Datatype ;
-                    owl:onDatatype xsd:string ;
-                    owl:withRestrictions ( [ xsd:pattern "true" ] ) ] ] ;
-    owl:intersectionOf ( [ a owl:Restriction ;
-                owl:onProperty openlabel_v2:longitudinalUpSlopeValue ;
-                owl:someValuesFrom xsd:string ] openlabel_v2:Odd ) .
-
-
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix prof: <http://www.w3.org/ns/dx/prof/> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix dcmitype: <http://purl.org/dc/dcmitype/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix sosa: <http://www.w3.org/ns/sosa/> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix ssn: <http://www.w3.org/ns/ssn/> .
+@prefix dcam: <http://purl.org/dc/dcam/> .
+@prefix void: <http://rdfs.org/ns/void#> .
+@prefix linkml: <https://w3id.org/linkml/> .
+@prefix pav: <http://purl.org/pav/> .
+@prefix sdo: <https://schema.org/> .
+openlabel_v2:AdminTag a owl:Class , owl:ObjectProperty , linkml:ClassDefinition , linkml:SlotDefinition ;
+	rdfs:label "AdminTag" ;
+	rdfs:range openlabel_v2:AdminTag ;
+	rdfs:subClassOf _:c14n102 , _:c14n107 , _:c14n129 , _:c14n146 , _:c14n183 , _:c14n201 , _:c14n211 , _:c14n216 , _:c14n239 , _:c14n260 , _:c14n270 , _:c14n290 , _:c14n305 , _:c14n315 , _:c14n344 , _:c14n363 , _:c14n366 , _:c14n370 , _:c14n418 , _:c14n454 , _:c14n474 , _:c14n588 , _:c14n62 , _:c14n650 , _:c14n662 , _:c14n668 , _:c14n691 , _:c14n750 , _:c14n769 , _:c14n789 , _:c14n813 , _:c14n817 , _:c14n830 , _:c14n834 , _:c14n873 , _:c14n892 , _:c14n905 , _:c14n907 , _:c14n910 ;
+	skos:definition "Administration tag." , "The base tag to use when extending the Administration tags with new classes." ;
+	skos:exactMatch openlabel_v2:AdminTag ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:ArtificialStreetLighting a owl:Class , openlabel_v2:IlluminationArtificial ;
+	rdfs:label "ArtificialStreetLighting" ;
+	rdfs:subClassOf openlabel_v2:IlluminationArtificial ;
+	skos:definition "Streetlights." .
+openlabel_v2:ArtificialVehicleLighting a owl:Class , openlabel_v2:IlluminationArtificial ;
+	rdfs:label "ArtificialVehicleLighting" ;
+	rdfs:subClassOf openlabel_v2:IlluminationArtificial ;
+	skos:definition "Oncoming vehicle lights." .
+openlabel_v2:Behaviour a owl:Class , owl:ObjectProperty , linkml:ClassDefinition , linkml:SlotDefinition ;
+	rdfs:label "Behaviour" ;
+	rdfs:range openlabel_v2:Behaviour ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	rdfs:subClassOf _:c14n10 , _:c14n109 , _:c14n12 , _:c14n126 , _:c14n15 , _:c14n162 , _:c14n195 , _:c14n196 , _:c14n20 , _:c14n226 , _:c14n234 , _:c14n235 , _:c14n243 , _:c14n251 , _:c14n257 , _:c14n261 , _:c14n264 , _:c14n272 , _:c14n31 , _:c14n368 , _:c14n39 , _:c14n395 , _:c14n403 , _:c14n412 , _:c14n425 , _:c14n434 , _:c14n438 , _:c14n445 , _:c14n447 , _:c14n452 , _:c14n453 , _:c14n480 , _:c14n490 , _:c14n497 , _:c14n507 , _:c14n514 , _:c14n531 , _:c14n539 , _:c14n540 , _:c14n546 , _:c14n565 , _:c14n575 , _:c14n592 , _:c14n599 , _:c14n611 , _:c14n646 , _:c14n649 , _:c14n684 , _:c14n685 , _:c14n686 , _:c14n712 , _:c14n722 , _:c14n723 , _:c14n726 , _:c14n73 , _:c14n733 , _:c14n734 , _:c14n736 , _:c14n745 , _:c14n754 , _:c14n763 , _:c14n771 , _:c14n80 , _:c14n805 , _:c14n81 , _:c14n82 , _:c14n850 , _:c14n867 , _:c14n887 , _:c14n890 , _:c14n893 ;
+	skos:definition "An activity performed by a road user." , "Behaviour tag." ;
+	skos:exactMatch openlabel_v2:Behaviour ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:BehaviourCommunication a owl:Class , owl:ObjectProperty , linkml:EnumDefinition , linkml:SlotDefinition ;
+	rdfs:label "BehaviourCommunication" , "BehaviourCommunicationEnum" ;
+	rdfs:range openlabel_v2:BehaviourCommunication ;
+	owl:unionOf _:c14n617 ;
+	skos:definition "Communication type of road user behaviour." , "Types of communication behaviours by road users." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
+	linkml:permissible_values openlabel_v2:CommunicationHeadlightFlash , openlabel_v2:CommunicationHorn , openlabel_v2:CommunicationSignalEmergency , openlabel_v2:CommunicationSignalHazard , openlabel_v2:CommunicationSignalLeft , openlabel_v2:CommunicationSignalRight , openlabel_v2:CommunicationSignalSlowing , openlabel_v2:CommunicationWave .
+openlabel_v2:CommunicationHeadlightFlash a owl:Class , openlabel_v2:BehaviourCommunication ;
+	rdfs:label "CommunicationHeadlightFlash" ;
+	rdfs:subClassOf openlabel_v2:BehaviourCommunication ;
+	skos:definition "Flash headlight." .
+openlabel_v2:CommunicationHorn a owl:Class , openlabel_v2:BehaviourCommunication ;
+	rdfs:label "CommunicationHorn" ;
+	rdfs:subClassOf openlabel_v2:BehaviourCommunication ;
+	skos:definition "Sound horn." .
+openlabel_v2:CommunicationSignalEmergency a owl:Class , openlabel_v2:BehaviourCommunication ;
+	rdfs:label "CommunicationSignalEmergency" ;
+	rdfs:subClassOf openlabel_v2:BehaviourCommunication ;
+	skos:definition "Signal emergency." .
+openlabel_v2:CommunicationSignalHazard a owl:Class , openlabel_v2:BehaviourCommunication ;
+	rdfs:label "CommunicationSignalHazard" ;
+	rdfs:subClassOf openlabel_v2:BehaviourCommunication ;
+	skos:definition "Signal hazard." .
+openlabel_v2:CommunicationSignalLeft a owl:Class , openlabel_v2:BehaviourCommunication ;
+	rdfs:label "CommunicationSignalLeft" ;
+	rdfs:subClassOf openlabel_v2:BehaviourCommunication ;
+	skos:definition "Signal left." .
+openlabel_v2:CommunicationSignalRight a owl:Class , openlabel_v2:BehaviourCommunication ;
+	rdfs:label "CommunicationSignalRight" ;
+	rdfs:subClassOf openlabel_v2:BehaviourCommunication ;
+	skos:definition "Signal right." .
+openlabel_v2:CommunicationSignalSlowing a owl:Class , openlabel_v2:BehaviourCommunication ;
+	rdfs:label "CommunicationSignalSlowing" ;
+	rdfs:subClassOf openlabel_v2:BehaviourCommunication ;
+	skos:definition "Signal slowing." .
+openlabel_v2:CommunicationV2i a owl:Class , openlabel_v2:ConnectivityCommunication ;
+	rdfs:label "CommunicationV2i" ;
+	rdfs:subClassOf openlabel_v2:ConnectivityCommunication ;
+	skos:definition "Vehicle to infrastructure communication (V2I)." .
+openlabel_v2:CommunicationV2v a owl:Class , openlabel_v2:ConnectivityCommunication ;
+	rdfs:label "CommunicationV2v" ;
+	rdfs:subClassOf openlabel_v2:ConnectivityCommunication ;
+	skos:definition "Vehicle to vehicle communication (V2V)." .
+openlabel_v2:CommunicationWave a owl:Class , openlabel_v2:BehaviourCommunication ;
+	rdfs:label "CommunicationWave" ;
+	rdfs:subClassOf openlabel_v2:BehaviourCommunication ;
+	skos:definition "Wave." .
+openlabel_v2:ConnectivityCommunication a owl:Class , owl:ObjectProperty , linkml:EnumDefinition , linkml:SlotDefinition ;
+	rdfs:label "ConnectivityCommunication" , "ConnectivityCommunicationEnum" ;
+	rdfs:range openlabel_v2:ConnectivityCommunication ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	owl:unionOf _:c14n904 ;
+	skos:definition "Communication connectivity type. Refer to BSI PAS-1883 Section 5.3.4.a." , "Types of communication connectivity. Refer to BSI PAS-1883 Section 5.3.4.a." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
+	linkml:permissible_values openlabel_v2:CommunicationV2i , openlabel_v2:CommunicationV2v , openlabel_v2:V2iCellular , openlabel_v2:V2iSatellite , openlabel_v2:V2iWifi , openlabel_v2:V2vCellular , openlabel_v2:V2vSatellite , openlabel_v2:V2vWifi .
+openlabel_v2:ConnectivityPositioning a owl:Class , owl:ObjectProperty , linkml:EnumDefinition , linkml:SlotDefinition ;
+	rdfs:label "ConnectivityPositioning" , "ConnectivityPositioningEnum" ;
+	rdfs:range openlabel_v2:ConnectivityPositioning ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	owl:unionOf _:c14n313 ;
+	skos:definition "Positioning system type. Refer to BSI PAS-1883 Section 5.3.4.b." , "Types of positioning systems. Refer to BSI PAS-1883 Section 5.3.4.b." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
+	linkml:permissible_values openlabel_v2:PositioningGalileo , openlabel_v2:PositioningGlonass , openlabel_v2:PositioningGps .
+openlabel_v2:DaySunElevation a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "DaySunElevation" ;
+	rdfs:range linkml:Boolean ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Elevation of the sun above the horizon flag. Refer to BSI PAS-1883 Section 5.3.3.a.1." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:DaySunPosition a owl:Class , owl:ObjectProperty , linkml:EnumDefinition , linkml:SlotDefinition ;
+	rdfs:label "DaySunPosition" , "DaySunPositionEnum" ;
+	rdfs:range openlabel_v2:DaySunPosition ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	owl:unionOf _:c14n863 ;
+	skos:definition "Position of the sun relative to direction of travel. Refer to BSI PAS-1883 Section 5.3.3.a.2." , "Position of the sun. Refer to BSI PAS-1883 Section 5.3.3.a.2." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
+	linkml:permissible_values openlabel_v2:SunPositionBehind , openlabel_v2:SunPositionFront , openlabel_v2:SunPositionLeft , openlabel_v2:SunPositionRight .
+openlabel_v2:DrivableAreaEdge a owl:Class , owl:ObjectProperty , linkml:EnumDefinition , linkml:SlotDefinition ;
+	rdfs:label "DrivableAreaEdge" , "DrivableAreaEdgeEnum" ;
+	rdfs:range openlabel_v2:DrivableAreaEdge ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	owl:unionOf _:c14n407 ;
+	skos:definition "Drivable area edge type. Refer to BSI PAS-1883 Section 5.2.3.1.e." , "Types of drivable area edges. Refer to BSI PAS-1883 Section 5.2.3.6." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
+	linkml:permissible_values openlabel_v2:EdgeLineMarkers , openlabel_v2:EdgeNone , openlabel_v2:EdgeShoulderGrass , openlabel_v2:EdgeShoulderPavedOrGravel , openlabel_v2:EdgeSolidBarriers , openlabel_v2:EdgeTemporaryLineMarkers .
+openlabel_v2:DrivableAreaSurfaceCondition a owl:Class , owl:ObjectProperty , linkml:EnumDefinition , linkml:SlotDefinition ;
+	rdfs:label "DrivableAreaSurfaceCondition" , "DrivableAreaSurfaceConditionEnum" ;
+	rdfs:range openlabel_v2:DrivableAreaSurfaceCondition ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	owl:unionOf _:c14n468 ;
+	skos:definition "Road surface condition. Refer to BSI PAS-1883 Section 5.2.3.7.c." , "Road surface conditions. Refer to BSI PAS-1883 Section 5.2.3.7.c." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
+	linkml:permissible_values openlabel_v2:SurfaceConditionContamination , openlabel_v2:SurfaceConditionFlooded , openlabel_v2:SurfaceConditionIcy , openlabel_v2:SurfaceConditionMirage , openlabel_v2:SurfaceConditionSnow , openlabel_v2:SurfaceConditionStandingWater , openlabel_v2:SurfaceConditionWet .
+openlabel_v2:DrivableAreaSurfaceFeature a owl:Class , owl:ObjectProperty , linkml:EnumDefinition , linkml:SlotDefinition ;
+	rdfs:label "DrivableAreaSurfaceFeature" , "DrivableAreaSurfaceFeatureEnum" ;
+	rdfs:range openlabel_v2:DrivableAreaSurfaceFeature ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	owl:unionOf _:c14n800 ;
+	skos:definition "Road surface feature. Refer to BSI PAS-1883 Section 5.2.3.7.b." , "Road surface features. Refer to BSI PAS-1883 Section 5.2.3.7.b." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
+	linkml:permissible_values openlabel_v2:SurfaceFeatureCrack , openlabel_v2:SurfaceFeaturePothole , openlabel_v2:SurfaceFeatureRut , openlabel_v2:SurfaceFeatureSwell .
+openlabel_v2:DrivableAreaSurfaceType a owl:Class , owl:ObjectProperty , linkml:EnumDefinition , linkml:SlotDefinition ;
+	rdfs:label "DrivableAreaSurfaceType" , "DrivableAreaSurfaceTypeEnum" ;
+	rdfs:range openlabel_v2:DrivableAreaSurfaceType ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	owl:unionOf _:c14n713 ;
+	skos:definition "Road surface type. Refer to BSI PAS-1883 Section 5.2.3.7.a." , "Road surface types. Refer to BSI PAS-1883 Section 5.2.3.7.a." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
+	linkml:permissible_values openlabel_v2:SurfaceTypeLoose , openlabel_v2:SurfaceTypeSegmented , openlabel_v2:SurfaceTypeUniform .
+openlabel_v2:DrivableAreaType a owl:Class , owl:ObjectProperty , linkml:EnumDefinition , linkml:SlotDefinition ;
+	rdfs:label "DrivableAreaType" , "DrivableAreaTypeEnum" ;
+	rdfs:range openlabel_v2:DrivableAreaType ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	owl:unionOf _:c14n551 ;
+	skos:definition "Road type. Refer to BSI PAS-1883 Section 5.2.3.2." , "Road types. Refer to BSI PAS-1883 Section 5.2.3.2." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
+	linkml:permissible_values openlabel_v2:MotorwayManaged , openlabel_v2:MotorwayUnmanaged , openlabel_v2:RoadTypeDistributor , openlabel_v2:RoadTypeMinor , openlabel_v2:RoadTypeMotorway , openlabel_v2:RoadTypeParking , openlabel_v2:RoadTypeRadial , openlabel_v2:RoadTypeShared , openlabel_v2:RoadTypeSlip .
+openlabel_v2:EdgeLineMarkers a owl:Class , openlabel_v2:DrivableAreaEdge ;
+	rdfs:label "EdgeLineMarkers" ;
+	rdfs:subClassOf openlabel_v2:DrivableAreaEdge ;
+	skos:definition "Line markers." .
+openlabel_v2:EdgeNone a owl:Class , openlabel_v2:DrivableAreaEdge ;
+	rdfs:label "EdgeNone" ;
+	rdfs:subClassOf openlabel_v2:DrivableAreaEdge ;
+	skos:definition "None." .
+openlabel_v2:EdgeShoulderGrass a owl:Class , openlabel_v2:DrivableAreaEdge ;
+	rdfs:label "EdgeShoulderGrass" ;
+	rdfs:subClassOf openlabel_v2:DrivableAreaEdge ;
+	skos:definition "Shoulder (grass)." .
+openlabel_v2:EdgeShoulderPavedOrGravel a owl:Class , openlabel_v2:DrivableAreaEdge ;
+	rdfs:label "EdgeShoulderPavedOrGravel" ;
+	rdfs:subClassOf openlabel_v2:DrivableAreaEdge ;
+	skos:definition "Shoulder (paved or gravel)." .
+openlabel_v2:EdgeSolidBarriers a owl:Class , openlabel_v2:DrivableAreaEdge ;
+	rdfs:label "EdgeSolidBarriers" ;
+	rdfs:subClassOf openlabel_v2:DrivableAreaEdge ;
+	skos:definition "Solid barriers (e.g. grating, rails, curb, cones)." .
+openlabel_v2:EdgeTemporaryLineMarkers a owl:Class , openlabel_v2:DrivableAreaEdge ;
+	rdfs:label "EdgeTemporaryLineMarkers" ;
+	rdfs:subClassOf openlabel_v2:DrivableAreaEdge ;
+	skos:definition "Temporary line markers." .
+openlabel_v2:EnvironmentParticulates a owl:Class , owl:ObjectProperty , linkml:EnumDefinition , linkml:SlotDefinition ;
+	rdfs:label "EnvironmentParticulates" , "EnvironmentParticulatesEnum" ;
+	rdfs:range openlabel_v2:EnvironmentParticulates ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	owl:unionOf _:c14n478 ;
+	skos:definition "Particulate type. Refer to BSI PAS-1883 Section 5.3.2." , "Types of particulates. Refer to BSI PAS-1883 Section 5.3.2." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
+	linkml:permissible_values openlabel_v2:ParticulatesDust , openlabel_v2:ParticulatesMarine , openlabel_v2:ParticulatesPollution , openlabel_v2:ParticulatesVolcanic , openlabel_v2:ParticulatesWater .
+openlabel_v2:FixedStructureBuilding a owl:Class , openlabel_v2:SceneryFixedStructure ;
+	rdfs:label "FixedStructureBuilding" ;
+	rdfs:subClassOf openlabel_v2:SceneryFixedStructure ;
+	skos:definition "Buildings." .
+openlabel_v2:FixedStructureStreetFurniture a owl:Class , openlabel_v2:SceneryFixedStructure ;
+	rdfs:label "FixedStructureStreetFurniture" ;
+	rdfs:subClassOf openlabel_v2:SceneryFixedStructure ;
+	skos:definition "Street furniture (e.g. bollards)." .
+openlabel_v2:FixedStructureStreetlight a owl:Class , openlabel_v2:SceneryFixedStructure ;
+	rdfs:label "FixedStructureStreetlight" ;
+	rdfs:subClassOf openlabel_v2:SceneryFixedStructure ;
+	skos:definition "Street lights." .
+openlabel_v2:FixedStructureVegetation a owl:Class , openlabel_v2:SceneryFixedStructure ;
+	rdfs:label "FixedStructureVegetation" ;
+	rdfs:subClassOf openlabel_v2:SceneryFixedStructure ;
+	skos:definition "Vegetation." .
+openlabel_v2:GeometryTransverse a owl:Class , owl:ObjectProperty , linkml:EnumDefinition , linkml:SlotDefinition ;
+	rdfs:label "GeometryTransverse" , "GeometryTransverseEnum" ;
+	rdfs:range openlabel_v2:GeometryTransverse ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	owl:unionOf _:c14n820 ;
+	skos:definition "Transverse geometry type. Refer to BSI PAS-1883 Section 5.2.3.3.b." , "Types of transverse geometry. Refer to BSI PAS-1883 Section 5.2.3.3.b." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
+	linkml:permissible_values openlabel_v2:TransverseBarriers , openlabel_v2:TransverseDivided , openlabel_v2:TransverseLanesTogether , openlabel_v2:TransversePavements , openlabel_v2:TransverseUndivided .
+openlabel_v2:HorizontalCurves a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "HorizontalCurves" ;
+	rdfs:range linkml:Boolean ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Curves flag. Refer to BSI PAS-1883 Section 5.2.3.3." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:HorizontalStraights a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "HorizontalStraights" ;
+	rdfs:range linkml:Boolean ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Straight lines flag. Refer to BSI PAS-1883 Section 5.2.3.3." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:HumanAnimalRider a owl:Class , openlabel_v2:RoadUserHuman ;
+	rdfs:label "HumanAnimalRider" ;
+	rdfs:subClassOf openlabel_v2:RoadUserHuman ;
+	skos:definition "Animal rider (e.g. horse rider)." .
+openlabel_v2:HumanCyclist a owl:Class , openlabel_v2:RoadUserHuman ;
+	rdfs:label "HumanCyclist" ;
+	rdfs:subClassOf openlabel_v2:RoadUserHuman ;
+	skos:definition "Cyclist." .
+openlabel_v2:HumanDriver a owl:Class , openlabel_v2:RoadUserHuman ;
+	rdfs:label "HumanDriver" ;
+	rdfs:subClassOf openlabel_v2:RoadUserHuman ;
+	skos:definition "Driver." .
+openlabel_v2:HumanMotorcyclist a owl:Class , openlabel_v2:RoadUserHuman ;
+	rdfs:label "HumanMotorcyclist" ;
+	rdfs:subClassOf openlabel_v2:RoadUserHuman ;
+	skos:definition "Motorcyclist." .
+openlabel_v2:HumanPassenger a owl:Class , openlabel_v2:RoadUserHuman ;
+	rdfs:label "HumanPassenger" ;
+	rdfs:subClassOf openlabel_v2:RoadUserHuman ;
+	skos:definition "Passenger." .
+openlabel_v2:HumanPedestrian a owl:Class , openlabel_v2:RoadUserHuman ;
+	rdfs:label "HumanPedestrian" ;
+	rdfs:subClassOf openlabel_v2:RoadUserHuman ;
+	skos:definition "Pedestrian." .
+openlabel_v2:HumanWheelchairUser a owl:Class , openlabel_v2:RoadUserHuman ;
+	rdfs:label "HumanWheelchairUser" ;
+	rdfs:subClassOf openlabel_v2:RoadUserHuman ;
+	skos:definition "Wheelchair user." .
+openlabel_v2:IlluminationArtificial a owl:Class , owl:ObjectProperty , linkml:EnumDefinition , linkml:SlotDefinition ;
+	rdfs:label "IlluminationArtificial" , "IlluminationArtificialEnum" ;
+	rdfs:range openlabel_v2:IlluminationArtificial ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	owl:unionOf _:c14n34 ;
+	skos:definition "Artificial illumination type. Refer to BSI PAS-1883 Section 5.3.3.d." , "Types of artificial illumination. Refer to BSI PAS-1883 Section 5.3.3.d." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
+	linkml:permissible_values openlabel_v2:ArtificialStreetLighting , openlabel_v2:ArtificialVehicleLighting .
+openlabel_v2:IlluminationCloudiness a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "IlluminationCloudiness" ;
+	rdfs:range linkml:Boolean ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Cloudiness flag. Refer to BSI PAS-1883 Section 5.3.3.c." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:IlluminationLowLight a owl:Class , owl:ObjectProperty , linkml:EnumDefinition , linkml:SlotDefinition ;
+	rdfs:label "IlluminationLowLight" , "IlluminationLowLightEnum" ;
+	rdfs:range openlabel_v2:IlluminationLowLight ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	owl:unionOf _:c14n802 ;
+	skos:definition "Low light condition. Refer to BSI PAS-1883 Section 5.3.3.b." , "Types of low light conditions. Refer to BSI PAS-1883 Section 5.3.3.b." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
+	linkml:permissible_values openlabel_v2:LowLightAmbient , openlabel_v2:LowLightNight .
+openlabel_v2:InformationSignsUniformFullTime a owl:Class , openlabel_v2:SignsInformation ;
+	rdfs:label "InformationSignsUniformFullTime" ;
+	rdfs:subClassOf openlabel_v2:SignsInformation ;
+	skos:definition "Uniform full-time." .
+openlabel_v2:InformationSignsUniformTemporary a owl:Class , openlabel_v2:SignsInformation ;
+	rdfs:label "InformationSignsUniformTemporary" ;
+	rdfs:subClassOf openlabel_v2:SignsInformation ;
+	skos:definition "Uniform temporary." .
+openlabel_v2:InformationSignsVariableFullTime a owl:Class , openlabel_v2:SignsInformation ;
+	rdfs:label "InformationSignsVariableFullTime" ;
+	rdfs:subClassOf openlabel_v2:SignsInformation ;
+	skos:definition "Variable full-time." .
+openlabel_v2:InformationSignsVariableTemporary a owl:Class , openlabel_v2:SignsInformation ;
+	rdfs:label "InformationSignsVariableTemporary" ;
+	rdfs:subClassOf openlabel_v2:SignsInformation ;
+	skos:definition "Variable temporary." .
+openlabel_v2:IntersectionCrossroad a owl:Class , openlabel_v2:JunctionIntersection ;
+	rdfs:label "IntersectionCrossroad" ;
+	rdfs:subClassOf openlabel_v2:JunctionIntersection ;
+	skos:definition "Crossroads." .
+openlabel_v2:IntersectionGradeSeperated a owl:Class , openlabel_v2:JunctionIntersection ;
+	rdfs:label "IntersectionGradeSeperated" ;
+	rdfs:subClassOf openlabel_v2:JunctionIntersection ;
+	skos:definition "Grade separated." .
+openlabel_v2:IntersectionStaggered a owl:Class , openlabel_v2:JunctionIntersection ;
+	rdfs:label "IntersectionStaggered" ;
+	rdfs:subClassOf openlabel_v2:JunctionIntersection ;
+	skos:definition "Staggered." .
+openlabel_v2:IntersectionTJunction a owl:Class , openlabel_v2:JunctionIntersection ;
+	rdfs:label "IntersectionTJunction" ;
+	rdfs:subClassOf openlabel_v2:JunctionIntersection ;
+	skos:definition "T-Junctions." .
+openlabel_v2:IntersectionYJunction a owl:Class , openlabel_v2:JunctionIntersection ;
+	rdfs:label "IntersectionYJunction" ;
+	rdfs:subClassOf openlabel_v2:JunctionIntersection ;
+	skos:definition "Y-Junction." .
+openlabel_v2:JunctionIntersection a owl:Class , owl:ObjectProperty , linkml:EnumDefinition , linkml:SlotDefinition ;
+	rdfs:label "JunctionIntersection" , "JunctionIntersectionEnum" ;
+	rdfs:range openlabel_v2:JunctionIntersection ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	owl:unionOf _:c14n601 ;
+	skos:definition "Intersection type. Refer to BSI PAS-1883 Section 5.2.4." , "Types of intersections. Refer to BSI PAS-1883 Section 5.2.4." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
+	linkml:permissible_values openlabel_v2:IntersectionCrossroad , openlabel_v2:IntersectionGradeSeperated , openlabel_v2:IntersectionStaggered , openlabel_v2:IntersectionTJunction , openlabel_v2:IntersectionYJunction .
+openlabel_v2:JunctionRoundabout a owl:Class , owl:ObjectProperty , linkml:EnumDefinition , linkml:SlotDefinition ;
+	rdfs:label "JunctionRoundabout" , "JunctionRoundaboutEnum" ;
+	rdfs:range openlabel_v2:JunctionRoundabout ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	owl:unionOf _:c14n571 ;
+	skos:definition "Roundabout type. Refer to BSI PAS-1883 Section 5.2.4." , "Types of roundabouts. Refer to BSI PAS-1883 Section 5.2.4." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
+	linkml:permissible_values openlabel_v2:RoundaboutCompactNosignal , openlabel_v2:RoundaboutCompactSignal , openlabel_v2:RoundaboutDoubleNosignal , openlabel_v2:RoundaboutDoubleSignal , openlabel_v2:RoundaboutLargeNosignal , openlabel_v2:RoundaboutLargeSignal , openlabel_v2:RoundaboutMiniNosignal , openlabel_v2:RoundaboutMiniSignal , openlabel_v2:RoundaboutNormalNosignal , openlabel_v2:RoundaboutNormalSignal .
+openlabel_v2:LaneSpecificationDimensions a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "LaneSpecificationDimensions" ;
+	rdfs:range linkml:Boolean ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Lane dimensions flag. Refer to BSI PAS-1883 Section 5.2.3.4.a." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:LaneSpecificationLaneCount a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "LaneSpecificationLaneCount" ;
+	rdfs:range linkml:Boolean ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Number of lanes flag. Refer to BSI PAS-1883 Section 5.2.3.4.d." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:LaneSpecificationMarking a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "LaneSpecificationMarking" ;
+	rdfs:range linkml:Boolean ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Lane marking flag. Refer to BSI PAS-1883 Section 5.2.3.4.b." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:LaneSpecificationTravelDirection a owl:Class , owl:ObjectProperty , linkml:EnumDefinition , linkml:SlotDefinition ;
+	rdfs:label "LaneSpecificationTravelDirection" , "LaneSpecificationTravelDirectionEnum" ;
+	rdfs:range openlabel_v2:LaneSpecificationTravelDirection ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	owl:unionOf _:c14n224 ;
+	skos:definition "Direction of travel. Refer to BSI PAS-1883 Section 5.2.3.4.e." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
+	linkml:permissible_values openlabel_v2:TravelDirectionLeft , openlabel_v2:TravelDirectionRight .
+openlabel_v2:LaneSpecificationType a owl:Class , owl:ObjectProperty , linkml:EnumDefinition , linkml:SlotDefinition ;
+	rdfs:label "LaneSpecificationType" , "LaneSpecificationTypeEnum" ;
+	rdfs:range openlabel_v2:LaneSpecificationType ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	owl:unionOf _:c14n98 ;
+	skos:definition "Lane type. Refer to BSI PAS-1883 Section 5.2.3.4.c." , "Types of lanes. Refer to BSI PAS-1883 Section 5.2.3.4.c." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
+	linkml:permissible_values openlabel_v2:LaneTypeBus , openlabel_v2:LaneTypeCycle , openlabel_v2:LaneTypeEmergency , openlabel_v2:LaneTypeSpecial , openlabel_v2:LaneTypeTraffic , openlabel_v2:LaneTypeTram .
+openlabel_v2:LaneTypeBus a owl:Class , openlabel_v2:LaneSpecificationType ;
+	rdfs:label "LaneTypeBus" ;
+	rdfs:subClassOf openlabel_v2:LaneSpecificationType ;
+	skos:definition "Bus lane." .
+openlabel_v2:LaneTypeCycle a owl:Class , openlabel_v2:LaneSpecificationType ;
+	rdfs:label "LaneTypeCycle" ;
+	rdfs:subClassOf openlabel_v2:LaneSpecificationType ;
+	skos:definition "Cycle lane." .
+openlabel_v2:LaneTypeEmergency a owl:Class , openlabel_v2:LaneSpecificationType ;
+	rdfs:label "LaneTypeEmergency" ;
+	rdfs:subClassOf openlabel_v2:LaneSpecificationType ;
+	skos:definition "Emergency lane." .
+openlabel_v2:LaneTypeSpecial a owl:Class , openlabel_v2:LaneSpecificationType ;
+	rdfs:label "LaneTypeSpecial" ;
+	rdfs:subClassOf openlabel_v2:LaneSpecificationType ;
+	skos:definition "Special purpose lane." .
+openlabel_v2:LaneTypeTraffic a owl:Class , openlabel_v2:LaneSpecificationType ;
+	rdfs:label "LaneTypeTraffic" ;
+	rdfs:subClassOf openlabel_v2:LaneSpecificationType ;
+	skos:definition "Traffic lane." .
+openlabel_v2:LaneTypeTram a owl:Class , openlabel_v2:LaneSpecificationType ;
+	rdfs:label "LaneTypeTram" ;
+	rdfs:subClassOf openlabel_v2:LaneSpecificationType ;
+	skos:definition "Tram lane." .
+openlabel_v2:LongitudinalDownSlope a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "LongitudinalDownSlope" ;
+	rdfs:range linkml:Boolean ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Down-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.ii." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:LongitudinalLevelPlane a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "LongitudinalLevelPlane" ;
+	rdfs:range linkml:Boolean ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Level plane flag. Refer to BSI PAS-1883 Section 5.2.3.3.iii." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:LongitudinalUpSlope a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "LongitudinalUpSlope" ;
+	rdfs:range linkml:Boolean ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Up-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.i." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:LowLightAmbient a owl:Class , openlabel_v2:IlluminationLowLight ;
+	rdfs:label "LowLightAmbient" ;
+	rdfs:subClassOf openlabel_v2:IlluminationLowLight ;
+	skos:definition "Low ambient lighting." .
+openlabel_v2:LowLightNight a owl:Class , openlabel_v2:IlluminationLowLight ;
+	rdfs:label "LowLightNight" ;
+	rdfs:subClassOf openlabel_v2:IlluminationLowLight ;
+	skos:definition "Night." .
+openlabel_v2:MotionAccelerate a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "MotionAccelerate" ;
+	rdfs:range linkml:Boolean ;
+	skos:definition "An activity where the road user increases their velocity." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:MotionAway a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "MotionAway" ;
+	rdfs:range linkml:Boolean ;
+	skos:definition "An activity where the road user is further away from the object by the end." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:MotionCross a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "MotionCross" ;
+	rdfs:range linkml:Boolean ;
+	skos:definition "An activity where the trajectory of the road user crosses the trajectory of the object." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:MotionCutIn a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "MotionCutIn" ;
+	rdfs:range linkml:Boolean ;
+	skos:definition "An activity where the subject vehicle ends up directly in front of the object vehicle." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:MotionCutOut a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "MotionCutOut" ;
+	rdfs:range linkml:Boolean ;
+	skos:definition "An activity where the object vehicle suddenly moves out of the lane." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:MotionDecelerate a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "MotionDecelerate" ;
+	rdfs:range linkml:Boolean ;
+	skos:definition "An activity where the road user decreases their velocity." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:MotionDrive a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "MotionDrive" ;
+	rdfs:range linkml:Boolean ;
+	skos:definition "An activity where the subject vehicle is moving in the direction it is facing." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:MotionLaneChangeLeft a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "MotionLaneChangeLeft" ;
+	rdfs:range linkml:Boolean ;
+	skos:definition "An activity where the subject vehicle is in a lane left of the original." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:MotionLaneChangeRight a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "MotionLaneChangeRight" ;
+	rdfs:range linkml:Boolean ;
+	skos:definition "An activity where the subject vehicle is in a lane right of the original." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:MotionOvertake a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "MotionOvertake" ;
+	rdfs:range linkml:Boolean ;
+	skos:definition "An activity where the subject starts behind and ends up in front by changing lanes." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:MotionReverse a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "MotionReverse" ;
+	rdfs:range linkml:Boolean ;
+	skos:definition "An activity where the subject vehicle is moving in the opposite direction to which it is facing." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:MotionRun a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "MotionRun" ;
+	rdfs:range linkml:Boolean ;
+	skos:definition "Locomotion mode where at a specific point no foot touches the ground." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:MotionSlide a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "MotionSlide" ;
+	rdfs:range linkml:Boolean ;
+	skos:definition "An activity where a pedestrian is slipping/sliding on the road." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:MotionStop a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "MotionStop" ;
+	rdfs:range linkml:Boolean ;
+	skos:definition "An activity where the road user is stationary." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:MotionTowards a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "MotionTowards" ;
+	rdfs:range linkml:Boolean ;
+	skos:definition "An activity where the road user is closer to the object by the end." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:MotionTurn a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "MotionTurn" ;
+	rdfs:range linkml:Boolean ;
+	skos:definition "An activity where the road user changes their heading." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:MotionTurnLeft a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "MotionTurnLeft" ;
+	rdfs:range linkml:Boolean ;
+	skos:definition "Subject exits the intersection on a road to the left of the original." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:MotionTurnRight a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "MotionTurnRight" ;
+	rdfs:range linkml:Boolean ;
+	skos:definition "Subject exits the intersection on a road to the right of the original." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:MotionUTurn a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "MotionUTurn" ;
+	rdfs:range linkml:Boolean ;
+	skos:definition "Subject performs a turn resulting in heading in the opposite direction." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:MotionWalk a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "MotionWalk" ;
+	rdfs:range linkml:Boolean ;
+	skos:definition "Locomotion mode where at least one foot is always on the ground." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:MotorwayManaged a owl:Class , openlabel_v2:DrivableAreaType ;
+	rdfs:label "MotorwayManaged" ;
+	rdfs:subClassOf openlabel_v2:DrivableAreaType ;
+	skos:definition "Managed motorways." .
+openlabel_v2:MotorwayUnmanaged a owl:Class , openlabel_v2:DrivableAreaType ;
+	rdfs:label "MotorwayUnmanaged" ;
+	rdfs:subClassOf openlabel_v2:DrivableAreaType ;
+	skos:definition "Unmanaged motorways." .
+openlabel_v2:Odd a owl:Class , owl:ObjectProperty , linkml:ClassDefinition , linkml:SlotDefinition ;
+	rdfs:label "Odd" ;
+	rdfs:range openlabel_v2:Odd ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	rdfs:subClassOf _:c14n108 , _:c14n11 , _:c14n110 , _:c14n111 , _:c14n112 , _:c14n116 , _:c14n123 , _:c14n124 , _:c14n125 , _:c14n138 , _:c14n139 , _:c14n143 , _:c14n145 , _:c14n148 , _:c14n149 , _:c14n150 , _:c14n151 , _:c14n154 , _:c14n155 , _:c14n157 , _:c14n161 , _:c14n166 , _:c14n167 , _:c14n169 , _:c14n175 , _:c14n199 , _:c14n210 , _:c14n212 , _:c14n22 , _:c14n232 , _:c14n241 , _:c14n244 , _:c14n248 , _:c14n249 , _:c14n255 , _:c14n256 , _:c14n26 , _:c14n265 , _:c14n268 , _:c14n271 , _:c14n275 , _:c14n279 , _:c14n282 , _:c14n283 , _:c14n288 , _:c14n289 , _:c14n29 , _:c14n298 , _:c14n302 , _:c14n303 , _:c14n309 , _:c14n311 , _:c14n319 , _:c14n323 , _:c14n325 , _:c14n328 , _:c14n333 , _:c14n336 , _:c14n339 , _:c14n353 , _:c14n357 , _:c14n358 , _:c14n359 , _:c14n36 , _:c14n361 , _:c14n369 , _:c14n371 , _:c14n373 , _:c14n378 , _:c14n379 , _:c14n382 , _:c14n392 , _:c14n394 , _:c14n397 , _:c14n4 , _:c14n406 , _:c14n408 , _:c14n414 , _:c14n416 , _:c14n422 , _:c14n423 , _:c14n43 , _:c14n439 , _:c14n440 , _:c14n444 , _:c14n446 , _:c14n455 , _:c14n481 , _:c14n482 , _:c14n486 , _:c14n5 , _:c14n50 , _:c14n503 , _:c14n505 , _:c14n518 , _:c14n52 , _:c14n520 , _:c14n523 , _:c14n538 , _:c14n541 , _:c14n547 , _:c14n552 , _:c14n554 , _:c14n555 , _:c14n556 , _:c14n57 , _:c14n573 , _:c14n576 , _:c14n577 , _:c14n58 , _:c14n581 , _:c14n583 , _:c14n590 , _:c14n591 , _:c14n594 , _:c14n597 , _:c14n598 , _:c14n60 , _:c14n614 , _:c14n618 , _:c14n624 , _:c14n635 , _:c14n636 , _:c14n638 , _:c14n643 , _:c14n655 , _:c14n660 , _:c14n663 , _:c14n67 , _:c14n674 , _:c14n68 , _:c14n681 , _:c14n687 , _:c14n701 , _:c14n706 , _:c14n707 , _:c14n709 , _:c14n714 , _:c14n715 , _:c14n719 , _:c14n720 , _:c14n724 , _:c14n729 , _:c14n730 , _:c14n731 , _:c14n732 , _:c14n740 , _:c14n743 , _:c14n744 , _:c14n757 , _:c14n758 , _:c14n767 , _:c14n775 , _:c14n777 , _:c14n779 , _:c14n780 , _:c14n785 , _:c14n786 , _:c14n791 , _:c14n792 , _:c14n801 , _:c14n807 , _:c14n810 , _:c14n819 , _:c14n824 , _:c14n828 , _:c14n83 , _:c14n84 , _:c14n840 , _:c14n846 , _:c14n852 , _:c14n855 , _:c14n857 , _:c14n858 , _:c14n859 , _:c14n860 , _:c14n861 , _:c14n865 , _:c14n866 , _:c14n877 , _:c14n878 , _:c14n88 , _:c14n881 , _:c14n884 , _:c14n89 , _:c14n897 , _:c14n900 , _:c14n93 , _:c14n97 ;
+	skos:definition "Operational Design Domain tag." , "Operational Design Domain. Refer to BSI PAS-1883 Section 5." ;
+	skos:exactMatch openlabel_v2:Odd ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:OddDynamicElements a owl:Class , linkml:ClassDefinition ;
+	rdfs:label "OddDynamicElements" ;
+	rdfs:subClassOf openlabel_v2:Odd , _:c14n100 , _:c14n103 , _:c14n105 , _:c14n113 , _:c14n130 , _:c14n131 , _:c14n136 , _:c14n137 , _:c14n14 , _:c14n140 , _:c14n147 , _:c14n153 , _:c14n156 , _:c14n159 , _:c14n160 , _:c14n17 , _:c14n174 , _:c14n179 , _:c14n18 , _:c14n180 , _:c14n186 , _:c14n197 , _:c14n198 , _:c14n200 , _:c14n204 , _:c14n215 , _:c14n220 , _:c14n222 , _:c14n225 , _:c14n228 , _:c14n242 , _:c14n245 , _:c14n25 , _:c14n253 , _:c14n263 , _:c14n273 , _:c14n277 , _:c14n280 , _:c14n281 , _:c14n296 , _:c14n3 , _:c14n316 , _:c14n320 , _:c14n335 , _:c14n338 , _:c14n341 , _:c14n346 , _:c14n351 , _:c14n360 , _:c14n364 , _:c14n367 , _:c14n37 , _:c14n374 , _:c14n375 , _:c14n383 , _:c14n389 , _:c14n390 , _:c14n399 , _:c14n405 , _:c14n409 , _:c14n41 , _:c14n411 , _:c14n421 , _:c14n429 , _:c14n432 , _:c14n437 , _:c14n44 , _:c14n450 , _:c14n461 , _:c14n464 , _:c14n467 , _:c14n475 , _:c14n49 , _:c14n491 , _:c14n508 , _:c14n51 , _:c14n511 , _:c14n515 , _:c14n524 , _:c14n532 , _:c14n537 , _:c14n54 , _:c14n550 , _:c14n560 , _:c14n561 , _:c14n562 , _:c14n566 , _:c14n567 , _:c14n569 , _:c14n570 , _:c14n574 , _:c14n587 , _:c14n600 , _:c14n602 , _:c14n604 , _:c14n605 , _:c14n608 , _:c14n609 , _:c14n61 , _:c14n610 , _:c14n612 , _:c14n619 , _:c14n622 , _:c14n628 , _:c14n631 , _:c14n637 , _:c14n641 , _:c14n65 , _:c14n654 , _:c14n683 , _:c14n689 , _:c14n697 , _:c14n70 , _:c14n702 , _:c14n703 , _:c14n708 , _:c14n716 , _:c14n72 , _:c14n747 , _:c14n748 , _:c14n75 , _:c14n752 , _:c14n755 , _:c14n762 , _:c14n764 , _:c14n765 , _:c14n766 , _:c14n770 , _:c14n773 , _:c14n78 , _:c14n782 , _:c14n783 , _:c14n784 , _:c14n788 , _:c14n797 , _:c14n815 , _:c14n818 , _:c14n821 , _:c14n823 , _:c14n826 , _:c14n833 , _:c14n837 , _:c14n838 , _:c14n843 , _:c14n844 , _:c14n849 , _:c14n86 , _:c14n868 , _:c14n869 , _:c14n872 , _:c14n874 , _:c14n876 , _:c14n880 , _:c14n888 , _:c14n889 , _:c14n898 , _:c14n902 , _:c14n903 , _:c14n909 ;
+	skos:definition "Dynamic elements subset of the Operational Design Domain. Covers traffic agents, flow rates, volume, and subject vehicle speed. Refer to BSI PAS-1883 Section 5.4." ;
+	skos:exactMatch openlabel_v2:OddDynamicElements ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:OddEnvironment a owl:Class , linkml:ClassDefinition ;
+	rdfs:label "OddEnvironment" ;
+	rdfs:subClassOf openlabel_v2:Odd , _:c14n1 , _:c14n121 , _:c14n127 , _:c14n13 , _:c14n163 , _:c14n164 , _:c14n177 , _:c14n181 , _:c14n188 , _:c14n19 , _:c14n193 , _:c14n207 , _:c14n208 , _:c14n21 , _:c14n217 , _:c14n223 , _:c14n23 , _:c14n237 , _:c14n246 , _:c14n254 , _:c14n258 , _:c14n262 , _:c14n269 , _:c14n274 , _:c14n293 , _:c14n295 , _:c14n30 , _:c14n300 , _:c14n304 , _:c14n306 , _:c14n307 , _:c14n314 , _:c14n321 , _:c14n322 , _:c14n330 , _:c14n340 , _:c14n352 , _:c14n354 , _:c14n372 , _:c14n38 , _:c14n380 , _:c14n385 , _:c14n391 , _:c14n398 , _:c14n40 , _:c14n400 , _:c14n415 , _:c14n424 , _:c14n427 , _:c14n431 , _:c14n451 , _:c14n456 , _:c14n458 , _:c14n47 , _:c14n471 , _:c14n479 , _:c14n494 , _:c14n495 , _:c14n504 , _:c14n506 , _:c14n509 , _:c14n510 , _:c14n517 , _:c14n527 , _:c14n528 , _:c14n533 , _:c14n535 , _:c14n536 , _:c14n542 , _:c14n545 , _:c14n553 , _:c14n568 , _:c14n578 , _:c14n585 , _:c14n586 , _:c14n59 , _:c14n607 , _:c14n613 , _:c14n616 , _:c14n633 , _:c14n634 , _:c14n639 , _:c14n644 , _:c14n648 , _:c14n658 , _:c14n661 , _:c14n669 , _:c14n677 , _:c14n678 , _:c14n680 , _:c14n692 , _:c14n698 , _:c14n704 , _:c14n705 , _:c14n71 , _:c14n710 , _:c14n727 , _:c14n737 , _:c14n742 , _:c14n746 , _:c14n749 , _:c14n753 , _:c14n76 , _:c14n761 , _:c14n768 , _:c14n772 , _:c14n774 , _:c14n776 , _:c14n79 , _:c14n790 , _:c14n793 , _:c14n816 , _:c14n839 , _:c14n85 , _:c14n875 , _:c14n882 , _:c14n896 , _:c14n899 , _:c14n90 , _:c14n908 , _:c14n92 , _:c14n94 , _:c14n99 ;
+	skos:definition "Environment-related subset of the Operational Design Domain. Covers weather, illumination, connectivity, and particulates. Refer to BSI PAS-1883 Section 5.3." ;
+	skos:exactMatch openlabel_v2:OddEnvironment ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:OddScenery a owl:Class , linkml:ClassDefinition ;
+	rdfs:label "OddScenery" ;
+	rdfs:subClassOf openlabel_v2:Odd , _:c14n0 , _:c14n104 , _:c14n114 , _:c14n119 , _:c14n120 , _:c14n135 , _:c14n144 , _:c14n16 , _:c14n165 , _:c14n178 , _:c14n194 , _:c14n2 , _:c14n203 , _:c14n205 , _:c14n206 , _:c14n229 , _:c14n236 , _:c14n238 , _:c14n24 , _:c14n240 , _:c14n250 , _:c14n266 , _:c14n278 , _:c14n284 , _:c14n285 , _:c14n287 , _:c14n297 , _:c14n299 , _:c14n312 , _:c14n324 , _:c14n327 , _:c14n342 , _:c14n343 , _:c14n35 , _:c14n350 , _:c14n356 , _:c14n362 , _:c14n386 , _:c14n401 , _:c14n404 , _:c14n413 , _:c14n419 , _:c14n428 , _:c14n430 , _:c14n433 , _:c14n436 , _:c14n46 , _:c14n462 , _:c14n466 , _:c14n469 , _:c14n470 , _:c14n48 , _:c14n485 , _:c14n489 , _:c14n492 , _:c14n493 , _:c14n498 , _:c14n499 , _:c14n500 , _:c14n501 , _:c14n512 , _:c14n513 , _:c14n519 , _:c14n529 , _:c14n543 , _:c14n557 , _:c14n56 , _:c14n563 , _:c14n572 , _:c14n595 , _:c14n606 , _:c14n623 , _:c14n630 , _:c14n632 , _:c14n653 , _:c14n656 , _:c14n66 , _:c14n664 , _:c14n666 , _:c14n676 , _:c14n688 , _:c14n69 , _:c14n694 , _:c14n700 , _:c14n718 , _:c14n739 , _:c14n74 , _:c14n751 , _:c14n787 , _:c14n798 , _:c14n799 , _:c14n804 , _:c14n808 , _:c14n811 , _:c14n814 , _:c14n825 , _:c14n836 , _:c14n848 , _:c14n854 , _:c14n879 , _:c14n885 , _:c14n901 ;
+	skos:definition "Scenery-related subset of the Operational Design Domain. Covers drivable area, geometry, lane specifications, junctions, signs, and structures. Refer to BSI PAS-1883 Section 5.2." ;
+	skos:exactMatch openlabel_v2:OddScenery ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:ParticulatesDust a owl:Class , owl:ObjectProperty , openlabel_v2:EnvironmentParticulates , linkml:SlotDefinition ;
+	rdfs:label "ParticulatesDust" ;
+	rdfs:range linkml:Boolean ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	rdfs:subClassOf openlabel_v2:EnvironmentParticulates ;
+	skos:definition "Sand and dust flag. Refer to BSI PAS-1883 Section 5.3.2.c." , "Sand and dust." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:ParticulatesMarine a owl:Class , owl:ObjectProperty , openlabel_v2:EnvironmentParticulates , linkml:SlotDefinition ;
+	rdfs:label "ParticulatesMarine" ;
+	rdfs:range linkml:Boolean ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	rdfs:subClassOf openlabel_v2:EnvironmentParticulates ;
+	skos:definition "Marine (coastal areas only) flag. Refer to BSI PAS-1883 Section 5.3.2.a." , "Marine (coastal areas only)." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:ParticulatesPollution a owl:Class , owl:ObjectProperty , openlabel_v2:EnvironmentParticulates , linkml:SlotDefinition ;
+	rdfs:label "ParticulatesPollution" ;
+	rdfs:range linkml:Boolean ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	rdfs:subClassOf openlabel_v2:EnvironmentParticulates ;
+	skos:definition "Smoke and pollution flag. Refer to BSI PAS-1883 Section 5.3.2.d." , "Smoke and pollution." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:ParticulatesVolcanic a owl:Class , owl:ObjectProperty , openlabel_v2:EnvironmentParticulates , linkml:SlotDefinition ;
+	rdfs:label "ParticulatesVolcanic" ;
+	rdfs:range linkml:Boolean ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	rdfs:subClassOf openlabel_v2:EnvironmentParticulates ;
+	skos:definition "Volcanic ash flag. Refer to BSI PAS-1883 Section 5.3.2.e." , "Volcanic ash." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:ParticulatesWater a owl:Class , owl:ObjectProperty , openlabel_v2:EnvironmentParticulates , linkml:SlotDefinition ;
+	rdfs:label "ParticulatesWater" ;
+	rdfs:range linkml:Boolean ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	rdfs:subClassOf openlabel_v2:EnvironmentParticulates ;
+	skos:definition "Non-precipitating water droplets or ice crystals (i.e. mist/fog)." , "Non-precipitating water droplets or ice crystals (mist/fog) flag. Refer to BSI PAS-1883 Section 5.3.2.b." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:PositioningGalileo a owl:Class , openlabel_v2:ConnectivityPositioning ;
+	rdfs:label "PositioningGalileo" ;
+	rdfs:subClassOf openlabel_v2:ConnectivityPositioning ;
+	skos:definition "Galileo." .
+openlabel_v2:PositioningGlonass a owl:Class , openlabel_v2:ConnectivityPositioning ;
+	rdfs:label "PositioningGlonass" ;
+	rdfs:subClassOf openlabel_v2:ConnectivityPositioning ;
+	skos:definition "GLObal NAvigation Satellite System (GLONASS)." .
+openlabel_v2:PositioningGps a owl:Class , openlabel_v2:ConnectivityPositioning ;
+	rdfs:label "PositioningGps" ;
+	rdfs:subClassOf openlabel_v2:ConnectivityPositioning ;
+	skos:definition "Global Positioning System (GPS)." .
+openlabel_v2:QuantitativeValue a owl:Class , linkml:ClassDefinition ;
+	rdfs:label "QuantitativeValue" ;
+	rdfs:subClassOf _:c14n122 , _:c14n219 , _:c14n291 , _:c14n384 , _:c14n457 , _:c14n530 , _:c14n794 , _:c14n803 , _:c14n831 , _:c14n864 , _:c14n891 , _:c14n895 ;
+	skos:definition "A point value or interval for quantitative measurements. Requires minValue and maxValue." ;
+	skos:exactMatch sdo:QuantitativeValue ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:RainType a owl:Class , owl:ObjectProperty , linkml:EnumDefinition , linkml:SlotDefinition ;
+	rdfs:label "RainType" , "RainTypeEnum" ;
+	rdfs:range openlabel_v2:RainType ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	owl:unionOf _:c14n218 ;
+	skos:definition "Rainfall type. Refer to BSI PAS-1883 Section 5.3.1.2." , "Types of rainfall. Refer to BSI PAS-1883 Section 5.3.1.2." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
+	linkml:permissible_values openlabel_v2:RainTypeConvective , openlabel_v2:RainTypeDynamic , openlabel_v2:RainTypeOrographic .
+openlabel_v2:RainTypeConvective a owl:Class , openlabel_v2:RainType ;
+	rdfs:label "RainTypeConvective" ;
+	rdfs:subClassOf openlabel_v2:RainType ;
+	skos:definition "Convective." .
+openlabel_v2:RainTypeDynamic a owl:Class , openlabel_v2:RainType ;
+	rdfs:label "RainTypeDynamic" ;
+	rdfs:subClassOf openlabel_v2:RainType ;
+	skos:definition "Dynamic." .
+openlabel_v2:RainTypeOrographic a owl:Class , openlabel_v2:RainType ;
+	rdfs:label "RainTypeOrographic" ;
+	rdfs:subClassOf openlabel_v2:RainType ;
+	skos:definition "Orographic." .
+openlabel_v2:RegulatorySignsUniformFullTime a owl:Class , openlabel_v2:SignsRegulatory ;
+	rdfs:label "RegulatorySignsUniformFullTime" ;
+	rdfs:subClassOf openlabel_v2:SignsRegulatory ;
+	skos:definition "Uniform full-time." .
+openlabel_v2:RegulatorySignsUniformTemporary a owl:Class , openlabel_v2:SignsRegulatory ;
+	rdfs:label "RegulatorySignsUniformTemporary" ;
+	rdfs:subClassOf openlabel_v2:SignsRegulatory ;
+	skos:definition "Uniform temporary." .
+openlabel_v2:RegulatorySignsVariableFullTime a owl:Class , openlabel_v2:SignsRegulatory ;
+	rdfs:label "RegulatorySignsVariableFullTime" ;
+	rdfs:subClassOf openlabel_v2:SignsRegulatory ;
+	skos:definition "Variable full-time." .
+openlabel_v2:RegulatorySignsVariableTemporary a owl:Class , openlabel_v2:SignsRegulatory ;
+	rdfs:label "RegulatorySignsVariableTemporary" ;
+	rdfs:subClassOf openlabel_v2:SignsRegulatory ;
+	skos:definition "Variable temporary." .
+openlabel_v2:RoadTypeDistributor a owl:Class , openlabel_v2:DrivableAreaType ;
+	rdfs:label "RoadTypeDistributor" ;
+	rdfs:subClassOf openlabel_v2:DrivableAreaType ;
+	skos:definition "Distributor roads." .
+openlabel_v2:RoadTypeMinor a owl:Class , openlabel_v2:DrivableAreaType ;
+	rdfs:label "RoadTypeMinor" ;
+	rdfs:subClassOf openlabel_v2:DrivableAreaType ;
+	skos:definition "Minor roads." .
+openlabel_v2:RoadTypeMotorway a owl:Class , openlabel_v2:DrivableAreaType ;
+	rdfs:label "RoadTypeMotorway" ;
+	rdfs:subClassOf openlabel_v2:DrivableAreaType ;
+	skos:definition "Motorways." .
+openlabel_v2:RoadTypeParking a owl:Class , openlabel_v2:DrivableAreaType ;
+	rdfs:label "RoadTypeParking" ;
+	rdfs:subClassOf openlabel_v2:DrivableAreaType ;
+	skos:definition "Parking." .
+openlabel_v2:RoadTypeRadial a owl:Class , openlabel_v2:DrivableAreaType ;
+	rdfs:label "RoadTypeRadial" ;
+	rdfs:subClassOf openlabel_v2:DrivableAreaType ;
+	skos:definition "Radial roads." .
+openlabel_v2:RoadTypeShared a owl:Class , openlabel_v2:DrivableAreaType ;
+	rdfs:label "RoadTypeShared" ;
+	rdfs:subClassOf openlabel_v2:DrivableAreaType ;
+	skos:definition "Shared space." .
+openlabel_v2:RoadTypeSlip a owl:Class , openlabel_v2:DrivableAreaType ;
+	rdfs:label "RoadTypeSlip" ;
+	rdfs:subClassOf openlabel_v2:DrivableAreaType ;
+	skos:definition "Slip roads." .
+openlabel_v2:RoadUser a owl:Class , owl:ObjectProperty , linkml:ClassDefinition , linkml:SlotDefinition ;
+	rdfs:label "RoadUser" ;
+	rdfs:range openlabel_v2:RoadUser ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	rdfs:subClassOf _:c14n128 , _:c14n184 , _:c14n190 , _:c14n345 , _:c14n377 , _:c14n549 , _:c14n667 , _:c14n682 , _:c14n827 , _:c14n870 , _:c14n883 , _:c14n894 ;
+	skos:definition "Road user tag." , "Something which uses a road to travel." ;
+	skos:exactMatch openlabel_v2:RoadUser ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:RoadUserAnimal a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "RoadUserAnimal" ;
+	rdfs:range linkml:Boolean ;
+	skos:definition "Animal road user flag." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:RoadUserHuman a owl:Class , owl:ObjectProperty , linkml:EnumDefinition , linkml:SlotDefinition ;
+	rdfs:label "RoadUserHuman" , "RoadUserHumanEnum" ;
+	rdfs:range openlabel_v2:RoadUserHuman ;
+	owl:unionOf _:c14n231 ;
+	skos:definition "Human road user type." , "Types of human road users." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
+	linkml:permissible_values openlabel_v2:HumanAnimalRider , openlabel_v2:HumanCyclist , openlabel_v2:HumanDriver , openlabel_v2:HumanMotorcyclist , openlabel_v2:HumanPassenger , openlabel_v2:HumanPedestrian , openlabel_v2:HumanWheelchairUser .
+openlabel_v2:RoadUserVehicle a owl:Class , owl:ObjectProperty , linkml:EnumDefinition , linkml:SlotDefinition ;
+	rdfs:label "RoadUserVehicle" , "RoadUserVehicleEnum" ;
+	rdfs:range openlabel_v2:RoadUserVehicle ;
+	owl:unionOf _:c14n460 ;
+	skos:definition "Types of vehicles." , "Vehicle type." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
+	linkml:permissible_values openlabel_v2:VehicleAgricultural , openlabel_v2:VehicleBus , openlabel_v2:VehicleCar , openlabel_v2:VehicleConstruction , openlabel_v2:VehicleCycle , openlabel_v2:VehicleEmergency , openlabel_v2:VehicleMotorcycle , openlabel_v2:VehicleTrailer , openlabel_v2:VehicleTruck , openlabel_v2:VehicleVan , openlabel_v2:VehicleWheelchair .
+openlabel_v2:RoundaboutCompactNosignal a owl:Class , openlabel_v2:JunctionRoundabout ;
+	rdfs:label "RoundaboutCompactNosignal" ;
+	rdfs:subClassOf openlabel_v2:JunctionRoundabout ;
+	skos:definition "Compact non-signalised." .
+openlabel_v2:RoundaboutCompactSignal a owl:Class , openlabel_v2:JunctionRoundabout ;
+	rdfs:label "RoundaboutCompactSignal" ;
+	rdfs:subClassOf openlabel_v2:JunctionRoundabout ;
+	skos:definition "Compact signalised." .
+openlabel_v2:RoundaboutDoubleNosignal a owl:Class , openlabel_v2:JunctionRoundabout ;
+	rdfs:label "RoundaboutDoubleNosignal" ;
+	rdfs:subClassOf openlabel_v2:JunctionRoundabout ;
+	skos:definition "Double non-signalised." .
+openlabel_v2:RoundaboutDoubleSignal a owl:Class , openlabel_v2:JunctionRoundabout ;
+	rdfs:label "RoundaboutDoubleSignal" ;
+	rdfs:subClassOf openlabel_v2:JunctionRoundabout ;
+	skos:definition "Double signalised." .
+openlabel_v2:RoundaboutLargeNosignal a owl:Class , openlabel_v2:JunctionRoundabout ;
+	rdfs:label "RoundaboutLargeNosignal" ;
+	rdfs:subClassOf openlabel_v2:JunctionRoundabout ;
+	skos:definition "Large non-signalised." .
+openlabel_v2:RoundaboutLargeSignal a owl:Class , openlabel_v2:JunctionRoundabout ;
+	rdfs:label "RoundaboutLargeSignal" ;
+	rdfs:subClassOf openlabel_v2:JunctionRoundabout ;
+	skos:definition "Large signalised." .
+openlabel_v2:RoundaboutMiniNosignal a owl:Class , openlabel_v2:JunctionRoundabout ;
+	rdfs:label "RoundaboutMiniNosignal" ;
+	rdfs:subClassOf openlabel_v2:JunctionRoundabout ;
+	skos:definition "Mini non-signalised." .
+openlabel_v2:RoundaboutMiniSignal a owl:Class , openlabel_v2:JunctionRoundabout ;
+	rdfs:label "RoundaboutMiniSignal" ;
+	rdfs:subClassOf openlabel_v2:JunctionRoundabout ;
+	skos:definition "Mini signalised." .
+openlabel_v2:RoundaboutNormalNosignal a owl:Class , openlabel_v2:JunctionRoundabout ;
+	rdfs:label "RoundaboutNormalNosignal" ;
+	rdfs:subClassOf openlabel_v2:JunctionRoundabout ;
+	skos:definition "Normal non-signalised." .
+openlabel_v2:RoundaboutNormalSignal a owl:Class , openlabel_v2:JunctionRoundabout ;
+	rdfs:label "RoundaboutNormalSignal" ;
+	rdfs:subClassOf openlabel_v2:JunctionRoundabout ;
+	skos:definition "Normal signalised." .
+openlabel_v2:Scenario a owl:Class , linkml:ClassDefinition ;
+	rdfs:label "Scenario" ;
+	rdfs:subClassOf _:c14n227 , _:c14n32 , _:c14n463 ;
+	skos:definition "A scenario that can be tagged with OpenLABEL tags." ;
+	skos:exactMatch openlabel_v2:Scenario ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:SceneryFixedStructure a owl:Class , owl:ObjectProperty , linkml:EnumDefinition , linkml:SlotDefinition ;
+	rdfs:label "SceneryFixedStructure" , "SceneryFixedStructureEnum" ;
+	rdfs:range openlabel_v2:SceneryFixedStructure ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	owl:unionOf _:c14n33 ;
+	skos:definition "Fixed road structure. Refer to BSI PAS-1883 Section 5.2.1.e." , "Types of fixed road structures. Refer to BSI PAS-1883 Section 5.2.6." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
+	linkml:permissible_values openlabel_v2:FixedStructureBuilding , openlabel_v2:FixedStructureStreetFurniture , openlabel_v2:FixedStructureStreetlight , openlabel_v2:FixedStructureVegetation .
+openlabel_v2:ScenerySpecialStructure a owl:Class , owl:ObjectProperty , linkml:EnumDefinition , linkml:SlotDefinition ;
+	rdfs:label "ScenerySpecialStructure" , "ScenerySpecialStructureEnum" ;
+	rdfs:range openlabel_v2:ScenerySpecialStructure ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	owl:unionOf _:c14n45 ;
+	skos:definition "Special road structure. Refer to BSI PAS-1883 Section 5.2.1.d." , "Types of special road structures. Refer to BSI PAS-1883 Section 5.2.5." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
+	linkml:permissible_values openlabel_v2:SpecialStructureAutoAccess , openlabel_v2:SpecialStructureBridge , openlabel_v2:SpecialStructurePedestrianCrossing , openlabel_v2:SpecialStructureRailCrossing , openlabel_v2:SpecialStructureTollPlaza , openlabel_v2:SpecialStructureTunnel .
+openlabel_v2:SceneryTemporaryStructure a owl:Class , owl:ObjectProperty , linkml:EnumDefinition , linkml:SlotDefinition ;
+	rdfs:label "SceneryTemporaryStructure" , "SceneryTemporaryStructureEnum" ;
+	rdfs:range openlabel_v2:SceneryTemporaryStructure ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	owl:unionOf _:c14n173 ;
+	skos:definition "Temporary road structure. Refer to BSI PAS-1883 Section 5.2.1.f." , "Types of temporary road structures. Refer to BSI PAS-1883 Section 5.2.7." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
+	linkml:permissible_values openlabel_v2:TemporaryStructureConstructionDetour , openlabel_v2:TemporaryStructureRefuseCollection , openlabel_v2:TemporaryStructureRoadSignage , openlabel_v2:TemporaryStructureRoadWorks .
+openlabel_v2:SceneryZone a owl:Class , owl:ObjectProperty , linkml:EnumDefinition , linkml:SlotDefinition ;
+	rdfs:label "SceneryZone" , "SceneryZoneEnum" ;
+	rdfs:range openlabel_v2:SceneryZone ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	owl:unionOf _:c14n158 ;
+	skos:definition "Types of zones. Refer to BSI PAS-1883 Section 5.2.2." , "Zone type. Refer to BSI PAS-1883 Section 5.2.1.a." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
+	linkml:permissible_values openlabel_v2:ZoneGeoFenced , openlabel_v2:ZoneInterference , openlabel_v2:ZoneRegion , openlabel_v2:ZoneSchool , openlabel_v2:ZoneTrafficManagement .
+openlabel_v2:SignsInformation a owl:Class , owl:ObjectProperty , linkml:EnumDefinition , linkml:SlotDefinition ;
+	rdfs:label "SignsInformation" , "SignsInformationEnum" ;
+	rdfs:range openlabel_v2:SignsInformation ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	owl:unionOf _:c14n642 ;
+	skos:definition "Information sign type. Refer to BSI PAS-1883 Section 5.2.3.5.a." , "Types of information signs. Refer to BSI PAS-1883 Section 5.2.3.5.a." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
+	linkml:permissible_values openlabel_v2:InformationSignsUniformFullTime , openlabel_v2:InformationSignsUniformTemporary , openlabel_v2:InformationSignsVariableFullTime , openlabel_v2:InformationSignsVariableTemporary .
+openlabel_v2:SignsRegulatory a owl:Class , owl:ObjectProperty , linkml:EnumDefinition , linkml:SlotDefinition ;
+	rdfs:label "SignsRegulatory" , "SignsRegulatoryEnum" ;
+	rdfs:range openlabel_v2:SignsRegulatory ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	owl:unionOf _:c14n657 ;
+	skos:definition "Regulatory sign type. Refer to BSI PAS-1883 Section 5.2.3.5.b." , "Types of regulatory signs. Refer to BSI PAS-1883 Section 5.2.3.5.b." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
+	linkml:permissible_values openlabel_v2:RegulatorySignsUniformFullTime , openlabel_v2:RegulatorySignsUniformTemporary , openlabel_v2:RegulatorySignsVariableFullTime , openlabel_v2:RegulatorySignsVariableTemporary .
+openlabel_v2:SignsWarning a owl:Class , owl:ObjectProperty , linkml:EnumDefinition , linkml:SlotDefinition ;
+	rdfs:label "SignsWarning" , "SignsWarningEnum" ;
+	rdfs:range openlabel_v2:SignsWarning ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	owl:unionOf _:c14n584 ;
+	skos:definition "Types of warning signs. Refer to BSI PAS-1883 Section 5.2.3.5.c." , "Warning sign type. Refer to BSI PAS-1883 Section 5.2.3.5.c." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> ;
+	linkml:permissible_values openlabel_v2:WarningSignsUniform , openlabel_v2:WarningSignsUniformFullTime , openlabel_v2:WarningSignsUniformTemporary , openlabel_v2:WarningSignsVariableFullTime , openlabel_v2:WarningSignsVariableTemporary .
+openlabel_v2:SpecialStructureAutoAccess a owl:Class , openlabel_v2:ScenerySpecialStructure ;
+	rdfs:label "SpecialStructureAutoAccess" ;
+	rdfs:subClassOf openlabel_v2:ScenerySpecialStructure ;
+	skos:definition "Automatic access control." .
+openlabel_v2:SpecialStructureBridge a owl:Class , openlabel_v2:ScenerySpecialStructure ;
+	rdfs:label "SpecialStructureBridge" ;
+	rdfs:subClassOf openlabel_v2:ScenerySpecialStructure ;
+	skos:definition "Bridges." .
+openlabel_v2:SpecialStructurePedestrianCrossing a owl:Class , openlabel_v2:ScenerySpecialStructure ;
+	rdfs:label "SpecialStructurePedestrianCrossing" ;
+	rdfs:subClassOf openlabel_v2:ScenerySpecialStructure ;
+	skos:definition "Pedestrian crossings." .
+openlabel_v2:SpecialStructureRailCrossing a owl:Class , openlabel_v2:ScenerySpecialStructure ;
+	rdfs:label "SpecialStructureRailCrossing" ;
+	rdfs:subClassOf openlabel_v2:ScenerySpecialStructure ;
+	skos:definition "Rail crossings." .
+openlabel_v2:SpecialStructureTollPlaza a owl:Class , openlabel_v2:ScenerySpecialStructure ;
+	rdfs:label "SpecialStructureTollPlaza" ;
+	rdfs:subClassOf openlabel_v2:ScenerySpecialStructure ;
+	skos:definition "Toll plaza." .
+openlabel_v2:SpecialStructureTunnel a owl:Class , openlabel_v2:ScenerySpecialStructure ;
+	rdfs:label "SpecialStructureTunnel" ;
+	rdfs:subClassOf openlabel_v2:ScenerySpecialStructure ;
+	skos:definition "Tunnels." .
+openlabel_v2:SubjectVehicleSpeed a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "SubjectVehicleSpeed" ;
+	rdfs:range linkml:Boolean ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Subject vehicle speed flag. Refer to BSI PAS-1883 Section 5.4.b." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:SunPositionBehind a owl:Class , openlabel_v2:DaySunPosition ;
+	rdfs:label "SunPositionBehind" ;
+	rdfs:subClassOf openlabel_v2:DaySunPosition ;
+	skos:definition "Sun behind." .
+openlabel_v2:SunPositionFront a owl:Class , openlabel_v2:DaySunPosition ;
+	rdfs:label "SunPositionFront" ;
+	rdfs:subClassOf openlabel_v2:DaySunPosition ;
+	skos:definition "Sun in front." .
+openlabel_v2:SunPositionLeft a owl:Class , openlabel_v2:DaySunPosition ;
+	rdfs:label "SunPositionLeft" ;
+	rdfs:subClassOf openlabel_v2:DaySunPosition ;
+	skos:definition "Sun on the left." .
+openlabel_v2:SunPositionRight a owl:Class , openlabel_v2:DaySunPosition ;
+	rdfs:label "SunPositionRight" ;
+	rdfs:subClassOf openlabel_v2:DaySunPosition ;
+	skos:definition "Sun on the right." .
+openlabel_v2:SurfaceConditionContamination a owl:Class , openlabel_v2:DrivableAreaSurfaceCondition ;
+	rdfs:label "SurfaceConditionContamination" ;
+	rdfs:subClassOf openlabel_v2:DrivableAreaSurfaceCondition ;
+	skos:definition "Surface contamination." .
+openlabel_v2:SurfaceConditionFlooded a owl:Class , openlabel_v2:DrivableAreaSurfaceCondition ;
+	rdfs:label "SurfaceConditionFlooded" ;
+	rdfs:subClassOf openlabel_v2:DrivableAreaSurfaceCondition ;
+	skos:definition "Flooded roadways." .
+openlabel_v2:SurfaceConditionIcy a owl:Class , openlabel_v2:DrivableAreaSurfaceCondition ;
+	rdfs:label "SurfaceConditionIcy" ;
+	rdfs:subClassOf openlabel_v2:DrivableAreaSurfaceCondition ;
+	skos:definition "Icy." .
+openlabel_v2:SurfaceConditionMirage a owl:Class , openlabel_v2:DrivableAreaSurfaceCondition ;
+	rdfs:label "SurfaceConditionMirage" ;
+	rdfs:subClassOf openlabel_v2:DrivableAreaSurfaceCondition ;
+	skos:definition "Mirage." .
+openlabel_v2:SurfaceConditionSnow a owl:Class , openlabel_v2:DrivableAreaSurfaceCondition ;
+	rdfs:label "SurfaceConditionSnow" ;
+	rdfs:subClassOf openlabel_v2:DrivableAreaSurfaceCondition ;
+	skos:definition "Snow on drivable area." .
+openlabel_v2:SurfaceConditionStandingWater a owl:Class , openlabel_v2:DrivableAreaSurfaceCondition ;
+	rdfs:label "SurfaceConditionStandingWater" ;
+	rdfs:subClassOf openlabel_v2:DrivableAreaSurfaceCondition ;
+	skos:definition "Standing water." .
+openlabel_v2:SurfaceConditionWet a owl:Class , openlabel_v2:DrivableAreaSurfaceCondition ;
+	rdfs:label "SurfaceConditionWet" ;
+	rdfs:subClassOf openlabel_v2:DrivableAreaSurfaceCondition ;
+	skos:definition "Wet road." .
+openlabel_v2:SurfaceFeatureCrack a owl:Class , openlabel_v2:DrivableAreaSurfaceFeature ;
+	rdfs:label "SurfaceFeatureCrack" ;
+	rdfs:subClassOf openlabel_v2:DrivableAreaSurfaceFeature ;
+	skos:definition "Cracks." .
+openlabel_v2:SurfaceFeaturePothole a owl:Class , openlabel_v2:DrivableAreaSurfaceFeature ;
+	rdfs:label "SurfaceFeaturePothole" ;
+	rdfs:subClassOf openlabel_v2:DrivableAreaSurfaceFeature ;
+	skos:definition "Potholes." .
+openlabel_v2:SurfaceFeatureRut a owl:Class , openlabel_v2:DrivableAreaSurfaceFeature ;
+	rdfs:label "SurfaceFeatureRut" ;
+	rdfs:subClassOf openlabel_v2:DrivableAreaSurfaceFeature ;
+	skos:definition "Ruts." .
+openlabel_v2:SurfaceFeatureSwell a owl:Class , openlabel_v2:DrivableAreaSurfaceFeature ;
+	rdfs:label "SurfaceFeatureSwell" ;
+	rdfs:subClassOf openlabel_v2:DrivableAreaSurfaceFeature ;
+	skos:definition "Swells." .
+openlabel_v2:SurfaceTypeLoose a owl:Class , openlabel_v2:DrivableAreaSurfaceType ;
+	rdfs:label "SurfaceTypeLoose" ;
+	rdfs:subClassOf openlabel_v2:DrivableAreaSurfaceType ;
+	skos:definition "Loose (e.g. gravel, earth, sand)." .
+openlabel_v2:SurfaceTypeSegmented a owl:Class , openlabel_v2:DrivableAreaSurfaceType ;
+	rdfs:label "SurfaceTypeSegmented" ;
+	rdfs:subClassOf openlabel_v2:DrivableAreaSurfaceType ;
+	skos:definition "Segmented (e.g. concrete slabs, granite setts, cobblestones)." .
+openlabel_v2:SurfaceTypeUniform a owl:Class , openlabel_v2:DrivableAreaSurfaceType ;
+	rdfs:label "SurfaceTypeUniform" ;
+	rdfs:subClassOf openlabel_v2:DrivableAreaSurfaceType ;
+	skos:definition "Uniform (e.g. asphalt)." .
+openlabel_v2:Tag a owl:Class , linkml:ClassDefinition ;
+	rdfs:label "Tag" ;
+	rdfs:subClassOf _:c14n117 , _:c14n132 , _:c14n187 , _:c14n318 , _:c14n388 , _:c14n42 , _:c14n448 , _:c14n487 , _:c14n579 , _:c14n690 , _:c14n906 , _:c14n911 ;
+	skos:definition "The base tag." ;
+	skos:exactMatch openlabel_v2:Tag ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:TemporaryStructureConstructionDetour a owl:Class , openlabel_v2:SceneryTemporaryStructure ;
+	rdfs:label "TemporaryStructureConstructionDetour" ;
+	rdfs:subClassOf openlabel_v2:SceneryTemporaryStructure ;
+	skos:definition "Construction site detours." .
+openlabel_v2:TemporaryStructureRefuseCollection a owl:Class , openlabel_v2:SceneryTemporaryStructure ;
+	rdfs:label "TemporaryStructureRefuseCollection" ;
+	rdfs:subClassOf openlabel_v2:SceneryTemporaryStructure ;
+	skos:definition "Refuse collection." .
+openlabel_v2:TemporaryStructureRoadSignage a owl:Class , openlabel_v2:SceneryTemporaryStructure ;
+	rdfs:label "TemporaryStructureRoadSignage" ;
+	rdfs:subClassOf openlabel_v2:SceneryTemporaryStructure ;
+	skos:definition "Road signage." .
+openlabel_v2:TemporaryStructureRoadWorks a owl:Class , openlabel_v2:SceneryTemporaryStructure ;
+	rdfs:label "TemporaryStructureRoadWorks" ;
+	rdfs:subClassOf openlabel_v2:SceneryTemporaryStructure ;
+	skos:definition "Road works." .
+openlabel_v2:TrafficAgentDensity a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "TrafficAgentDensity" ;
+	rdfs:range linkml:Boolean ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Traffic agent density flag. Refer to BSI PAS-1883 Section 5.4.a.1." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:TrafficAgentType a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "TrafficAgentType" ;
+	rdfs:range linkml:Boolean ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Traffic agent type classification flag. Refer to BSI PAS-1883 Section 5.4.a.4." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:TrafficFlowRate a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "TrafficFlowRate" ;
+	rdfs:range linkml:Boolean ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Traffic flow rate flag. Refer to BSI PAS-1883 Section 5.4.a.3." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:TrafficSpecialVehicle a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "TrafficSpecialVehicle" ;
+	rdfs:range linkml:Boolean ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Presence of special vehicles flag. Refer to BSI PAS-1883 Section 5.4.a.5." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:TrafficVolume a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "TrafficVolume" ;
+	rdfs:range linkml:Boolean ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Traffic volume flag. Refer to BSI PAS-1883 Section 5.4.a.2." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:TransverseBarriers a owl:Class , openlabel_v2:GeometryTransverse ;
+	rdfs:label "TransverseBarriers" ;
+	rdfs:subClassOf openlabel_v2:GeometryTransverse ;
+	skos:definition "Barriers on edges." .
+openlabel_v2:TransverseDivided a owl:Class , openlabel_v2:GeometryTransverse ;
+	rdfs:label "TransverseDivided" ;
+	rdfs:subClassOf openlabel_v2:GeometryTransverse ;
+	skos:definition "Divided." .
+openlabel_v2:TransverseLanesTogether a owl:Class , openlabel_v2:GeometryTransverse ;
+	rdfs:label "TransverseLanesTogether" ;
+	rdfs:subClassOf openlabel_v2:GeometryTransverse ;
+	skos:definition "Types of lanes together." .
+openlabel_v2:TransversePavements a owl:Class , openlabel_v2:GeometryTransverse ;
+	rdfs:label "TransversePavements" ;
+	rdfs:subClassOf openlabel_v2:GeometryTransverse ;
+	skos:definition "Pavements." .
+openlabel_v2:TransverseUndivided a owl:Class , openlabel_v2:GeometryTransverse ;
+	rdfs:label "TransverseUndivided" ;
+	rdfs:subClassOf openlabel_v2:GeometryTransverse ;
+	skos:definition "Undivided." .
+openlabel_v2:TravelDirectionLeft a owl:Class , openlabel_v2:LaneSpecificationTravelDirection ;
+	rdfs:label "TravelDirectionLeft" ;
+	rdfs:subClassOf openlabel_v2:LaneSpecificationTravelDirection ;
+	skos:definition "Left." .
+openlabel_v2:TravelDirectionRight a owl:Class , openlabel_v2:LaneSpecificationTravelDirection ;
+	rdfs:label "TravelDirectionRight" ;
+	rdfs:subClassOf openlabel_v2:LaneSpecificationTravelDirection ;
+	skos:definition "Right." .
+openlabel_v2:V2iCellular a owl:Class , openlabel_v2:ConnectivityCommunication ;
+	rdfs:label "V2iCellular" ;
+	rdfs:subClassOf openlabel_v2:ConnectivityCommunication ;
+	skos:definition "V2I via cellular network." .
+openlabel_v2:V2iSatellite a owl:Class , openlabel_v2:ConnectivityCommunication ;
+	rdfs:label "V2iSatellite" ;
+	rdfs:subClassOf openlabel_v2:ConnectivityCommunication ;
+	skos:definition "V2I via satellite." .
+openlabel_v2:V2iWifi a owl:Class , openlabel_v2:ConnectivityCommunication ;
+	rdfs:label "V2iWifi" ;
+	rdfs:subClassOf openlabel_v2:ConnectivityCommunication ;
+	skos:definition "V2I via WiFi." .
+openlabel_v2:V2vCellular a owl:Class , openlabel_v2:ConnectivityCommunication ;
+	rdfs:label "V2vCellular" ;
+	rdfs:subClassOf openlabel_v2:ConnectivityCommunication ;
+	skos:definition "V2V via cellular network." .
+openlabel_v2:V2vSatellite a owl:Class , openlabel_v2:ConnectivityCommunication ;
+	rdfs:label "V2vSatellite" ;
+	rdfs:subClassOf openlabel_v2:ConnectivityCommunication ;
+	skos:definition "V2V via satellite." .
+openlabel_v2:V2vWifi a owl:Class , openlabel_v2:ConnectivityCommunication ;
+	rdfs:label "V2vWifi" ;
+	rdfs:subClassOf openlabel_v2:ConnectivityCommunication ;
+	skos:definition "V2V via WiFi." .
+openlabel_v2:VehicleAgricultural a owl:Class , openlabel_v2:RoadUserVehicle ;
+	rdfs:label "VehicleAgricultural" ;
+	rdfs:subClassOf openlabel_v2:RoadUserVehicle ;
+	skos:definition "Agricultural vehicle." .
+openlabel_v2:VehicleBus a owl:Class , openlabel_v2:RoadUserVehicle ;
+	rdfs:label "VehicleBus" ;
+	rdfs:subClassOf openlabel_v2:RoadUserVehicle ;
+	skos:definition "Bus." .
+openlabel_v2:VehicleCar a owl:Class , openlabel_v2:RoadUserVehicle ;
+	rdfs:label "VehicleCar" ;
+	rdfs:subClassOf openlabel_v2:RoadUserVehicle ;
+	skos:definition "Car." .
+openlabel_v2:VehicleConstruction a owl:Class , openlabel_v2:RoadUserVehicle ;
+	rdfs:label "VehicleConstruction" ;
+	rdfs:subClassOf openlabel_v2:RoadUserVehicle ;
+	skos:definition "Construction vehicle." .
+openlabel_v2:VehicleCycle a owl:Class , openlabel_v2:RoadUserVehicle ;
+	rdfs:label "VehicleCycle" ;
+	rdfs:subClassOf openlabel_v2:RoadUserVehicle ;
+	skos:definition "Cycle." .
+openlabel_v2:VehicleEmergency a owl:Class , openlabel_v2:RoadUserVehicle ;
+	rdfs:label "VehicleEmergency" ;
+	rdfs:subClassOf openlabel_v2:RoadUserVehicle ;
+	skos:definition "Emergency vehicle." .
+openlabel_v2:VehicleMotorcycle a owl:Class , openlabel_v2:RoadUserVehicle ;
+	rdfs:label "VehicleMotorcycle" ;
+	rdfs:subClassOf openlabel_v2:RoadUserVehicle ;
+	skos:definition "Motorcycle." .
+openlabel_v2:VehicleTrailer a owl:Class , openlabel_v2:RoadUserVehicle ;
+	rdfs:label "VehicleTrailer" ;
+	rdfs:subClassOf openlabel_v2:RoadUserVehicle ;
+	skos:definition "Trailer." .
+openlabel_v2:VehicleTruck a owl:Class , openlabel_v2:RoadUserVehicle ;
+	rdfs:label "VehicleTruck" ;
+	rdfs:subClassOf openlabel_v2:RoadUserVehicle ;
+	skos:definition "Truck." .
+openlabel_v2:VehicleVan a owl:Class , openlabel_v2:RoadUserVehicle ;
+	rdfs:label "VehicleVan" ;
+	rdfs:subClassOf openlabel_v2:RoadUserVehicle ;
+	skos:definition "Van." .
+openlabel_v2:VehicleWheelchair a owl:Class , openlabel_v2:RoadUserVehicle ;
+	rdfs:label "VehicleWheelchair" ;
+	rdfs:subClassOf openlabel_v2:RoadUserVehicle ;
+	skos:definition "Wheelchair." .
+openlabel_v2:WarningSignsUniform a owl:Class , openlabel_v2:SignsWarning ;
+	rdfs:label "WarningSignsUniform" ;
+	rdfs:subClassOf openlabel_v2:SignsWarning ;
+	skos:definition "Uniform." .
+openlabel_v2:WarningSignsUniformFullTime a owl:Class , openlabel_v2:SignsWarning ;
+	rdfs:label "WarningSignsUniformFullTime" ;
+	rdfs:subClassOf openlabel_v2:SignsWarning ;
+	skos:definition "Uniform full-time." .
+openlabel_v2:WarningSignsUniformTemporary a owl:Class , openlabel_v2:SignsWarning ;
+	rdfs:label "WarningSignsUniformTemporary" ;
+	rdfs:subClassOf openlabel_v2:SignsWarning ;
+	skos:definition "Uniform temporary." .
+openlabel_v2:WarningSignsVariableFullTime a owl:Class , openlabel_v2:SignsWarning ;
+	rdfs:label "WarningSignsVariableFullTime" ;
+	rdfs:subClassOf openlabel_v2:SignsWarning ;
+	skos:definition "Variable full-time." .
+openlabel_v2:WarningSignsVariableTemporary a owl:Class , openlabel_v2:SignsWarning ;
+	rdfs:label "WarningSignsVariableTemporary" ;
+	rdfs:subClassOf openlabel_v2:SignsWarning ;
+	skos:definition "Variable temporary." .
+openlabel_v2:WeatherRain a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "WeatherRain" ;
+	rdfs:range linkml:Boolean ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Rainfall flag. Refer to BSI PAS-1883 Section 5.3.1.2." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:WeatherSnow a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "WeatherSnow" ;
+	rdfs:range linkml:Boolean ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Snowfall flag. Refer to BSI PAS-1883 Section 5.3.1.3." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:WeatherWind a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "WeatherWind" ;
+	rdfs:range linkml:Boolean ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Wind flag. Refer to BSI PAS-1883 Section 5.3.1.1." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:ZoneGeoFenced a owl:Class , openlabel_v2:SceneryZone ;
+	rdfs:label "ZoneGeoFenced" ;
+	rdfs:subClassOf openlabel_v2:SceneryZone ;
+	skos:definition "GeoFenced areas." .
+openlabel_v2:ZoneInterference a owl:Class , openlabel_v2:SceneryZone ;
+	rdfs:label "ZoneInterference" ;
+	rdfs:subClassOf openlabel_v2:SceneryZone ;
+	skos:definition "Interference zones." .
+openlabel_v2:ZoneRegion a owl:Class , openlabel_v2:SceneryZone ;
+	rdfs:label "ZoneRegion" ;
+	rdfs:subClassOf openlabel_v2:SceneryZone ;
+	skos:definition "Regions or states." .
+openlabel_v2:ZoneSchool a owl:Class , openlabel_v2:SceneryZone ;
+	rdfs:label "ZoneSchool" ;
+	rdfs:subClassOf openlabel_v2:SceneryZone ;
+	skos:definition "School zones." .
+openlabel_v2:ZoneTrafficManagement a owl:Class , openlabel_v2:SceneryZone ;
+	rdfs:label "ZoneTrafficManagement" ;
+	rdfs:subClassOf openlabel_v2:SceneryZone ;
+	skos:definition "Traffic management zones." .
+openlabel_v2:daySunElevationValue a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "daySunElevationValue" ;
+	rdfs:range linkml:Decimal ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Sun elevation (degrees). Refer to BSI PAS-1883 Section 5.3.3.a.1." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:hasLowerBound a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "hasLowerBound" ;
+	rdfs:range linkml:Decimal ;
+	skos:definition "Lower bound inferred via RDFS from schema:minValue being a subPropertyOf cmns-q:hasLowerBound in schema.org OWL." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:hasTag a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "hasTag" ;
+	rdfs:range openlabel_v2:Tag ;
+	skos:definition "A tag associated with a scenario." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:hasUpperBound a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "hasUpperBound" ;
+	rdfs:range linkml:Decimal ;
+	skos:definition "Upper bound inferred via RDFS from schema:maxValue being a subPropertyOf cmns-q:hasUpperBound in schema.org OWL." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:horizontalCurvesValue a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "horizontalCurvesValue" ;
+	rdfs:range linkml:Decimal ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Curve radius (m). Refer to BSI PAS-1883 Section 5.2.3.3." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:illuminationCloudinessValue a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "illuminationCloudinessValue" ;
+	rdfs:range linkml:Decimal ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Cloud cover (okta). Refer to BSI PAS-1883 Section 5.3.3.c." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:laneSpecificationDimensionsValue a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "laneSpecificationDimensionsValue" ;
+	rdfs:range _:c14n55 ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Lane width (m). Refer to BSI PAS-1883 Section 5.2.3.4.a." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:laneSpecificationLaneCountValue a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "laneSpecificationLaneCountValue" ;
+	rdfs:range _:c14n629 ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Number of lanes (unit). Refer to BSI PAS-1883 Section 5.2.3.4.d." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:licenseURI a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "licenseURI" ;
+	rdfs:range linkml:String ;
+	skos:definition "The type of license which governs usage of the scenario." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:longitudinalDownSlopeValue a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "longitudinalDownSlopeValue" ;
+	rdfs:range linkml:Decimal ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.ii." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:longitudinalUpSlopeValue a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "longitudinalUpSlopeValue" ;
+	rdfs:range linkml:Decimal ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.i." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:maxValue a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "maxValue" ;
+	rdfs:range linkml:Decimal ;
+	skos:definition "Maximum value of the range." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:minValue a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "minValue" ;
+	rdfs:range linkml:Decimal ;
+	skos:definition "Minimum value of the range." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:motionAccelerateValue a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "motionAccelerateValue" ;
+	rdfs:range _:c14n134 ;
+	skos:definition "Rate of acceleration (ms-2)." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:motionDecelerateValue a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "motionDecelerateValue" ;
+	rdfs:range _:c14n756 ;
+	skos:definition "Rate of deceleration (ms-2)." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:motionDriveValue a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "motionDriveValue" ;
+	rdfs:range _:c14n483 ;
+	skos:definition "Speed (km/h)." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:ownerEmail a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "ownerEmail" ;
+	rdfs:range linkml:String ;
+	skos:definition "The email address of the legal entity who owns the rights to the scenario." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:ownerName a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "ownerName" ;
+	rdfs:range linkml:String ;
+	skos:definition "The name of the legal entity who owns the rights to the scenario." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:ownerURL a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "ownerURL" ;
+	rdfs:range linkml:String ;
+	skos:definition "The URL of the legal entity who owns the rights to the scenario." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:particulatesWaterValue a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "particulatesWaterValue" ;
+	rdfs:range linkml:Decimal ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Meteorological Optical Range (MOR) (m). Refer to BSI PAS-1883 Section 5.3.2.b." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:scenarioCreatedDate a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "scenarioCreatedDate" ;
+	rdfs:range linkml:Datetime ;
+	skos:definition "The date that the scenario was created/published." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:scenarioDefinition a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "scenarioDefinition" ;
+	rdfs:range linkml:String ;
+	skos:definition "SDL definition of the scenario." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:scenarioDefinitionLanguageURI a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "scenarioDefinitionLanguageURI" ;
+	rdfs:range linkml:String ;
+	skos:definition "URI of SDL language used for the definition of the scenario." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:scenarioDescription a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "scenarioDescription" ;
+	rdfs:range linkml:String ;
+	skos:definition "A description of the scenario." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:scenarioName a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "scenarioName" ;
+	rdfs:range linkml:String ;
+	skos:definition "The name of the scenario." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:scenarioParentReference a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "scenarioParentReference" ;
+	rdfs:range linkml:String ;
+	skos:definition "Universally unique identifier (UUID) which identifies the scenario which this one has been derived from." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:scenarioUniqueReference a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "scenarioUniqueReference" ;
+	rdfs:range linkml:String ;
+	skos:definition "Universally unique identifier (UUID) assigned to the scenario which allows the scenario to be identified." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:scenarioVersion a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "scenarioVersion" ;
+	rdfs:range linkml:String ;
+	skos:definition "The version number of the scenario." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:scenarioVisualisationURL a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "scenarioVisualisationURL" ;
+	rdfs:range linkml:String ;
+	skos:definition "Relative or absolute URL of a static image or animation of the scenario to allow users to easily see what the scenario represents." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:subjectVehicleSpeedValue a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "subjectVehicleSpeedValue" ;
+	rdfs:range _:c14n334 ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Speed (km/h). Refer to BSI PAS-1883 Section 5.4.b." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:trafficAgentDensityValue a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "trafficAgentDensityValue" ;
+	rdfs:range _:c14n679 ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Density (vehicles/km). Refer to BSI PAS-1883 Section 5.4.a.1." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:trafficAgentTypeValue a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "trafficAgentTypeValue" ;
+	rdfs:range _:c14n308 ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Agent type. Refer to BSI PAS-1883 Section 5.4.a.4." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:trafficFlowRateValue a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "trafficFlowRateValue" ;
+	rdfs:range _:c14n665 ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Rate (vehicles/h). Refer to BSI PAS-1883 Section 5.4.a.3." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:trafficVolumeValue a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "trafficVolumeValue" ;
+	rdfs:range _:c14n209 ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Volume (vehicle km). Refer to BSI PAS-1883 Section 5.4.a.2." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:weatherRainValue a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "weatherRainValue" ;
+	rdfs:range linkml:Decimal ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Rainfall intensity (mm/h). Refer to BSI PAS-1883 Section 5.3.1.2." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:weatherSnowValue a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "weatherSnowValue" ;
+	rdfs:range linkml:Decimal ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Visibility (km). Refer to BSI PAS-1883 Section 5.3.1.3." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+openlabel_v2:weatherWindValue a owl:ObjectProperty , linkml:SlotDefinition ;
+	rdfs:label "weatherWindValue" ;
+	rdfs:range linkml:Decimal ;
+	rdfs:seeAlso <https://www.bsigroup.com/en-GB/CAV/pas-1883> ;
+	skos:definition "Wind speed (m/s). Refer to BSI PAS-1883 Section 5.3.1.1." ;
+	skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+<https://w3id.org/ascs-ev/envited-x/openlabel/v2> dcterms:license "https://www.eclipse.org/legal/epl-2.0/" ;
+	dcterms:title "ASAM OpenLABEL Scenario Tagging Ontology" ;
+	pav:version "2.0.0" ;
+	a owl:Ontology ;
+	rdfs:label "openlabel-v2" ;
+	skos:definition "Ontology for scenario tagging based on the ASAM OpenLABEL standard and BSI PAS-1883 Operational Design Domain taxonomy." .
+_:c14n0 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:IlluminationCloudiness .
+_:c14n1 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:GeometryTransverse .
+_:c14n10 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:MotionLaneChangeLeft .
+_:c14n100 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:horizontalCurvesValue .
+_:c14n1000 rdf:first openlabel_v2:QuantitativeValue ;
+	rdf:rest rdf:nil .
+_:c14n1001 rdf:first linkml:Decimal ;
+	rdf:rest _:c14n1000 .
+_:c14n1002 rdf:first openlabel_v2:QuantitativeValue ;
+	rdf:rest rdf:nil .
+_:c14n1003 rdf:first _:c14n1004 ;
+	rdf:rest _:c14n1002 .
+_:c14n1004 a rdfs:Datatype ;
+	owl:intersectionOf _:c14n1005 .
+_:c14n1005 rdf:first linkml:Integer ;
+	rdf:rest _:c14n1006 .
+_:c14n1006 rdf:first _:c14n1007 ;
+	rdf:rest rdf:nil .
+_:c14n1007 a rdfs:Datatype ;
+	owl:onDatatype xsd:integer ;
+	owl:withRestrictions _:c14n1008 .
+_:c14n1008 rdf:first _:c14n1009 ;
+	rdf:rest rdf:nil .
+_:c14n1009 xsd:minInclusive 0 .
+_:c14n101 rdf:first openlabel_v2:SurfaceFeaturePothole ;
+	rdf:rest _:c14n672 .
+_:c14n1010 rdf:first openlabel_v2:QuantitativeValue ;
+	rdf:rest rdf:nil .
+_:c14n1011 rdf:first _:c14n1012 ;
+	rdf:rest _:c14n1010 .
+_:c14n1012 a rdfs:Datatype ;
+	owl:intersectionOf _:c14n1013 .
+_:c14n1013 rdf:first linkml:Integer ;
+	rdf:rest _:c14n1014 .
+_:c14n1014 rdf:first _:c14n1015 ;
+	rdf:rest rdf:nil .
+_:c14n1015 a rdfs:Datatype ;
+	owl:onDatatype xsd:integer ;
+	owl:withRestrictions _:c14n1016 .
+_:c14n1016 rdf:first _:c14n1017 ;
+	rdf:rest rdf:nil .
+_:c14n1017 xsd:minInclusive 1 .
+_:c14n1018 rdf:first openlabel_v2:QuantitativeValue ;
+	rdf:rest rdf:nil .
+_:c14n1019 rdf:first linkml:Decimal ;
+	rdf:rest _:c14n1018 .
+_:c14n102 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:ownerURL .
+_:c14n1020 a rdfs:Datatype ;
+	owl:onDatatype xsd:integer ;
+	owl:withRestrictions _:c14n1024 .
+_:c14n1021 rdf:first _:c14n1020 ;
+	rdf:rest rdf:nil .
+_:c14n1022 rdf:first linkml:Integer ;
+	rdf:rest _:c14n1021 .
+_:c14n1023 a rdfs:Datatype ;
+	owl:intersectionOf _:c14n1022 .
+_:c14n1024 rdf:first _:c14n1025 ;
+	rdf:rest rdf:nil .
+_:c14n1025 xsd:minInclusive 0 .
+_:c14n1026 a rdfs:Datatype ;
+	owl:onDatatype xsd:integer ;
+	owl:withRestrictions _:c14n1029 .
+_:c14n1027 rdf:first _:c14n1026 ;
+	rdf:rest rdf:nil .
+_:c14n1028 rdf:first linkml:Integer ;
+	rdf:rest _:c14n1027 .
+_:c14n1029 rdf:first _:c14n1030 ;
+	rdf:rest rdf:nil .
+_:c14n103 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:particulatesWaterValue .
+_:c14n1030 xsd:minInclusive 0 .
+_:c14n1031 a rdfs:Datatype ;
+	owl:onDatatype xsd:integer ;
+	owl:withRestrictions _:c14n1034 .
+_:c14n1032 rdf:first _:c14n1031 ;
+	rdf:rest rdf:nil .
+_:c14n1033 rdf:first linkml:Integer ;
+	rdf:rest _:c14n1032 .
+_:c14n1034 rdf:first _:c14n1035 ;
+	rdf:rest rdf:nil .
+_:c14n1035 xsd:minInclusive 0 .
+_:c14n1036 a rdfs:Datatype ;
+	owl:onDatatype xsd:integer ;
+	owl:withRestrictions _:c14n1040 .
+_:c14n1037 rdf:first _:c14n1036 ;
+	rdf:rest rdf:nil .
+_:c14n1038 rdf:first linkml:Integer ;
+	rdf:rest _:c14n1037 .
+_:c14n1039 a rdfs:Datatype ;
+	owl:intersectionOf _:c14n1038 .
+_:c14n104 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:EnvironmentParticulates .
+_:c14n1040 rdf:first _:c14n1041 ;
+	rdf:rest rdf:nil .
+_:c14n1041 xsd:minInclusive 0 .
+_:c14n1042 a rdfs:Datatype ;
+	owl:onDatatype xsd:integer ;
+	owl:withRestrictions _:c14n1045 .
+_:c14n1043 rdf:first _:c14n1042 ;
+	rdf:rest rdf:nil .
+_:c14n1044 rdf:first linkml:Integer ;
+	rdf:rest _:c14n1043 .
+_:c14n1045 rdf:first _:c14n1046 ;
+	rdf:rest rdf:nil .
+_:c14n1046 xsd:minInclusive 0 .
+_:c14n1047 a rdfs:Datatype ;
+	owl:onDatatype xsd:integer ;
+	owl:withRestrictions _:c14n1051 .
+_:c14n1048 rdf:first _:c14n1047 ;
+	rdf:rest rdf:nil .
+_:c14n1049 rdf:first linkml:Integer ;
+	rdf:rest _:c14n1048 .
+_:c14n105 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:DrivableAreaEdge .
+_:c14n1050 a rdfs:Datatype ;
+	owl:intersectionOf _:c14n1049 .
+_:c14n1051 rdf:first _:c14n1052 ;
+	rdf:rest rdf:nil .
+_:c14n1052 xsd:minInclusive 0 .
+_:c14n1053 rdf:first _:c14n435 ;
+	rdf:rest _:c14n1055 .
+_:c14n1054 rdfs:subClassOf _:c14n851 ;
+	owl:intersectionOf _:c14n1053 .
+_:c14n1055 rdf:first openlabel_v2:Behaviour ;
+	rdf:rest rdf:nil .
+_:c14n1056 rdf:first _:c14n580 ;
+	rdf:rest _:c14n1058 .
+_:c14n1057 rdfs:subClassOf _:c14n526 ;
+	owl:intersectionOf _:c14n1056 .
+_:c14n1058 rdf:first openlabel_v2:Behaviour ;
+	rdf:rest rdf:nil .
+_:c14n1059 rdf:first _:c14n806 ;
+	rdf:rest _:c14n1061 .
+_:c14n106 a owl:Restriction ;
+	owl:onProperty openlabel_v2:subjectVehicleSpeedValue ;
+	owl:someValuesFrom linkml:String .
+_:c14n1060 rdfs:subClassOf _:c14n521 ;
+	owl:intersectionOf _:c14n1059 .
+_:c14n1061 rdf:first openlabel_v2:Behaviour ;
+	rdf:rest rdf:nil .
+_:c14n1062 rdf:first openlabel_v2:RoadUserVehicle ;
+	rdf:rest rdf:nil .
+_:c14n1063 rdf:first openlabel_v2:RoadUserHuman ;
+	rdf:rest _:c14n1062 .
+_:c14n1064 xsd:pattern "true" .
+_:c14n1065 rdf:first _:c14n1064 ;
+	rdf:rest rdf:nil .
+_:c14n1066 a rdfs:Datatype ;
+	owl:onDatatype xsd:string ;
+	owl:withRestrictions _:c14n1065 .
+_:c14n1067 xsd:pattern "true" .
+_:c14n1068 rdf:first _:c14n1067 ;
+	rdf:rest rdf:nil .
+_:c14n1069 a rdfs:Datatype ;
+	owl:onDatatype xsd:string ;
+	owl:withRestrictions _:c14n1068 .
+_:c14n107 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:scenarioDescription .
+_:c14n1070 xsd:pattern "true" .
+_:c14n1071 rdf:first _:c14n1070 ;
+	rdf:rest rdf:nil .
+_:c14n1072 a rdfs:Datatype ;
+	owl:onDatatype xsd:string ;
+	owl:withRestrictions _:c14n1071 .
+_:c14n1073 xsd:pattern "true" .
+_:c14n1074 rdf:first _:c14n1073 ;
+	rdf:rest rdf:nil .
+_:c14n1075 a rdfs:Datatype ;
+	owl:onDatatype xsd:string ;
+	owl:withRestrictions _:c14n1074 .
+_:c14n1076 xsd:pattern "true" .
+_:c14n1077 rdf:first _:c14n1076 ;
+	rdf:rest rdf:nil .
+_:c14n1078 a rdfs:Datatype ;
+	owl:onDatatype xsd:string ;
+	owl:withRestrictions _:c14n1077 .
+_:c14n1079 xsd:pattern "true" .
+_:c14n108 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:LaneSpecificationMarking .
+_:c14n1080 rdf:first _:c14n1079 ;
+	rdf:rest rdf:nil .
+_:c14n1081 a rdfs:Datatype ;
+	owl:onDatatype xsd:string ;
+	owl:withRestrictions _:c14n1080 .
+_:c14n1082 xsd:pattern "true" .
+_:c14n1083 rdf:first _:c14n1082 ;
+	rdf:rest rdf:nil .
+_:c14n1084 a rdfs:Datatype ;
+	owl:onDatatype xsd:string ;
+	owl:withRestrictions _:c14n1083 .
+_:c14n1085 xsd:pattern "true" .
+_:c14n1086 rdf:first _:c14n1085 ;
+	rdf:rest rdf:nil .
+_:c14n1087 a rdfs:Datatype ;
+	owl:onDatatype xsd:string ;
+	owl:withRestrictions _:c14n1086 .
+_:c14n1088 xsd:pattern "true" .
+_:c14n1089 rdf:first _:c14n1088 ;
+	rdf:rest rdf:nil .
+_:c14n109 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:MotionUTurn .
+_:c14n1090 a rdfs:Datatype ;
+	owl:onDatatype xsd:string ;
+	owl:withRestrictions _:c14n1089 .
+_:c14n1091 xsd:pattern "true" .
+_:c14n1092 rdf:first _:c14n1091 ;
+	rdf:rest rdf:nil .
+_:c14n1093 a rdfs:Datatype ;
+	owl:onDatatype xsd:string ;
+	owl:withRestrictions _:c14n1092 .
+_:c14n1094 xsd:pattern "true" .
+_:c14n1095 rdf:first _:c14n1094 ;
+	rdf:rest rdf:nil .
+_:c14n1096 a rdfs:Datatype ;
+	owl:onDatatype xsd:string ;
+	owl:withRestrictions _:c14n1095 .
+_:c14n1097 xsd:pattern "true" .
+_:c14n1098 rdf:first _:c14n1097 ;
+	rdf:rest rdf:nil .
+_:c14n1099 a rdfs:Datatype ;
+	owl:onDatatype xsd:string ;
+	owl:withRestrictions _:c14n1098 .
+_:c14n11 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:trafficVolumeValue .
+_:c14n110 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:ParticulatesDust .
+_:c14n1100 xsd:pattern "true" .
+_:c14n1101 rdf:first _:c14n1100 ;
+	rdf:rest rdf:nil .
+_:c14n1102 a rdfs:Datatype ;
+	owl:onDatatype xsd:string ;
+	owl:withRestrictions _:c14n1101 .
+_:c14n1103 xsd:pattern "true" .
+_:c14n1104 rdf:first _:c14n1103 ;
+	rdf:rest rdf:nil .
+_:c14n1105 a rdfs:Datatype ;
+	owl:onDatatype xsd:string ;
+	owl:withRestrictions _:c14n1104 .
+_:c14n1106 xsd:pattern "true" .
+_:c14n1107 rdf:first _:c14n1106 ;
+	rdf:rest rdf:nil .
+_:c14n1108 a rdfs:Datatype ;
+	owl:onDatatype xsd:string ;
+	owl:withRestrictions _:c14n1107 .
+_:c14n1109 xsd:pattern "true" .
+_:c14n111 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:weatherRainValue .
+_:c14n1110 rdf:first _:c14n1109 ;
+	rdf:rest rdf:nil .
+_:c14n1111 a rdfs:Datatype ;
+	owl:onDatatype xsd:string ;
+	owl:withRestrictions _:c14n1110 .
+_:c14n1112 xsd:pattern "true" .
+_:c14n1113 rdf:first _:c14n1112 ;
+	rdf:rest rdf:nil .
+_:c14n1114 a rdfs:Datatype ;
+	owl:onDatatype xsd:string ;
+	owl:withRestrictions _:c14n1113 .
+_:c14n1115 xsd:pattern "true" .
+_:c14n1116 rdf:first _:c14n1115 ;
+	rdf:rest rdf:nil .
+_:c14n1117 a rdfs:Datatype ;
+	owl:onDatatype xsd:string ;
+	owl:withRestrictions _:c14n1116 .
+_:c14n1118 xsd:pattern "true" .
+_:c14n1119 rdf:first _:c14n1118 ;
+	rdf:rest rdf:nil .
+_:c14n112 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationDimensions .
+_:c14n1120 a rdfs:Datatype ;
+	owl:onDatatype xsd:string ;
+	owl:withRestrictions _:c14n1119 .
+_:c14n113 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:SignsRegulatory .
+_:c14n114 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:IlluminationLowLight .
+_:c14n115 rdf:first openlabel_v2:EdgeNone ;
+	rdf:rest _:c14n171 .
+_:c14n116 a owl:Restriction ;
+	owl:allValuesFrom linkml:Decimal ;
+	owl:onProperty openlabel_v2:longitudinalUpSlopeValue .
+_:c14n117 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:AdminTag .
+_:c14n118 a owl:Restriction ;
+	owl:onProperty openlabel_v2:WeatherRain ;
+	owl:someValuesFrom _:c14n1120 .
+_:c14n119 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:TrafficVolume .
+_:c14n12 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:MotionTowards .
+_:c14n120 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:TrafficVolume .
+_:c14n121 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:TrafficAgentType .
+_:c14n122 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:hasUpperBound .
+_:c14n123 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:LaneSpecificationType ;
+	owl:onProperty openlabel_v2:LaneSpecificationType .
+_:c14n124 a owl:Restriction ;
+	owl:allValuesFrom linkml:Decimal ;
+	owl:onProperty openlabel_v2:horizontalCurvesValue .
+_:c14n125 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:ParticulatesVolcanic .
+_:c14n126 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:MotionTurnLeft .
+_:c14n127 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:ScenerySpecialStructure .
+_:c14n128 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:motionDriveValue .
+_:c14n129 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:ownerName .
+_:c14n13 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:TrafficAgentDensity .
+_:c14n130 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:DaySunElevation .
+_:c14n131 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:SceneryFixedStructure .
+_:c14n132 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:Odd ;
+	owl:onProperty openlabel_v2:Odd .
+_:c14n133 a owl:Restriction ;
+	owl:onProperty openlabel_v2:TrafficAgentType ;
+	owl:someValuesFrom _:c14n1066 .
+_:c14n134 owl:unionOf _:c14n1019 .
+_:c14n135 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:ParticulatesWater .
+_:c14n136 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:JunctionIntersection .
+_:c14n137 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:IlluminationLowLight .
+_:c14n138 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:SceneryTemporaryStructure .
+_:c14n139 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:ConnectivityCommunication ;
+	owl:onProperty openlabel_v2:ConnectivityCommunication .
+_:c14n14 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:laneSpecificationLaneCountValue .
+_:c14n140 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:WeatherWind .
+_:c14n141 rdf:first openlabel_v2:RoundaboutMiniSignal ;
+	rdf:rest _:c14n862 .
+_:c14n142 rdf:first openlabel_v2:HumanCyclist ;
+	rdf:rest _:c14n294 .
+_:c14n143 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:laneSpecificationDimensionsValue .
+_:c14n144 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:illuminationCloudinessValue .
+_:c14n145 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:IlluminationLowLight ;
+	owl:onProperty openlabel_v2:IlluminationLowLight .
+_:c14n146 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:licenseURI .
+_:c14n147 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:particulatesWaterValue .
+_:c14n148 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:SignsInformation ;
+	owl:onProperty openlabel_v2:SignsInformation .
+_:c14n149 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:LongitudinalDownSlope .
+_:c14n15 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:MotionUTurn .
+_:c14n150 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:TrafficFlowRate .
+_:c14n151 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:SignsWarning ;
+	owl:onProperty openlabel_v2:SignsWarning .
+_:c14n152 a owl:Restriction ;
+	owl:onProperty openlabel_v2:trafficVolumeValue ;
+	owl:someValuesFrom linkml:String .
+_:c14n153 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:SignsInformation .
+_:c14n154 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceCondition .
+_:c14n155 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:DaySunPosition .
+_:c14n156 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:WeatherRain .
+_:c14n157 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:HorizontalStraights .
+_:c14n158 rdf:first openlabel_v2:ZoneGeoFenced ;
+	rdf:rest _:c14n337 .
+_:c14n159 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:HorizontalCurves .
+_:c14n16 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:illuminationCloudinessValue .
+_:c14n160 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:LaneSpecificationLaneCount .
+_:c14n161 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:horizontalCurvesValue .
+_:c14n162 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:MotionSlide .
+_:c14n163 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:subjectVehicleSpeedValue .
+_:c14n164 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:LongitudinalUpSlope .
+_:c14n165 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:subjectVehicleSpeedValue .
+_:c14n166 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:daySunElevationValue .
+_:c14n167 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:DrivableAreaType .
+_:c14n168 a owl:Restriction ;
+	owl:onProperty openlabel_v2:weatherRainValue ;
+	owl:someValuesFrom linkml:String .
+_:c14n169 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:illuminationCloudinessValue .
+_:c14n17 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceFeature .
+_:c14n170 rdf:first openlabel_v2:SurfaceConditionIcy ;
+	rdf:rest _:c14n472 .
+_:c14n171 rdf:first openlabel_v2:EdgeShoulderGrass ;
+	rdf:rest _:c14n192 .
+_:c14n172 a owl:Restriction ;
+	owl:onProperty openlabel_v2:DaySunElevation ;
+	owl:someValuesFrom _:c14n1108 .
+_:c14n173 rdf:first openlabel_v2:TemporaryStructureConstructionDetour ;
+	rdf:rest _:c14n355 .
+_:c14n174 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:DaySunPosition .
+_:c14n175 a owl:Restriction ;
+	owl:allValuesFrom linkml:Decimal ;
+	owl:onProperty openlabel_v2:weatherWindValue .
+_:c14n176 rdf:first openlabel_v2:RoadTypeSlip ;
+	rdf:rest rdf:nil .
+_:c14n177 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:SignsInformation .
+_:c14n178 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:DaySunElevation .
+_:c14n179 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationMarking .
+_:c14n18 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationMarking .
+_:c14n180 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:LaneSpecificationType .
+_:c14n181 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:TrafficSpecialVehicle .
+_:c14n182 rdf:first openlabel_v2:SurfaceConditionFlooded ;
+	rdf:rest _:c14n170 .
+_:c14n183 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:ownerEmail .
+_:c14n184 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:RoadUserHuman .
+_:c14n185 a owl:Restriction ;
+	owl:onProperty openlabel_v2:illuminationCloudinessValue ;
+	owl:someValuesFrom linkml:String .
+_:c14n186 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:SignsWarning .
+_:c14n187 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:RoadUser ;
+	owl:onProperty openlabel_v2:RoadUser .
+_:c14n188 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:ScenerySpecialStructure .
+_:c14n189 rdf:first openlabel_v2:CommunicationHorn ;
+	rdf:rest _:c14n252 .
+_:c14n19 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:trafficFlowRateValue .
+_:c14n190 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:RoadUserVehicle .
+_:c14n191 rdf:first openlabel_v2:IntersectionTJunction ;
+	rdf:rest _:c14n652 .
+_:c14n192 rdf:first openlabel_v2:EdgeShoulderPavedOrGravel ;
+	rdf:rest _:c14n847 .
+_:c14n193 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:DrivableAreaType .
+_:c14n194 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:particulatesWaterValue .
+_:c14n195 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:MotionDrive .
+_:c14n196 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:MotionAccelerate .
+_:c14n197 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:ParticulatesWater .
+_:c14n198 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:horizontalCurvesValue .
+_:c14n199 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:WeatherSnow .
+_:c14n2 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:weatherRainValue .
+_:c14n20 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:MotionLaneChangeRight .
+_:c14n200 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:SignsRegulatory .
+_:c14n201 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:scenarioUniqueReference .
+_:c14n202 a owl:Restriction ;
+	owl:onProperty openlabel_v2:LongitudinalDownSlope ;
+	owl:someValuesFrom _:c14n1081 .
+_:c14n203 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:TrafficFlowRate .
+_:c14n204 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:laneSpecificationDimensionsValue .
+_:c14n205 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:RainType .
+_:c14n206 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:DaySunPosition .
+_:c14n207 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationMarking .
+_:c14n208 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:TrafficFlowRate .
+_:c14n209 a rdfs:Datatype ;
+	owl:intersectionOf _:c14n1028 .
+_:c14n21 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:HorizontalCurves .
+_:c14n210 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:TrafficFlowRate .
+_:c14n211 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:scenarioVersion .
+_:c14n212 a owl:Restriction ;
+	owl:allValuesFrom linkml:Decimal ;
+	owl:onProperty openlabel_v2:particulatesWaterValue .
+_:c14n213 rdf:first openlabel_v2:HumanPassenger ;
+	rdf:rest _:c14n558 .
+_:c14n214 a owl:Restriction ;
+	owl:onProperty openlabel_v2:LaneSpecificationDimensions ;
+	owl:someValuesFrom _:c14n1075 .
+_:c14n215 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:IlluminationArtificial .
+_:c14n216 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:scenarioCreatedDate .
+_:c14n217 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:SceneryZone .
+_:c14n218 rdf:first openlabel_v2:RainTypeConvective ;
+	rdf:rest _:c14n332 .
+_:c14n219 a owl:Restriction ;
+	owl:allValuesFrom linkml:Decimal ;
+	owl:onProperty openlabel_v2:hasUpperBound .
+_:c14n22 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:ParticulatesPollution .
+_:c14n220 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceType .
+_:c14n221 rdf:first openlabel_v2:ZoneSchool ;
+	rdf:rest _:c14n402 .
+_:c14n222 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:SceneryZone .
+_:c14n223 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:longitudinalDownSlopeValue .
+_:c14n224 rdf:first openlabel_v2:TravelDirectionLeft ;
+	rdf:rest _:c14n835 .
+_:c14n225 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:GeometryTransverse .
+_:c14n226 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:MotionDrive .
+_:c14n227 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:hasTag .
+_:c14n228 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:ParticulatesPollution .
+_:c14n229 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:trafficAgentDensityValue .
+_:c14n23 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:HorizontalStraights .
+_:c14n230 rdf:first openlabel_v2:VehicleTruck ;
+	rdf:rest _:c14n420 .
+_:c14n231 rdf:first openlabel_v2:HumanAnimalRider ;
+	rdf:rest _:c14n142 .
+_:c14n232 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:WeatherWind .
+_:c14n233 rdf:first openlabel_v2:RoundaboutDoubleNosignal ;
+	rdf:rest _:c14n310 .
+_:c14n234 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:MotionOvertake .
+_:c14n235 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:MotionReverse .
+_:c14n236 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:WeatherRain .
+_:c14n237 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:TrafficAgentDensity .
+_:c14n238 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:ParticulatesDust .
+_:c14n239 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:scenarioVisualisationURL .
+_:c14n24 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:TrafficSpecialVehicle .
+_:c14n240 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:ConnectivityPositioning .
+_:c14n241 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:JunctionRoundabout ;
+	owl:onProperty openlabel_v2:JunctionRoundabout .
+_:c14n242 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:weatherSnowValue .
+_:c14n243 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:MotionLaneChangeLeft .
+_:c14n244 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:trafficAgentTypeValue .
+_:c14n245 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationTravelDirection .
+_:c14n246 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:laneSpecificationDimensionsValue .
+_:c14n247 rdf:first openlabel_v2:PositioningGlonass ;
+	rdf:rest _:c14n695 .
+_:c14n248 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:EnvironmentParticulates .
+_:c14n249 a owl:Restriction ;
+	owl:allValuesFrom _:c14n981 ;
+	owl:onProperty openlabel_v2:subjectVehicleSpeedValue .
+_:c14n25 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:IlluminationCloudiness .
+_:c14n250 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:SubjectVehicleSpeed .
+_:c14n251 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:BehaviourCommunication ;
+	owl:onProperty openlabel_v2:BehaviourCommunication .
+_:c14n252 rdf:first openlabel_v2:CommunicationSignalEmergency ;
+	rdf:rest _:c14n87 .
+_:c14n253 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:LongitudinalUpSlope .
+_:c14n254 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:ScenerySpecialStructure .
+_:c14n255 a owl:Restriction ;
+	owl:allValuesFrom linkml:Decimal ;
+	owl:onProperty openlabel_v2:longitudinalDownSlopeValue .
+_:c14n256 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:SceneryFixedStructure .
+_:c14n257 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:motionDriveValue .
+_:c14n258 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:longitudinalDownSlopeValue .
+_:c14n259 rdf:first openlabel_v2:SurfaceConditionSnow ;
+	rdf:rest _:c14n329 .
+_:c14n26 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:ParticulatesPollution .
+_:c14n260 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:licenseURI .
+_:c14n261 a owl:Restriction ;
+	owl:allValuesFrom _:c14n963 ;
+	owl:onProperty openlabel_v2:motionDriveValue .
+_:c14n262 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:LongitudinalDownSlope .
+_:c14n263 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:SignsInformation .
+_:c14n264 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:MotionTurnRight .
+_:c14n265 a owl:Restriction ;
+	owl:allValuesFrom linkml:Decimal ;
+	owl:onProperty openlabel_v2:weatherRainValue .
+_:c14n266 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:EnvironmentParticulates .
+_:c14n267 rdf:first openlabel_v2:HumanWheelchairUser ;
+	rdf:rest rdf:nil .
+_:c14n268 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:ScenerySpecialStructure ;
+	owl:onProperty openlabel_v2:ScenerySpecialStructure .
+_:c14n269 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:HorizontalCurves .
+_:c14n27 rdf:first openlabel_v2:SurfaceTypeUniform ;
+	rdf:rest rdf:nil .
+_:c14n270 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:scenarioName .
+_:c14n271 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:GeometryTransverse ;
+	owl:onProperty openlabel_v2:GeometryTransverse .
+_:c14n272 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:MotionStop .
+_:c14n273 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:weatherSnowValue .
+_:c14n274 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationTravelDirection .
+_:c14n275 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:SignsWarning .
+_:c14n276 rdf:first openlabel_v2:VehicleTrailer ;
+	rdf:rest _:c14n230 .
+_:c14n277 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:ConnectivityCommunication .
+_:c14n278 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:trafficAgentTypeValue .
+_:c14n279 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:DrivableAreaEdge ;
+	owl:onProperty openlabel_v2:DrivableAreaEdge .
+_:c14n28 rdf:first openlabel_v2:ParticulatesPollution ;
+	rdf:rest _:c14n759 .
+_:c14n280 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:RainType .
+_:c14n281 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:ConnectivityPositioning .
+_:c14n282 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:LaneSpecificationDimensions .
+_:c14n283 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:trafficAgentDensityValue .
+_:c14n284 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:daySunElevationValue .
+_:c14n285 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:ParticulatesWater .
+_:c14n286 a owl:Restriction ;
+	owl:onProperty openlabel_v2:ParticulatesWater ;
+	owl:someValuesFrom _:c14n1099 .
+_:c14n287 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:WeatherWind .
+_:c14n288 a owl:Restriction ;
+	owl:allValuesFrom _:c14n1039 ;
+	owl:onProperty openlabel_v2:trafficAgentDensityValue .
+_:c14n289 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:ParticulatesVolcanic .
+_:c14n29 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:LongitudinalUpSlope .
+_:c14n290 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:ownerURL .
+_:c14n291 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty openlabel_v2:minValue .
+_:c14n292 rdf:first openlabel_v2:EdgeTemporaryLineMarkers ;
+	rdf:rest rdf:nil .
+_:c14n293 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:LaneSpecificationTravelDirection .
+_:c14n294 rdf:first openlabel_v2:HumanDriver ;
+	rdf:rest _:c14n326 .
+_:c14n295 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:longitudinalUpSlopeValue .
+_:c14n296 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:LongitudinalLevelPlane .
+_:c14n297 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:weatherSnowValue .
+_:c14n298 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:laneSpecificationLaneCountValue .
+_:c14n299 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:SubjectVehicleSpeed .
+_:c14n3 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:SceneryZone .
+_:c14n30 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:GeometryTransverse .
+_:c14n300 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationLaneCount .
+_:c14n301 rdf:first openlabel_v2:ParticulatesMarine ;
+	rdf:rest _:c14n28 .
+_:c14n302 a owl:Restriction ;
+	owl:allValuesFrom linkml:Decimal ;
+	owl:onProperty openlabel_v2:daySunElevationValue .
+_:c14n303 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:HorizontalStraights .
+_:c14n304 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:DrivableAreaType .
+_:c14n305 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:scenarioDefinition .
+_:c14n306 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceFeature .
+_:c14n307 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:trafficAgentDensityValue .
+_:c14n308 owl:unionOf _:c14n1063 .
+_:c14n309 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:DaySunPosition ;
+	owl:onProperty openlabel_v2:DaySunPosition .
+_:c14n31 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:MotionWalk .
+_:c14n310 rdf:first openlabel_v2:RoundaboutDoubleSignal ;
+	rdf:rest _:c14n853 .
+_:c14n311 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:IlluminationLowLight .
+_:c14n312 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:TrafficAgentType .
+_:c14n313 rdf:first openlabel_v2:PositioningGalileo ;
+	rdf:rest _:c14n247 .
+_:c14n314 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceType .
+_:c14n315 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:scenarioUniqueReference .
+_:c14n316 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:IlluminationArtificial .
+_:c14n317 rdf:first openlabel_v2:RegulatorySignsVariableFullTime ;
+	rdf:rest _:c14n459 .
+_:c14n318 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:Behaviour .
+_:c14n319 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:subjectVehicleSpeedValue .
+_:c14n32 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:Tag ;
+	owl:onProperty openlabel_v2:hasTag .
+_:c14n320 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:DrivableAreaEdge .
+_:c14n321 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:trafficFlowRateValue .
+_:c14n322 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationLaneCount .
+_:c14n323 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:JunctionIntersection .
+_:c14n324 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:TrafficAgentType .
+_:c14n325 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:LongitudinalUpSlope .
+_:c14n326 rdf:first openlabel_v2:HumanMotorcyclist ;
+	rdf:rest _:c14n213 .
+_:c14n327 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:IlluminationCloudiness .
+_:c14n328 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:WeatherSnow .
+_:c14n329 rdf:first openlabel_v2:SurfaceConditionStandingWater ;
+	rdf:rest _:c14n516 .
+_:c14n33 rdf:first openlabel_v2:FixedStructureBuilding ;
+	rdf:rest _:c14n347 .
+_:c14n330 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:SubjectVehicleSpeed .
+_:c14n331 a owl:Restriction ;
+	owl:onProperty openlabel_v2:WeatherWind ;
+	owl:someValuesFrom _:c14n1069 .
+_:c14n332 rdf:first openlabel_v2:RainTypeDynamic ;
+	rdf:rest _:c14n645 .
+_:c14n333 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:ScenerySpecialStructure .
+_:c14n334 owl:unionOf _:c14n1003 .
+_:c14n335 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:JunctionRoundabout .
+_:c14n336 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:ConnectivityPositioning .
+_:c14n337 rdf:first openlabel_v2:ZoneInterference ;
+	rdf:rest _:c14n760 .
+_:c14n338 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:IlluminationCloudiness .
+_:c14n339 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:ParticulatesWater .
+_:c14n34 rdf:first openlabel_v2:ArtificialStreetLighting ;
+	rdf:rest _:c14n596 .
+_:c14n340 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:DrivableAreaEdge .
+_:c14n341 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:HorizontalStraights .
+_:c14n342 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:WeatherSnow .
+_:c14n343 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:ConnectivityCommunication .
+_:c14n344 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:ownerEmail .
+_:c14n345 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:RoadUserVehicle .
+_:c14n346 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:ParticulatesWater .
+_:c14n347 rdf:first openlabel_v2:FixedStructureStreetFurniture ;
+	rdf:rest _:c14n626 .
+_:c14n348 a owl:Restriction ;
+	owl:onProperty openlabel_v2:laneSpecificationLaneCountValue ;
+	owl:someValuesFrom linkml:String .
+_:c14n349 rdf:first openlabel_v2:TemporaryStructureRoadWorks ;
+	rdf:rest rdf:nil .
+_:c14n35 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:ParticulatesMarine .
+_:c14n350 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:trafficAgentDensityValue .
+_:c14n351 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationType .
+_:c14n352 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:LaneSpecificationDimensions .
+_:c14n353 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:ParticulatesDust .
+_:c14n354 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationTravelDirection .
+_:c14n355 rdf:first openlabel_v2:TemporaryStructureRefuseCollection ;
+	rdf:rest _:c14n484 .
+_:c14n356 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:IlluminationArtificial .
+_:c14n357 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:TrafficAgentType .
+_:c14n358 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:LongitudinalDownSlope .
+_:c14n359 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:subjectVehicleSpeedValue .
+_:c14n36 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:WeatherRain .
+_:c14n360 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:RainType .
+_:c14n361 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:LaneSpecificationLaneCount .
+_:c14n362 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:TrafficVolume .
+_:c14n363 a owl:Restriction ;
+	owl:allValuesFrom linkml:Datetime ;
+	owl:onProperty openlabel_v2:scenarioCreatedDate .
+_:c14n364 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:illuminationCloudinessValue .
+_:c14n365 rdf:first openlabel_v2:TransverseDivided ;
+	rdf:rest _:c14n725 .
+_:c14n366 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:scenarioUniqueReference .
+_:c14n367 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceType .
+_:c14n368 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:MotionAway .
+_:c14n369 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:trafficVolumeValue .
+_:c14n37 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:ParticulatesMarine .
+_:c14n370 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:scenarioDefinition .
+_:c14n371 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:RainType .
+_:c14n372 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:SceneryFixedStructure .
+_:c14n373 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:IlluminationArtificial .
+_:c14n374 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:ConnectivityPositioning .
+_:c14n375 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:ParticulatesMarine .
+_:c14n376 rdf:first openlabel_v2:RoadTypeMotorway ;
+	rdf:rest _:c14n856 .
+_:c14n377 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:RoadUserHuman ;
+	owl:onProperty openlabel_v2:RoadUserHuman .
+_:c14n378 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:EnvironmentParticulates .
+_:c14n379 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:TrafficVolume .
+_:c14n38 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:HorizontalStraights .
+_:c14n380 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:SubjectVehicleSpeed .
+_:c14n381 rdf:first openlabel_v2:TransverseUndivided ;
+	rdf:rest rdf:nil .
+_:c14n382 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:trafficFlowRateValue .
+_:c14n383 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceType .
+_:c14n384 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:hasLowerBound .
+_:c14n385 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:laneSpecificationLaneCountValue .
+_:c14n386 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:IlluminationLowLight .
+_:c14n387 rdf:first openlabel_v2:V2iWifi ;
+	rdf:rest _:c14n696 .
+_:c14n388 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:Odd .
+_:c14n389 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:SceneryTemporaryStructure .
+_:c14n39 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:motionAccelerateValue .
+_:c14n390 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:ConnectivityCommunication .
+_:c14n391 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:HorizontalCurves .
+_:c14n392 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:SceneryZone .
+_:c14n393 rdf:first openlabel_v2:RegulatorySignsUniformTemporary ;
+	rdf:rest _:c14n317 .
+_:c14n394 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:JunctionIntersection ;
+	owl:onProperty openlabel_v2:JunctionIntersection .
+_:c14n395 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:MotionCutOut .
+_:c14n396 rdf:first openlabel_v2:VehicleBus ;
+	rdf:rest _:c14n671 .
+_:c14n397 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:DrivableAreaType ;
+	owl:onProperty openlabel_v2:DrivableAreaType .
+_:c14n398 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:SignsInformation .
+_:c14n399 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:weatherWindValue .
+_:c14n4 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:DaySunElevation .
+_:c14n40 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:TrafficAgentType .
+_:c14n400 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationDimensions .
+_:c14n401 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:ParticulatesMarine .
+_:c14n402 rdf:first openlabel_v2:ZoneTrafficManagement ;
+	rdf:rest rdf:nil .
+_:c14n403 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:BehaviourCommunication .
+_:c14n404 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:trafficFlowRateValue .
+_:c14n405 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:ScenerySpecialStructure .
+_:c14n406 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceType .
+_:c14n407 rdf:first openlabel_v2:EdgeLineMarkers ;
+	rdf:rest _:c14n115 .
+_:c14n408 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:SignsInformation .
+_:c14n409 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationDimensions .
+_:c14n41 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:WeatherRain .
+_:c14n410 rdf:first openlabel_v2:RoundaboutMiniNosignal ;
+	rdf:rest _:c14n141 .
+_:c14n411 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:ParticulatesWater .
+_:c14n412 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:MotionRun .
+_:c14n413 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:IlluminationLowLight .
+_:c14n414 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:HorizontalCurves .
+_:c14n415 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:trafficAgentTypeValue .
+_:c14n416 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:LongitudinalLevelPlane .
+_:c14n417 a owl:Restriction ;
+	owl:onProperty openlabel_v2:daySunElevationValue ;
+	owl:someValuesFrom linkml:String .
+_:c14n418 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:scenarioName .
+_:c14n419 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:trafficAgentTypeValue .
+_:c14n42 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:AdminTag .
+_:c14n420 rdf:first openlabel_v2:VehicleVan ;
+	rdf:rest _:c14n693 .
+_:c14n421 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:ConnectivityCommunication .
+_:c14n422 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:DrivableAreaEdge .
+_:c14n423 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:SceneryZone ;
+	owl:onProperty openlabel_v2:SceneryZone .
+_:c14n424 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:trafficVolumeValue .
+_:c14n425 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:MotionUTurn .
+_:c14n426 rdf:first openlabel_v2:SpecialStructureBridge ;
+	rdf:rest _:c14n795 .
+_:c14n427 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:trafficAgentTypeValue .
+_:c14n428 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:daySunElevationValue .
+_:c14n429 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:DrivableAreaEdge .
+_:c14n43 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:SceneryTemporaryStructure .
+_:c14n430 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:weatherRainValue .
+_:c14n431 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:JunctionIntersection .
+_:c14n432 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:weatherWindValue .
+_:c14n433 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:weatherSnowValue .
+_:c14n434 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:MotionOvertake .
+_:c14n435 a owl:Restriction ;
+	owl:onProperty openlabel_v2:motionDecelerateValue ;
+	owl:someValuesFrom linkml:String .
+_:c14n436 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:trafficAgentDensityValue .
+_:c14n437 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:SceneryZone .
+_:c14n438 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:MotionStop .
+_:c14n439 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:TrafficAgentDensity .
+_:c14n44 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:DrivableAreaType .
+_:c14n440 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:ParticulatesVolcanic .
+_:c14n441 rdf:first openlabel_v2:SunPositionRight ;
+	rdf:rest rdf:nil .
+_:c14n442 rdf:first openlabel_v2:WarningSignsUniformTemporary ;
+	rdf:rest _:c14n53 .
+_:c14n443 rdf:first openlabel_v2:V2iSatellite ;
+	rdf:rest _:c14n387 .
+_:c14n444 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:DrivableAreaType .
+_:c14n445 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:MotionCutIn .
+_:c14n446 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:ParticulatesWater .
+_:c14n447 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:MotionCutOut .
+_:c14n448 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:Behaviour ;
+	owl:onProperty openlabel_v2:Behaviour .
+_:c14n449 a owl:Restriction ;
+	owl:onProperty openlabel_v2:TrafficVolume ;
+	owl:someValuesFrom _:c14n1084 .
+_:c14n45 rdf:first openlabel_v2:SpecialStructureAutoAccess ;
+	rdf:rest _:c14n426 .
+_:c14n450 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:IlluminationCloudiness .
+_:c14n451 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:TrafficSpecialVehicle .
+_:c14n452 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:MotionDecelerate .
+_:c14n453 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:MotionTurnRight .
+_:c14n454 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:scenarioParentReference .
+_:c14n455 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:TrafficVolume .
+_:c14n456 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:DrivableAreaEdge .
+_:c14n457 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:hasUpperBound .
+_:c14n458 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:trafficVolumeValue .
+_:c14n459 rdf:first openlabel_v2:RegulatorySignsVariableTemporary ;
+	rdf:rest rdf:nil .
+_:c14n46 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:WeatherSnow .
+_:c14n460 rdf:first openlabel_v2:VehicleAgricultural ;
+	rdf:rest _:c14n396 .
+_:c14n461 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:WeatherWind .
+_:c14n462 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:ParticulatesVolcanic .
+_:c14n463 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:hasTag .
+_:c14n464 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:longitudinalUpSlopeValue .
+_:c14n465 a owl:Restriction ;
+	owl:onProperty openlabel_v2:trafficFlowRateValue ;
+	owl:someValuesFrom linkml:String .
+_:c14n466 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:weatherRainValue .
+_:c14n467 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:IlluminationLowLight .
+_:c14n468 rdf:first openlabel_v2:SurfaceConditionContamination ;
+	rdf:rest _:c14n182 .
+_:c14n469 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:trafficVolumeValue .
+_:c14n47 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:laneSpecificationLaneCountValue .
+_:c14n470 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:TrafficFlowRate .
+_:c14n471 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:SignsWarning .
+_:c14n472 rdf:first openlabel_v2:SurfaceConditionMirage ;
+	rdf:rest _:c14n259 .
+_:c14n473 a owl:Restriction ;
+	owl:onProperty openlabel_v2:HorizontalCurves ;
+	owl:someValuesFrom _:c14n1102 .
+_:c14n474 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:scenarioDefinitionLanguageURI .
+_:c14n475 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:ParticulatesPollution .
+_:c14n476 rdf:first openlabel_v2:CommunicationWave ;
+	rdf:rest rdf:nil .
+_:c14n477 rdf:first openlabel_v2:FixedStructureVegetation ;
+	rdf:rest rdf:nil .
+_:c14n478 rdf:first openlabel_v2:ParticulatesDust ;
+	rdf:rest _:c14n301 .
+_:c14n479 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:SceneryTemporaryStructure .
+_:c14n48 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:ConnectivityPositioning .
+_:c14n480 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:MotionCutIn .
+_:c14n481 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:LaneSpecificationDimensions .
+_:c14n482 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:ScenerySpecialStructure .
+_:c14n483 owl:unionOf _:c14n999 .
+_:c14n484 rdf:first openlabel_v2:TemporaryStructureRoadSignage ;
+	rdf:rest _:c14n349 .
+_:c14n485 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:ParticulatesMarine .
+_:c14n486 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:WeatherRain .
+_:c14n487 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:RoadUser .
+_:c14n488 a owl:Restriction ;
+	owl:onProperty openlabel_v2:longitudinalDownSlopeValue ;
+	owl:someValuesFrom linkml:String .
+_:c14n489 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:ParticulatesPollution .
+_:c14n49 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:LongitudinalUpSlope .
+_:c14n490 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:motionDriveValue .
+_:c14n491 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:ParticulatesVolcanic .
+_:c14n492 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:RainType .
+_:c14n493 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:weatherSnowValue .
+_:c14n494 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationMarking .
+_:c14n495 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceType .
+_:c14n496 rdf:first openlabel_v2:SunPositionFront ;
+	rdf:rest _:c14n735 .
+_:c14n497 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:MotionTurn .
+_:c14n498 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:TrafficAgentType .
+_:c14n499 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:SubjectVehicleSpeed .
+_:c14n5 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:LongitudinalLevelPlane .
+_:c14n50 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:TrafficAgentDensity .
+_:c14n500 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:ConnectivityCommunication .
+_:c14n501 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:WeatherWind .
+_:c14n502 a owl:Restriction ;
+	owl:onProperty openlabel_v2:trafficAgentDensityValue ;
+	owl:someValuesFrom linkml:String .
+_:c14n503 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:JunctionRoundabout .
+_:c14n504 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceFeature .
+_:c14n505 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:trafficFlowRateValue .
+_:c14n506 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:JunctionIntersection .
+_:c14n507 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:motionDecelerateValue .
+_:c14n508 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:IlluminationArtificial .
+_:c14n509 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:TrafficFlowRate .
+_:c14n51 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:EnvironmentParticulates .
+_:c14n510 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:LongitudinalDownSlope .
+_:c14n511 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:longitudinalDownSlopeValue .
+_:c14n512 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:DaySunElevation .
+_:c14n513 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:weatherWindValue .
+_:c14n514 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:MotionTurnLeft .
+_:c14n515 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:longitudinalUpSlopeValue .
+_:c14n516 rdf:first openlabel_v2:SurfaceConditionWet ;
+	rdf:rest rdf:nil .
+_:c14n517 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:SceneryTemporaryStructure .
+_:c14n518 a owl:Restriction ;
+	owl:allValuesFrom _:c14n1050 ;
+	owl:onProperty openlabel_v2:trafficFlowRateValue .
+_:c14n519 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:TrafficSpecialVehicle .
+_:c14n52 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:IlluminationCloudiness .
+_:c14n520 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:ConnectivityCommunication .
+_:c14n521 a owl:Restriction ;
+	owl:onProperty openlabel_v2:MotionAccelerate ;
+	owl:someValuesFrom _:c14n1078 .
+_:c14n522 rdf:first openlabel_v2:RoadTypeParking ;
+	rdf:rest _:c14n728 .
+_:c14n523 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:TrafficSpecialVehicle .
+_:c14n524 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:HorizontalStraights .
+_:c14n525 rdf:first openlabel_v2:RoundaboutLargeSignal ;
+	rdf:rest _:c14n410 .
+_:c14n526 a owl:Restriction ;
+	owl:onProperty openlabel_v2:MotionDrive ;
+	owl:someValuesFrom _:c14n1114 .
+_:c14n527 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:GeometryTransverse .
+_:c14n528 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceType .
+_:c14n529 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:IlluminationCloudiness .
+_:c14n53 rdf:first openlabel_v2:WarningSignsVariableFullTime ;
+	rdf:rest _:c14n627 .
+_:c14n530 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:hasLowerBound .
+_:c14n531 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:motionAccelerateValue .
+_:c14n532 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:laneSpecificationDimensionsValue .
+_:c14n533 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:LaneSpecificationMarking .
+_:c14n534 rdf:first openlabel_v2:SpecialStructureTunnel ;
+	rdf:rest rdf:nil .
+_:c14n535 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:LongitudinalLevelPlane .
+_:c14n536 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:LongitudinalLevelPlane .
+_:c14n537 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:DaySunPosition .
+_:c14n538 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:DaySunElevation .
+_:c14n539 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:MotionSlide .
+_:c14n54 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:HorizontalCurves .
+_:c14n540 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:MotionRun .
+_:c14n541 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:HorizontalCurves .
+_:c14n542 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationDimensions .
+_:c14n543 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:ConnectivityCommunication .
+_:c14n544 rdf:first openlabel_v2:VehicleConstruction ;
+	rdf:rest _:c14n63 .
+_:c14n545 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:SignsWarning .
+_:c14n546 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:MotionTurn .
+_:c14n547 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:SubjectVehicleSpeed .
+_:c14n548 rdf:first openlabel_v2:VehicleMotorcycle ;
+	rdf:rest _:c14n276 .
+_:c14n549 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:RoadUserAnimal .
+_:c14n55 owl:unionOf _:c14n1001 .
+_:c14n550 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:HorizontalStraights .
+_:c14n551 rdf:first openlabel_v2:RoadTypeDistributor ;
+	rdf:rest _:c14n711 .
+_:c14n552 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:IlluminationArtificial .
+_:c14n553 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:SceneryZone .
+_:c14n554 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:RainType ;
+	owl:onProperty openlabel_v2:RainType .
+_:c14n555 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:WeatherWind .
+_:c14n556 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:DaySunElevation .
+_:c14n557 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:weatherWindValue .
+_:c14n558 rdf:first openlabel_v2:HumanPedestrian ;
+	rdf:rest _:c14n267 .
+_:c14n559 rdf:first openlabel_v2:IntersectionStaggered ;
+	rdf:rest _:c14n191 .
+_:c14n56 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:ParticulatesDust .
+_:c14n560 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:longitudinalUpSlopeValue .
+_:c14n561 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:SignsWarning .
+_:c14n562 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:EnvironmentParticulates .
+_:c14n563 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:ConnectivityPositioning .
+_:c14n564 rdf:first openlabel_v2:LaneTypeSpecial ;
+	rdf:rest _:c14n77 .
+_:c14n565 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:MotionLaneChangeRight .
+_:c14n566 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceCondition .
+_:c14n567 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:ParticulatesVolcanic .
+_:c14n568 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:SignsRegulatory .
+_:c14n569 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:LongitudinalLevelPlane .
+_:c14n57 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:WeatherSnow .
+_:c14n570 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:ParticulatesMarine .
+_:c14n571 rdf:first openlabel_v2:RoundaboutCompactNosignal ;
+	rdf:rest _:c14n841 .
+_:c14n572 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:daySunElevationValue .
+_:c14n573 a owl:Restriction ;
+	owl:allValuesFrom _:c14n960 ;
+	owl:onProperty openlabel_v2:trafficAgentTypeValue .
+_:c14n574 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationLaneCount .
+_:c14n575 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:MotionCross .
+_:c14n576 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:SceneryFixedStructure ;
+	owl:onProperty openlabel_v2:SceneryFixedStructure .
+_:c14n577 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:RainType .
+_:c14n578 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:DrivableAreaEdge .
+_:c14n579 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:AdminTag ;
+	owl:onProperty openlabel_v2:AdminTag .
+_:c14n58 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:illuminationCloudinessValue .
+_:c14n580 a owl:Restriction ;
+	owl:onProperty openlabel_v2:motionDriveValue ;
+	owl:someValuesFrom linkml:String .
+_:c14n581 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:longitudinalUpSlopeValue .
+_:c14n582 a owl:Restriction ;
+	owl:onProperty openlabel_v2:particulatesWaterValue ;
+	owl:someValuesFrom linkml:String .
+_:c14n583 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationType .
+_:c14n584 rdf:first openlabel_v2:WarningSignsUniform ;
+	rdf:rest _:c14n781 .
+_:c14n585 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:LaneSpecificationLaneCount .
+_:c14n586 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceCondition .
+_:c14n587 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:SceneryTemporaryStructure .
+_:c14n588 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:scenarioParentReference .
+_:c14n589 rdf:first openlabel_v2:SpecialStructureRailCrossing ;
+	rdf:rest _:c14n812 .
+_:c14n59 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:TrafficSpecialVehicle .
+_:c14n590 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:ParticulatesWater .
+_:c14n591 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:TrafficAgentType .
+_:c14n592 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:MotionAway .
+_:c14n593 rdf:first openlabel_v2:RoundaboutNormalSignal ;
+	rdf:rest rdf:nil .
+_:c14n594 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:SignsInformation .
+_:c14n595 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:ParticulatesDust .
+_:c14n596 rdf:first openlabel_v2:ArtificialVehicleLighting ;
+	rdf:rest rdf:nil .
+_:c14n597 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:horizontalCurvesValue .
+_:c14n598 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:TrafficSpecialVehicle .
+_:c14n599 a owl:Restriction ;
+	owl:allValuesFrom _:c14n978 ;
+	owl:onProperty openlabel_v2:motionAccelerateValue .
+_:c14n6 a owl:Restriction ;
+	owl:onProperty openlabel_v2:WeatherSnow ;
+	owl:someValuesFrom _:c14n1105 .
+_:c14n60 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:SignsRegulatory ;
+	owl:onProperty openlabel_v2:SignsRegulatory .
+_:c14n600 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:WeatherWind .
+_:c14n601 rdf:first openlabel_v2:IntersectionCrossroad ;
+	rdf:rest _:c14n625 .
+_:c14n602 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:SceneryTemporaryStructure .
+_:c14n603 rdf:first openlabel_v2:ParticulatesWater ;
+	rdf:rest rdf:nil .
+_:c14n604 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:daySunElevationValue .
+_:c14n605 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceFeature .
+_:c14n606 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:trafficFlowRateValue .
+_:c14n607 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:trafficVolumeValue .
+_:c14n608 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:SceneryFixedStructure .
+_:c14n609 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:laneSpecificationLaneCountValue .
+_:c14n61 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:WeatherRain .
+_:c14n610 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:DaySunPosition .
+_:c14n611 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:MotionDrive .
+_:c14n612 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:longitudinalDownSlopeValue .
+_:c14n613 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationType .
+_:c14n614 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:HorizontalCurves .
+_:c14n615 rdf:first openlabel_v2:CommunicationSignalLeft ;
+	rdf:rest _:c14n796 .
+_:c14n616 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:TrafficAgentType .
+_:c14n617 rdf:first openlabel_v2:CommunicationHeadlightFlash ;
+	rdf:rest _:c14n189 .
+_:c14n618 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:DrivableAreaSurfaceType ;
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceType .
+_:c14n619 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:GeometryTransverse .
+_:c14n62 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:scenarioDefinition .
+_:c14n620 rdf:first openlabel_v2:VehicleEmergency ;
+	rdf:rest _:c14n548 .
+_:c14n621 rdf:first openlabel_v2:LaneTypeCycle ;
+	rdf:rest _:c14n95 .
+_:c14n622 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceCondition .
+_:c14n623 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:trafficAgentTypeValue .
+_:c14n624 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:weatherSnowValue .
+_:c14n625 rdf:first openlabel_v2:IntersectionGradeSeperated ;
+	rdf:rest _:c14n559 .
+_:c14n626 rdf:first openlabel_v2:FixedStructureStreetlight ;
+	rdf:rest _:c14n477 .
+_:c14n627 rdf:first openlabel_v2:WarningSignsVariableTemporary ;
+	rdf:rest rdf:nil .
+_:c14n628 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:LaneSpecificationTravelDirection .
+_:c14n629 owl:unionOf _:c14n1011 .
+_:c14n63 rdf:first openlabel_v2:VehicleCycle ;
+	rdf:rest _:c14n620 .
+_:c14n630 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:trafficFlowRateValue .
+_:c14n631 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:ConnectivityPositioning .
+_:c14n632 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:EnvironmentParticulates .
+_:c14n633 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:DrivableAreaType .
+_:c14n634 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:horizontalCurvesValue .
+_:c14n635 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:ConnectivityCommunication .
+_:c14n636 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:ParticulatesMarine .
+_:c14n637 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:GeometryTransverse .
+_:c14n638 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationTravelDirection .
+_:c14n639 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:SignsWarning .
+_:c14n64 rdf:first openlabel_v2:V2vWifi ;
+	rdf:rest rdf:nil .
+_:c14n640 a owl:Restriction ;
+	owl:onProperty openlabel_v2:trafficAgentTypeValue ;
+	owl:someValuesFrom linkml:String .
+_:c14n641 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:JunctionRoundabout .
+_:c14n642 rdf:first openlabel_v2:InformationSignsUniformFullTime ;
+	rdf:rest _:c14n91 .
+_:c14n643 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:trafficAgentDensityValue .
+_:c14n644 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:SignsRegulatory .
+_:c14n645 rdf:first openlabel_v2:RainTypeOrographic ;
+	rdf:rest rdf:nil .
+_:c14n646 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:MotionLaneChangeRight .
+_:c14n647 rdf:first openlabel_v2:InformationSignsVariableTemporary ;
+	rdf:rest rdf:nil .
+_:c14n648 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:LongitudinalUpSlope .
+_:c14n649 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:MotionCross .
+_:c14n65 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:LongitudinalDownSlope .
+_:c14n650 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:scenarioVersion .
+_:c14n651 a owl:Restriction ;
+	owl:onProperty openlabel_v2:weatherSnowValue ;
+	owl:someValuesFrom linkml:String .
+_:c14n652 rdf:first openlabel_v2:IntersectionYJunction ;
+	rdf:rest rdf:nil .
+_:c14n653 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:ParticulatesWater .
+_:c14n654 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:JunctionIntersection .
+_:c14n655 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:ConnectivityPositioning .
+_:c14n656 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:weatherWindValue .
+_:c14n657 rdf:first openlabel_v2:RegulatorySignsUniformFullTime ;
+	rdf:rest _:c14n393 .
+_:c14n658 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:trafficAgentDensityValue .
+_:c14n659 rdf:first openlabel_v2:TransversePavements ;
+	rdf:rest _:c14n381 .
+_:c14n66 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:illuminationCloudinessValue .
+_:c14n660 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:DrivableAreaSurfaceCondition ;
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceCondition .
+_:c14n661 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:trafficAgentDensityValue .
+_:c14n662 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:scenarioParentReference .
+_:c14n663 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:JunctionIntersection .
+_:c14n664 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:ParticulatesVolcanic .
+_:c14n665 a rdfs:Datatype ;
+	owl:intersectionOf _:c14n1044 .
+_:c14n666 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:TrafficFlowRate .
+_:c14n667 a owl:Restriction ;
+	owl:allValuesFrom _:c14n993 ;
+	owl:onProperty openlabel_v2:motionDriveValue .
+_:c14n668 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:scenarioDefinitionLanguageURI .
+_:c14n669 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:SceneryFixedStructure .
+_:c14n67 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceFeature .
+_:c14n670 a owl:Restriction ;
+	owl:onProperty openlabel_v2:longitudinalUpSlopeValue ;
+	owl:someValuesFrom linkml:String .
+_:c14n671 rdf:first openlabel_v2:VehicleCar ;
+	rdf:rest _:c14n544 .
+_:c14n672 rdf:first openlabel_v2:SurfaceFeatureRut ;
+	rdf:rest _:c14n832 .
+_:c14n673 a owl:Restriction ;
+	owl:onProperty openlabel_v2:TrafficFlowRate ;
+	owl:someValuesFrom _:c14n1090 .
+_:c14n674 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationLaneCount .
+_:c14n675 rdf:first openlabel_v2:InformationSignsVariableFullTime ;
+	rdf:rest _:c14n647 .
+_:c14n676 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:IlluminationArtificial .
+_:c14n677 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:SubjectVehicleSpeed .
+_:c14n678 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceCondition .
+_:c14n679 a rdfs:Datatype ;
+	owl:intersectionOf _:c14n1033 .
+_:c14n68 a owl:Restriction ;
+	owl:allValuesFrom linkml:Decimal ;
+	owl:onProperty openlabel_v2:illuminationCloudinessValue .
+_:c14n680 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceFeature .
+_:c14n681 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:SignsWarning .
+_:c14n682 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:RoadUserHuman .
+_:c14n683 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:laneSpecificationDimensionsValue .
+_:c14n684 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:MotionTurn .
+_:c14n685 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:MotionDecelerate .
+_:c14n686 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:MotionCross .
+_:c14n687 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:SignsRegulatory .
+_:c14n688 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:DaySunElevation .
+_:c14n689 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:RainType .
+_:c14n69 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:trafficVolumeValue .
+_:c14n690 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:Behaviour .
+_:c14n691 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:ownerName .
+_:c14n692 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:JunctionIntersection .
+_:c14n693 rdf:first openlabel_v2:VehicleWheelchair ;
+	rdf:rest rdf:nil .
+_:c14n694 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:TrafficAgentDensity .
+_:c14n695 rdf:first openlabel_v2:PositioningGps ;
+	rdf:rest rdf:nil .
+_:c14n696 rdf:first openlabel_v2:CommunicationV2v ;
+	rdf:rest _:c14n738 .
+_:c14n697 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:LongitudinalLevelPlane .
+_:c14n698 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:LongitudinalDownSlope .
+_:c14n699 rdf:first openlabel_v2:LowLightNight ;
+	rdf:rest rdf:nil .
+_:c14n7 a owl:Restriction ;
+	owl:onProperty openlabel_v2:horizontalCurvesValue ;
+	owl:someValuesFrom linkml:String .
+_:c14n70 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:LaneSpecificationMarking .
+_:c14n700 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:TrafficSpecialVehicle .
+_:c14n701 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:DaySunPosition .
+_:c14n702 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:weatherRainValue .
+_:c14n703 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:LongitudinalUpSlope .
+_:c14n704 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:trafficAgentTypeValue .
+_:c14n705 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationType .
+_:c14n706 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:SceneryZone .
+_:c14n707 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:SubjectVehicleSpeed .
+_:c14n708 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:LaneSpecificationDimensions .
+_:c14n709 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:SceneryFixedStructure .
+_:c14n71 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:HorizontalStraights .
+_:c14n710 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:longitudinalDownSlopeValue .
+_:c14n711 rdf:first openlabel_v2:RoadTypeMinor ;
+	rdf:rest _:c14n376 .
+_:c14n712 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:MotionAway .
+_:c14n713 rdf:first openlabel_v2:SurfaceTypeLoose ;
+	rdf:rest _:c14n809 .
+_:c14n714 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:SignsRegulatory .
+_:c14n715 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:daySunElevationValue .
+_:c14n716 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:illuminationCloudinessValue .
+_:c14n717 rdf:first openlabel_v2:LaneTypeTram ;
+	rdf:rest rdf:nil .
+_:c14n718 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:TrafficAgentDensity .
+_:c14n719 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:TrafficFlowRate .
+_:c14n72 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:daySunElevationValue .
+_:c14n720 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:LaneSpecificationTravelDirection .
+_:c14n721 a owl:Restriction ;
+	owl:onProperty openlabel_v2:TrafficAgentDensity ;
+	owl:someValuesFrom _:c14n1096 .
+_:c14n722 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:MotionTowards .
+_:c14n723 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:MotionWalk .
+_:c14n724 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:SceneryTemporaryStructure ;
+	owl:onProperty openlabel_v2:SceneryTemporaryStructure .
+_:c14n725 rdf:first openlabel_v2:TransverseLanesTogether ;
+	rdf:rest _:c14n659 .
+_:c14n726 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:MotionCutIn .
+_:c14n727 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:SceneryZone .
+_:c14n728 rdf:first openlabel_v2:RoadTypeRadial ;
+	rdf:rest _:c14n845 .
+_:c14n729 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:longitudinalUpSlopeValue .
+_:c14n73 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:MotionWalk .
+_:c14n730 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:TrafficAgentType .
+_:c14n731 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:LaneSpecificationLaneCount .
+_:c14n732 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:LongitudinalUpSlope .
+_:c14n733 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:MotionReverse .
+_:c14n734 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:MotionAccelerate .
+_:c14n735 rdf:first openlabel_v2:SunPositionLeft ;
+	rdf:rest _:c14n441 .
+_:c14n736 a owl:Restriction ;
+	owl:allValuesFrom _:c14n975 ;
+	owl:onProperty openlabel_v2:motionDecelerateValue .
+_:c14n737 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:TrafficFlowRate .
+_:c14n738 rdf:first openlabel_v2:V2vCellular ;
+	rdf:rest _:c14n829 .
+_:c14n739 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:subjectVehicleSpeedValue .
+_:c14n74 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:ParticulatesPollution .
+_:c14n740 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationMarking .
+_:c14n741 a owl:Restriction ;
+	owl:onProperty openlabel_v2:LaneSpecificationLaneCount ;
+	owl:someValuesFrom _:c14n1111 .
+_:c14n742 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:TrafficVolume .
+_:c14n743 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:particulatesWaterValue .
+_:c14n744 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:longitudinalDownSlopeValue .
+_:c14n745 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:motionDecelerateValue .
+_:c14n746 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceCondition .
+_:c14n747 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:JunctionRoundabout .
+_:c14n748 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationLaneCount .
+_:c14n749 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:horizontalCurvesValue .
+_:c14n75 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:horizontalCurvesValue .
+_:c14n750 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:ownerEmail .
+_:c14n751 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:subjectVehicleSpeedValue .
+_:c14n752 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:SignsInformation .
+_:c14n753 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:trafficFlowRateValue .
+_:c14n754 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:MotionOvertake .
+_:c14n755 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:longitudinalDownSlopeValue .
+_:c14n756 owl:unionOf _:c14n997 .
+_:c14n757 a owl:Restriction ;
+	owl:allValuesFrom linkml:Decimal ;
+	owl:onProperty openlabel_v2:weatherSnowValue .
+_:c14n758 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:IlluminationCloudiness .
+_:c14n759 rdf:first openlabel_v2:ParticulatesVolcanic ;
+	rdf:rest _:c14n603 .
+_:c14n76 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:JunctionRoundabout .
+_:c14n760 rdf:first openlabel_v2:ZoneRegion ;
+	rdf:rest _:c14n221 .
+_:c14n761 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:longitudinalUpSlopeValue .
+_:c14n762 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:ParticulatesDust .
+_:c14n763 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:MotionTowards .
+_:c14n764 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:illuminationCloudinessValue .
+_:c14n765 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:ScenerySpecialStructure .
+_:c14n766 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceCondition .
+_:c14n767 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:IlluminationArtificial ;
+	owl:onProperty openlabel_v2:IlluminationArtificial .
+_:c14n768 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:subjectVehicleSpeedValue .
+_:c14n769 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:scenarioCreatedDate .
+_:c14n77 rdf:first openlabel_v2:LaneTypeTraffic ;
+	rdf:rest _:c14n717 .
+_:c14n770 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:weatherWindValue .
+_:c14n771 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:MotionDecelerate .
+_:c14n772 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:LongitudinalLevelPlane .
+_:c14n773 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:particulatesWaterValue .
+_:c14n774 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:SignsInformation .
+_:c14n775 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:TrafficVolume .
+_:c14n776 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:laneSpecificationDimensionsValue .
+_:c14n777 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:ParticulatesMarine .
+_:c14n778 a owl:Restriction ;
+	owl:onProperty openlabel_v2:weatherWindValue ;
+	owl:someValuesFrom linkml:String .
+_:c14n779 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceType .
+_:c14n78 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:ParticulatesPollution .
+_:c14n780 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:longitudinalDownSlopeValue .
+_:c14n781 rdf:first openlabel_v2:WarningSignsUniformFullTime ;
+	rdf:rest _:c14n442 .
+_:c14n782 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:ScenerySpecialStructure .
+_:c14n783 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:IlluminationLowLight .
+_:c14n784 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationDimensions .
+_:c14n785 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:GeometryTransverse .
+_:c14n786 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:IlluminationLowLight .
+_:c14n787 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:WeatherSnow .
+_:c14n788 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:SceneryFixedStructure .
+_:c14n789 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:licenseURI .
+_:c14n79 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:horizontalCurvesValue .
+_:c14n790 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:laneSpecificationDimensionsValue .
+_:c14n791 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:weatherSnowValue .
+_:c14n792 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:WeatherRain .
+_:c14n793 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:SignsRegulatory .
+_:c14n794 a owl:Restriction ;
+	owl:minCardinality 1 ;
+	owl:onProperty openlabel_v2:maxValue .
+_:c14n795 rdf:first openlabel_v2:SpecialStructurePedestrianCrossing ;
+	rdf:rest _:c14n589 .
+_:c14n796 rdf:first openlabel_v2:CommunicationSignalRight ;
+	rdf:rest _:c14n9 .
+_:c14n797 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:LongitudinalDownSlope .
+_:c14n798 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:particulatesWaterValue .
+_:c14n799 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:WeatherRain .
+_:c14n8 a owl:Restriction ;
+	owl:onProperty openlabel_v2:SubjectVehicleSpeed ;
+	owl:someValuesFrom _:c14n1093 .
+_:c14n80 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:MotionRun .
+_:c14n800 rdf:first openlabel_v2:SurfaceFeatureCrack ;
+	rdf:rest _:c14n101 .
+_:c14n801 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:DrivableAreaSurfaceFeature ;
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceFeature .
+_:c14n802 rdf:first openlabel_v2:LowLightAmbient ;
+	rdf:rest _:c14n699 .
+_:c14n803 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:minValue .
+_:c14n804 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:WeatherRain .
+_:c14n805 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:MotionReverse .
+_:c14n806 a owl:Restriction ;
+	owl:onProperty openlabel_v2:motionAccelerateValue ;
+	owl:someValuesFrom linkml:String .
+_:c14n807 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:laneSpecificationLaneCountValue .
+_:c14n808 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:TrafficAgentDensity .
+_:c14n809 rdf:first openlabel_v2:SurfaceTypeSegmented ;
+	rdf:rest _:c14n27 .
+_:c14n81 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:MotionSlide .
+_:c14n810 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:weatherWindValue .
+_:c14n811 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:ParticulatesPollution .
+_:c14n812 rdf:first openlabel_v2:SpecialStructureTollPlaza ;
+	rdf:rest _:c14n534 .
+_:c14n813 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:scenarioDefinitionLanguageURI .
+_:c14n814 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:RainType .
+_:c14n815 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:SignsRegulatory .
+_:c14n816 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:LongitudinalUpSlope .
+_:c14n817 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:scenarioVisualisationURL .
+_:c14n818 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:DaySunElevation .
+_:c14n819 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:TrafficAgentDensity .
+_:c14n82 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:MotionCutOut .
+_:c14n820 rdf:first openlabel_v2:TransverseBarriers ;
+	rdf:rest _:c14n365 .
+_:c14n821 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:DrivableAreaType .
+_:c14n822 a owl:Restriction ;
+	owl:onProperty openlabel_v2:LongitudinalUpSlope ;
+	owl:someValuesFrom _:c14n1117 .
+_:c14n823 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:laneSpecificationLaneCountValue .
+_:c14n824 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:WeatherWind .
+_:c14n825 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:particulatesWaterValue .
+_:c14n826 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:JunctionIntersection .
+_:c14n827 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:RoadUserAnimal .
+_:c14n828 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:HorizontalStraights .
+_:c14n829 rdf:first openlabel_v2:V2vSatellite ;
+	rdf:rest _:c14n64 .
+_:c14n83 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:LongitudinalLevelPlane .
+_:c14n830 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:scenarioDescription .
+_:c14n831 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:maxValue .
+_:c14n832 rdf:first openlabel_v2:SurfaceFeatureSwell ;
+	rdf:rest rdf:nil .
+_:c14n833 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:EnvironmentParticulates .
+_:c14n834 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:scenarioVersion .
+_:c14n835 rdf:first openlabel_v2:TravelDirectionRight ;
+	rdf:rest rdf:nil .
+_:c14n836 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:DaySunPosition .
+_:c14n837 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:ParticulatesVolcanic .
+_:c14n838 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:WeatherSnow .
+_:c14n839 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:SceneryFixedStructure .
+_:c14n84 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:SubjectVehicleSpeed .
+_:c14n840 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:JunctionRoundabout .
+_:c14n841 rdf:first openlabel_v2:RoundaboutCompactSignal ;
+	rdf:rest _:c14n233 .
+_:c14n842 rdf:first openlabel_v2:MotorwayUnmanaged ;
+	rdf:rest _:c14n522 .
+_:c14n843 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:WeatherSnow .
+_:c14n844 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:DaySunElevation .
+_:c14n845 rdf:first openlabel_v2:RoadTypeShared ;
+	rdf:rest _:c14n176 .
+_:c14n846 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceCondition .
+_:c14n847 rdf:first openlabel_v2:EdgeSolidBarriers ;
+	rdf:rest _:c14n292 .
+_:c14n848 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:WeatherWind .
+_:c14n849 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:WeatherSnow .
+_:c14n85 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:LaneSpecificationType .
+_:c14n850 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:MotionLaneChangeLeft .
+_:c14n851 a owl:Restriction ;
+	owl:onProperty openlabel_v2:MotionDecelerate ;
+	owl:someValuesFrom _:c14n1072 .
+_:c14n852 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:EnvironmentParticulates ;
+	owl:onProperty openlabel_v2:EnvironmentParticulates .
+_:c14n853 rdf:first openlabel_v2:RoundaboutLargeNosignal ;
+	rdf:rest _:c14n525 .
+_:c14n854 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:DaySunPosition .
+_:c14n855 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:particulatesWaterValue .
+_:c14n856 rdf:first openlabel_v2:MotorwayManaged ;
+	rdf:rest _:c14n842 .
+_:c14n857 a owl:Restriction ;
+	owl:allValuesFrom _:c14n966 ;
+	owl:onProperty openlabel_v2:laneSpecificationLaneCountValue .
+_:c14n858 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:ConnectivityPositioning ;
+	owl:onProperty openlabel_v2:ConnectivityPositioning .
+_:c14n859 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:TrafficSpecialVehicle .
+_:c14n86 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:daySunElevationValue .
+_:c14n860 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:LaneSpecificationTravelDirection ;
+	owl:onProperty openlabel_v2:LaneSpecificationTravelDirection .
+_:c14n861 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:ParticulatesPollution .
+_:c14n862 rdf:first openlabel_v2:RoundaboutNormalNosignal ;
+	rdf:rest _:c14n593 .
+_:c14n863 rdf:first openlabel_v2:SunPositionBehind ;
+	rdf:rest _:c14n496 .
+_:c14n864 a owl:Restriction ;
+	owl:allValuesFrom linkml:Decimal ;
+	owl:onProperty openlabel_v2:maxValue .
+_:c14n865 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:ParticulatesMarine .
+_:c14n866 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:LongitudinalDownSlope .
+_:c14n867 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:MotionTurnRight .
+_:c14n868 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:SignsWarning .
+_:c14n869 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:weatherRainValue .
+_:c14n87 rdf:first openlabel_v2:CommunicationSignalHazard ;
+	rdf:rest _:c14n615 .
+_:c14n870 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:motionDriveValue .
+_:c14n871 a owl:Restriction ;
+	owl:onProperty openlabel_v2:laneSpecificationDimensionsValue ;
+	owl:someValuesFrom linkml:String .
+_:c14n872 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:ParticulatesDust .
+_:c14n873 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:scenarioDescription .
+_:c14n874 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceFeature .
+_:c14n875 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:TrafficVolume .
+_:c14n876 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:ParticulatesDust .
+_:c14n877 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:DrivableAreaSurfaceFeature .
+_:c14n878 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:IlluminationCloudiness .
+_:c14n879 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:trafficVolumeValue .
+_:c14n88 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:weatherWindValue .
+_:c14n880 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:LongitudinalDownSlope .
+_:c14n881 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:ParticulatesDust .
+_:c14n882 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:TrafficAgentDensity .
+_:c14n883 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:RoadUserAnimal .
+_:c14n884 a owl:Restriction ;
+	owl:allValuesFrom _:c14n990 ;
+	owl:onProperty openlabel_v2:laneSpecificationDimensionsValue .
+_:c14n885 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:ParticulatesVolcanic .
+_:c14n886 a owl:Restriction ;
+	owl:onProperty openlabel_v2:IlluminationCloudiness ;
+	owl:someValuesFrom _:c14n1087 .
+_:c14n887 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:MotionTurnLeft .
+_:c14n888 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationTravelDirection .
+_:c14n889 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:weatherSnowValue .
+_:c14n89 a owl:Restriction ;
+	owl:allValuesFrom _:c14n1023 ;
+	owl:onProperty openlabel_v2:trafficVolumeValue .
+_:c14n890 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:MotionAccelerate .
+_:c14n891 a owl:Restriction ;
+	owl:allValuesFrom linkml:Decimal ;
+	owl:onProperty openlabel_v2:hasLowerBound .
+_:c14n892 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:scenarioVisualisationURL .
+_:c14n893 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:MotionStop .
+_:c14n894 a owl:Restriction ;
+	owl:allValuesFrom openlabel_v2:RoadUserVehicle ;
+	owl:onProperty openlabel_v2:RoadUserVehicle .
+_:c14n895 a owl:Restriction ;
+	owl:allValuesFrom linkml:Decimal ;
+	owl:onProperty openlabel_v2:minValue .
+_:c14n896 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:laneSpecificationLaneCountValue .
+_:c14n897 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:laneSpecificationDimensionsValue .
+_:c14n898 a owl:Restriction ;
+	owl:maxCardinality 0 ;
+	owl:onProperty openlabel_v2:DrivableAreaType .
+_:c14n899 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:JunctionRoundabout .
+_:c14n9 rdf:first openlabel_v2:CommunicationSignalSlowing ;
+	rdf:rest _:c14n476 .
+_:c14n90 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:JunctionRoundabout .
+_:c14n900 a owl:Restriction ;
+	owl:allValuesFrom linkml:Boolean ;
+	owl:onProperty openlabel_v2:LaneSpecificationMarking .
+_:c14n901 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:IlluminationArtificial .
+_:c14n902 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:HorizontalCurves .
+_:c14n903 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:weatherRainValue .
+_:c14n904 rdf:first openlabel_v2:CommunicationV2i ;
+	rdf:rest _:c14n96 .
+_:c14n905 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:scenarioName .
+_:c14n906 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:RoadUser .
+_:c14n907 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:ownerURL .
+_:c14n908 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:longitudinalUpSlopeValue .
+_:c14n909 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:LaneSpecificationType .
+_:c14n91 rdf:first openlabel_v2:InformationSignsUniformTemporary ;
+	rdf:rest _:c14n675 .
+_:c14n910 a owl:Restriction ;
+	owl:allValuesFrom linkml:String ;
+	owl:onProperty openlabel_v2:ownerName .
+_:c14n911 a owl:Restriction ;
+	owl:maxCardinality 1 ;
+	owl:onProperty openlabel_v2:Odd .
+_:c14n912 rdf:first openlabel_v2:Odd ;
+	rdf:rest rdf:nil .
+_:c14n913 rdf:first _:c14n670 ;
+	rdf:rest _:c14n912 .
+_:c14n914 rdfs:subClassOf _:c14n822 ;
+	owl:intersectionOf _:c14n913 .
+_:c14n915 rdf:first openlabel_v2:Odd ;
+	rdf:rest rdf:nil .
+_:c14n916 rdf:first _:c14n871 ;
+	rdf:rest _:c14n915 .
+_:c14n917 rdfs:subClassOf _:c14n214 ;
+	owl:intersectionOf _:c14n916 .
+_:c14n918 rdf:first openlabel_v2:Odd ;
+	rdf:rest rdf:nil .
+_:c14n919 rdf:first _:c14n7 ;
+	rdf:rest _:c14n918 .
+_:c14n92 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:SceneryTemporaryStructure .
+_:c14n920 rdfs:subClassOf _:c14n473 ;
+	owl:intersectionOf _:c14n919 .
+_:c14n921 rdf:first openlabel_v2:Odd ;
+	rdf:rest rdf:nil .
+_:c14n922 rdf:first _:c14n465 ;
+	rdf:rest _:c14n921 .
+_:c14n923 rdfs:subClassOf _:c14n673 ;
+	owl:intersectionOf _:c14n922 .
+_:c14n924 rdf:first openlabel_v2:Odd ;
+	rdf:rest rdf:nil .
+_:c14n925 rdf:first _:c14n152 ;
+	rdf:rest _:c14n924 .
+_:c14n926 rdfs:subClassOf _:c14n449 ;
+	owl:intersectionOf _:c14n925 .
+_:c14n927 rdf:first openlabel_v2:Odd ;
+	rdf:rest rdf:nil .
+_:c14n928 rdf:first _:c14n640 ;
+	rdf:rest _:c14n927 .
+_:c14n929 rdfs:subClassOf _:c14n133 ;
+	owl:intersectionOf _:c14n928 .
+_:c14n93 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:GeometryTransverse .
+_:c14n930 rdf:first openlabel_v2:Odd ;
+	rdf:rest rdf:nil .
+_:c14n931 rdf:first _:c14n106 ;
+	rdf:rest _:c14n930 .
+_:c14n932 rdfs:subClassOf _:c14n8 ;
+	owl:intersectionOf _:c14n931 .
+_:c14n933 rdf:first openlabel_v2:Odd ;
+	rdf:rest rdf:nil .
+_:c14n934 rdf:first _:c14n651 ;
+	rdf:rest _:c14n933 .
+_:c14n935 rdfs:subClassOf _:c14n6 ;
+	owl:intersectionOf _:c14n934 .
+_:c14n936 rdf:first openlabel_v2:Odd ;
+	rdf:rest rdf:nil .
+_:c14n937 rdf:first _:c14n502 ;
+	rdf:rest _:c14n936 .
+_:c14n938 rdfs:subClassOf _:c14n721 ;
+	owl:intersectionOf _:c14n937 .
+_:c14n939 rdf:first openlabel_v2:Odd ;
+	rdf:rest rdf:nil .
+_:c14n94 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:TrafficVolume .
+_:c14n940 rdf:first _:c14n417 ;
+	rdf:rest _:c14n939 .
+_:c14n941 rdfs:subClassOf _:c14n172 ;
+	owl:intersectionOf _:c14n940 .
+_:c14n942 rdf:first openlabel_v2:Odd ;
+	rdf:rest rdf:nil .
+_:c14n943 rdf:first _:c14n488 ;
+	rdf:rest _:c14n942 .
+_:c14n944 rdfs:subClassOf _:c14n202 ;
+	owl:intersectionOf _:c14n943 .
+_:c14n945 rdf:first openlabel_v2:Odd ;
+	rdf:rest rdf:nil .
+_:c14n946 rdf:first _:c14n582 ;
+	rdf:rest _:c14n945 .
+_:c14n947 rdfs:subClassOf _:c14n286 ;
+	owl:intersectionOf _:c14n946 .
+_:c14n948 rdf:first openlabel_v2:Odd ;
+	rdf:rest rdf:nil .
+_:c14n949 rdf:first _:c14n168 ;
+	rdf:rest _:c14n948 .
+_:c14n95 rdf:first openlabel_v2:LaneTypeEmergency ;
+	rdf:rest _:c14n564 .
+_:c14n950 rdfs:subClassOf _:c14n118 ;
+	owl:intersectionOf _:c14n949 .
+_:c14n951 rdf:first openlabel_v2:Odd ;
+	rdf:rest rdf:nil .
+_:c14n952 rdf:first _:c14n185 ;
+	rdf:rest _:c14n951 .
+_:c14n953 rdfs:subClassOf _:c14n886 ;
+	owl:intersectionOf _:c14n952 .
+_:c14n954 rdf:first openlabel_v2:Odd ;
+	rdf:rest rdf:nil .
+_:c14n955 rdf:first _:c14n778 ;
+	rdf:rest _:c14n954 .
+_:c14n956 rdfs:subClassOf _:c14n331 ;
+	owl:intersectionOf _:c14n955 .
+_:c14n957 rdf:first openlabel_v2:Odd ;
+	rdf:rest rdf:nil .
+_:c14n958 rdf:first _:c14n348 ;
+	rdf:rest _:c14n957 .
+_:c14n959 rdfs:subClassOf _:c14n741 ;
+	owl:intersectionOf _:c14n958 .
+_:c14n96 rdf:first openlabel_v2:V2iCellular ;
+	rdf:rest _:c14n443 .
+_:c14n960 owl:unionOf _:c14n961 .
+_:c14n961 rdf:first openlabel_v2:RoadUserHuman ;
+	rdf:rest _:c14n962 .
+_:c14n962 rdf:first openlabel_v2:RoadUserVehicle ;
+	rdf:rest rdf:nil .
+_:c14n963 owl:unionOf _:c14n964 .
+_:c14n964 rdf:first linkml:Decimal ;
+	rdf:rest _:c14n965 .
+_:c14n965 rdf:first openlabel_v2:QuantitativeValue ;
+	rdf:rest rdf:nil .
+_:c14n966 owl:unionOf _:c14n967 .
+_:c14n967 rdf:first _:c14n968 ;
+	rdf:rest _:c14n974 .
+_:c14n968 a rdfs:Datatype ;
+	owl:intersectionOf _:c14n969 .
+_:c14n969 rdf:first linkml:Integer ;
+	rdf:rest _:c14n970 .
+_:c14n97 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:weatherRainValue .
+_:c14n970 rdf:first _:c14n971 ;
+	rdf:rest rdf:nil .
+_:c14n971 a rdfs:Datatype ;
+	owl:onDatatype xsd:integer ;
+	owl:withRestrictions _:c14n972 .
+_:c14n972 rdf:first _:c14n973 ;
+	rdf:rest rdf:nil .
+_:c14n973 xsd:minInclusive 1 .
+_:c14n974 rdf:first openlabel_v2:QuantitativeValue ;
+	rdf:rest rdf:nil .
+_:c14n975 owl:unionOf _:c14n976 .
+_:c14n976 rdf:first linkml:Decimal ;
+	rdf:rest _:c14n977 .
+_:c14n977 rdf:first openlabel_v2:QuantitativeValue ;
+	rdf:rest rdf:nil .
+_:c14n978 owl:unionOf _:c14n979 .
+_:c14n979 rdf:first linkml:Decimal ;
+	rdf:rest _:c14n980 .
+_:c14n98 rdf:first openlabel_v2:LaneTypeBus ;
+	rdf:rest _:c14n621 .
+_:c14n980 rdf:first openlabel_v2:QuantitativeValue ;
+	rdf:rest rdf:nil .
+_:c14n981 owl:unionOf _:c14n982 .
+_:c14n982 rdf:first _:c14n983 ;
+	rdf:rest _:c14n989 .
+_:c14n983 a rdfs:Datatype ;
+	owl:intersectionOf _:c14n984 .
+_:c14n984 rdf:first linkml:Integer ;
+	rdf:rest _:c14n985 .
+_:c14n985 rdf:first _:c14n986 ;
+	rdf:rest rdf:nil .
+_:c14n986 a rdfs:Datatype ;
+	owl:onDatatype xsd:integer ;
+	owl:withRestrictions _:c14n987 .
+_:c14n987 rdf:first _:c14n988 ;
+	rdf:rest rdf:nil .
+_:c14n988 xsd:minInclusive 0 .
+_:c14n989 rdf:first openlabel_v2:QuantitativeValue ;
+	rdf:rest rdf:nil .
+_:c14n99 a owl:Restriction ;
+	owl:minCardinality 0 ;
+	owl:onProperty openlabel_v2:subjectVehicleSpeedValue .
+_:c14n990 owl:unionOf _:c14n991 .
+_:c14n991 rdf:first linkml:Decimal ;
+	rdf:rest _:c14n992 .
+_:c14n992 rdf:first openlabel_v2:QuantitativeValue ;
+	rdf:rest rdf:nil .
+_:c14n993 owl:unionOf _:c14n994 .
+_:c14n994 rdf:first linkml:Decimal ;
+	rdf:rest _:c14n995 .
+_:c14n995 rdf:first openlabel_v2:QuantitativeValue ;
+	rdf:rest rdf:nil .
+_:c14n996 rdf:first openlabel_v2:QuantitativeValue ;
+	rdf:rest rdf:nil .
+_:c14n997 rdf:first linkml:Decimal ;
+	rdf:rest _:c14n996 .
+_:c14n998 rdf:first openlabel_v2:QuantitativeValue ;
+	rdf:rest rdf:nil .
+_:c14n999 rdf:first linkml:Decimal ;
+	rdf:rest _:c14n998 .

--- a/artifacts/openlabel-v2/openlabel-v2.shacl.ttl
+++ b/artifacts/openlabel-v2/openlabel-v2.shacl.ttl
@@ -1,2305 +1,2968 @@
-@prefix cmns-q: <https://www.omg.org/spec/Commons/Quantities/> .
 @prefix openlabel_v2: <https://w3id.org/ascs-ev/envited-x/openlabel/v2/> .
+@prefix cmns-q: <https://www.omg.org/spec/Commons/Quantities/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix wgs: <https://www.w3.org/2003/01/geo/wgs84_pos#> .
+@prefix brick: <https://brickschema.org/schema/Brick#> .
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix schema: <https://schema.org/> .
-@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix qb: <http://purl.org/linked-data/cube#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-
-openlabel_v2:OddDynamicElements a sh:NodeShape ;
-    rdfs:comment "Dynamic elements subset of the Operational Design Domain. Covers traffic agents, flow rates, volume, and subject vehicle speed. Refer to BSI PAS-1883 Section 5.4."@en ;
-    sh:closed true ;
-    sh:ignoredProperties ( rdf:type ) ;
-    sh:property [ sh:datatype xsd:boolean ;
-            sh:description "Rainfall flag. Refer to BSI PAS-1883 Section 5.3.1.2."@en ;
-            sh:maxCount 0 ;
-            sh:message "WeatherRain (OddDynamicElements): Rainfall flag. Refer to BSI PAS-1883 Section 5.3.1.2."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 58 ;
-            sh:path openlabel_v2:WeatherRain ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.i."@en ;
-            sh:maxCount 0 ;
-            sh:message "longitudinalUpSlopeValue (OddDynamicElements): Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.i."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 32 ;
-            sh:path openlabel_v2:longitudinalUpSlopeValue ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Traffic agent density flag. Refer to BSI PAS-1883 Section 5.4.a.1."@en ;
-            sh:maxCount 1 ;
-            sh:message "TrafficAgentDensity (OddDynamicElements): Traffic agent density flag. Refer to BSI PAS-1883 Section 5.4.a.1."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 49 ;
-            sh:path openlabel_v2:TrafficAgentDensity ],
-        [ sh:description "Direction of travel. Refer to BSI PAS-1883 Section 5.2.3.4.e."@en ;
-            sh:in ( openlabel_v2:TravelDirectionLeft openlabel_v2:TravelDirectionRight ) ;
-            sh:maxCount 0 ;
-            sh:message "LaneSpecificationTravelDirection (OddDynamicElements): Direction of travel. Refer to BSI PAS-1883 Section 5.2.3.4.e."@en ;
-            sh:order 26 ;
-            sh:path openlabel_v2:LaneSpecificationTravelDirection ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Number of lanes flag. Refer to BSI PAS-1883 Section 5.2.3.4.d."@en ;
-            sh:maxCount 0 ;
-            sh:message "LaneSpecificationLaneCount (OddDynamicElements): Number of lanes flag. Refer to BSI PAS-1883 Section 5.2.3.4.d."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 23 ;
-            sh:path openlabel_v2:LaneSpecificationLaneCount ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Wind speed (m/s). Refer to BSI PAS-1883 Section 5.3.1.1."@en ;
-            sh:maxCount 0 ;
-            sh:message "weatherWindValue (OddDynamicElements): Wind speed (m/s). Refer to BSI PAS-1883 Section 5.3.1.1."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 63 ;
-            sh:path openlabel_v2:weatherWindValue ],
-        [ sh:description "Warning sign type. Refer to BSI PAS-1883 Section 5.2.3.5.c."@en ;
-            sh:in ( openlabel_v2:WarningSignsUniform openlabel_v2:WarningSignsUniformFullTime openlabel_v2:WarningSignsUniformTemporary openlabel_v2:WarningSignsVariableFullTime openlabel_v2:WarningSignsVariableTemporary ) ;
-            sh:maxCount 0 ;
-            sh:message "SignsWarning (OddDynamicElements): Warning sign type. Refer to BSI PAS-1883 Section 5.2.3.5.c."@en ;
-            sh:order 46 ;
-            sh:path openlabel_v2:SignsWarning ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Smoke and pollution flag. Refer to BSI PAS-1883 Section 5.3.2.d."@en ;
-            sh:maxCount 0 ;
-            sh:message "ParticulatesPollution (OddDynamicElements): Smoke and pollution flag. Refer to BSI PAS-1883 Section 5.3.2.d."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 35 ;
-            sh:path openlabel_v2:ParticulatesPollution ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Wind flag. Refer to BSI PAS-1883 Section 5.3.1.1."@en ;
-            sh:maxCount 0 ;
-            sh:message "WeatherWind (OddDynamicElements): Wind flag. Refer to BSI PAS-1883 Section 5.3.1.1."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 62 ;
-            sh:path openlabel_v2:WeatherWind ],
-        [ sh:description "Lane width (m). Refer to BSI PAS-1883 Section 5.2.3.4.a."@en ;
-            sh:maxCount 0 ;
-            sh:message "laneSpecificationDimensionsValue (OddDynamicElements): Lane width (m). Refer to BSI PAS-1883 Section 5.2.3.4.a."@en ;
-            sh:or ( [ sh:datatype xsd:decimal ;
-                        sh:nodeKind sh:Literal ] [ sh:class schema:QuantitativeValue ] ) ;
-            sh:order 22 ;
-            sh:path openlabel_v2:laneSpecificationDimensionsValue ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Lane marking flag. Refer to BSI PAS-1883 Section 5.2.3.4.b."@en ;
-            sh:maxCount 0 ;
-            sh:message "LaneSpecificationMarking (OddDynamicElements): Lane marking flag. Refer to BSI PAS-1883 Section 5.2.3.4.b."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 25 ;
-            sh:path openlabel_v2:LaneSpecificationMarking ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Sun elevation (degrees). Refer to BSI PAS-1883 Section 5.3.3.a.1."@en ;
-            sh:maxCount 0 ;
-            sh:message "daySunElevationValue (OddDynamicElements): Sun elevation (degrees). Refer to BSI PAS-1883 Section 5.3.3.a.1."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 3 ;
-            sh:path openlabel_v2:daySunElevationValue ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Volcanic ash flag. Refer to BSI PAS-1883 Section 5.3.2.e."@en ;
-            sh:maxCount 0 ;
-            sh:message "ParticulatesVolcanic (OddDynamicElements): Volcanic ash flag. Refer to BSI PAS-1883 Section 5.3.2.e."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 36 ;
-            sh:path openlabel_v2:ParticulatesVolcanic ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Straight lines flag. Refer to BSI PAS-1883 Section 5.2.3.3."@en ;
-            sh:maxCount 0 ;
-            sh:message "HorizontalStraights (OddDynamicElements): Straight lines flag. Refer to BSI PAS-1883 Section 5.2.3.3."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 14 ;
-            sh:path openlabel_v2:HorizontalStraights ],
-        [ sh:description "Communication connectivity type. Refer to BSI PAS-1883 Section 5.3.4.a."@en ;
-            sh:in ( openlabel_v2:CommunicationV2i openlabel_v2:CommunicationV2v openlabel_v2:V2iCellular openlabel_v2:V2iSatellite openlabel_v2:V2iWifi openlabel_v2:V2vCellular openlabel_v2:V2vSatellite openlabel_v2:V2vWifi ) ;
-            sh:maxCount 0 ;
-            sh:message "ConnectivityCommunication (OddDynamicElements): Communication connectivity type. Refer to BSI PAS-1883 Section 5.3.4.a."@en ;
-            sh:order 0 ;
-            sh:path openlabel_v2:ConnectivityCommunication ],
-        [ sh:description "Rainfall type. Refer to BSI PAS-1883 Section 5.3.1.2."@en ;
-            sh:in ( openlabel_v2:RainTypeConvective openlabel_v2:RainTypeDynamic openlabel_v2:RainTypeOrographic ) ;
-            sh:maxCount 0 ;
-            sh:message "RainType (OddDynamicElements): Rainfall type. Refer to BSI PAS-1883 Section 5.3.1.2."@en ;
-            sh:order 39 ;
-            sh:path openlabel_v2:RainType ],
-        [ sh:description "Agent type. Refer to BSI PAS-1883 Section 5.4.a.4."@en ;
-            sh:message "trafficAgentTypeValue (OddDynamicElements): Agent type. Refer to BSI PAS-1883 Section 5.4.a.4."@en ;
-            sh:or ( [ sh:in ( openlabel_v2:HumanAnimalRider openlabel_v2:HumanCyclist openlabel_v2:HumanDriver openlabel_v2:HumanMotorcyclist openlabel_v2:HumanPassenger openlabel_v2:HumanPedestrian openlabel_v2:HumanWheelchairUser ) ] [ sh:in ( openlabel_v2:VehicleAgricultural openlabel_v2:VehicleBus openlabel_v2:VehicleCar openlabel_v2:VehicleConstruction openlabel_v2:VehicleCycle openlabel_v2:VehicleEmergency openlabel_v2:VehicleMotorcycle openlabel_v2:VehicleTrailer openlabel_v2:VehicleTruck openlabel_v2:VehicleVan openlabel_v2:VehicleWheelchair ) ] ) ;
-            sh:order 52 ;
-            sh:path openlabel_v2:trafficAgentTypeValue ],
-        [ sh:description "Road surface type. Refer to BSI PAS-1883 Section 5.2.3.7.a."@en ;
-            sh:in ( openlabel_v2:SurfaceTypeLoose openlabel_v2:SurfaceTypeSegmented openlabel_v2:SurfaceTypeUniform ) ;
-            sh:maxCount 0 ;
-            sh:message "DrivableAreaSurfaceType (OddDynamicElements): Road surface type. Refer to BSI PAS-1883 Section 5.2.3.7.a."@en ;
-            sh:order 8 ;
-            sh:path openlabel_v2:DrivableAreaSurfaceType ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Traffic flow rate flag. Refer to BSI PAS-1883 Section 5.4.a.3."@en ;
-            sh:maxCount 1 ;
-            sh:message "TrafficFlowRate (OddDynamicElements): Traffic flow rate flag. Refer to BSI PAS-1883 Section 5.4.a.3."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 53 ;
-            sh:path openlabel_v2:TrafficFlowRate ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Sand and dust flag. Refer to BSI PAS-1883 Section 5.3.2.c."@en ;
-            sh:maxCount 0 ;
-            sh:message "ParticulatesDust (OddDynamicElements): Sand and dust flag. Refer to BSI PAS-1883 Section 5.3.2.c."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 33 ;
-            sh:path openlabel_v2:ParticulatesDust ],
-        [ sh:description "Particulate type. Refer to BSI PAS-1883 Section 5.3.2."@en ;
-            sh:in ( openlabel_v2:ParticulatesDust openlabel_v2:ParticulatesMarine openlabel_v2:ParticulatesPollution openlabel_v2:ParticulatesVolcanic openlabel_v2:ParticulatesWater ) ;
-            sh:maxCount 0 ;
-            sh:message "EnvironmentParticulates (OddDynamicElements): Particulate type. Refer to BSI PAS-1883 Section 5.3.2."@en ;
-            sh:order 10 ;
-            sh:path openlabel_v2:EnvironmentParticulates ],
-        [ sh:datatype xsd:integer ;
-            sh:description "Volume (vehicle km). Refer to BSI PAS-1883 Section 5.4.a.2."@en ;
-            sh:maxCount 1 ;
-            sh:message "trafficVolumeValue (OddDynamicElements): Volume (vehicle km). Refer to BSI PAS-1883 Section 5.4.a.2."@en ;
-            sh:minInclusive 0 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 57 ;
-            sh:path openlabel_v2:trafficVolumeValue ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.ii."@en ;
-            sh:maxCount 0 ;
-            sh:message "longitudinalDownSlopeValue (OddDynamicElements): Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.ii."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 29 ;
-            sh:path openlabel_v2:longitudinalDownSlopeValue ],
-        [ sh:description "Special road structure. Refer to BSI PAS-1883 Section 5.2.1.d."@en ;
-            sh:in ( openlabel_v2:SpecialStructureAutoAccess openlabel_v2:SpecialStructureBridge openlabel_v2:SpecialStructurePedestrianCrossing openlabel_v2:SpecialStructureRailCrossing openlabel_v2:SpecialStructureTollPlaza openlabel_v2:SpecialStructureTunnel ) ;
-            sh:maxCount 0 ;
-            sh:message "ScenerySpecialStructure (OddDynamicElements): Special road structure. Refer to BSI PAS-1883 Section 5.2.1.d."@en ;
-            sh:order 41 ;
-            sh:path openlabel_v2:ScenerySpecialStructure ],
-        [ sh:description "Positioning system type. Refer to BSI PAS-1883 Section 5.3.4.b."@en ;
-            sh:in ( openlabel_v2:PositioningGalileo openlabel_v2:PositioningGlonass openlabel_v2:PositioningGps ) ;
-            sh:maxCount 0 ;
-            sh:message "ConnectivityPositioning (OddDynamicElements): Positioning system type. Refer to BSI PAS-1883 Section 5.3.4.b."@en ;
-            sh:order 1 ;
-            sh:path openlabel_v2:ConnectivityPositioning ],
-        [ sh:description "Transverse geometry type. Refer to BSI PAS-1883 Section 5.2.3.3.b."@en ;
-            sh:in ( openlabel_v2:TransverseBarriers openlabel_v2:TransverseDivided openlabel_v2:TransverseLanesTogether openlabel_v2:TransversePavements openlabel_v2:TransverseUndivided ) ;
-            sh:maxCount 0 ;
-            sh:message "GeometryTransverse (OddDynamicElements): Transverse geometry type. Refer to BSI PAS-1883 Section 5.2.3.3.b."@en ;
-            sh:order 11 ;
-            sh:path openlabel_v2:GeometryTransverse ],
-        [ sh:description "Artificial illumination type. Refer to BSI PAS-1883 Section 5.3.3.d."@en ;
-            sh:in ( openlabel_v2:ArtificialStreetLighting openlabel_v2:ArtificialVehicleLighting ) ;
-            sh:maxCount 0 ;
-            sh:message "IlluminationArtificial (OddDynamicElements): Artificial illumination type. Refer to BSI PAS-1883 Section 5.3.3.d."@en ;
-            sh:order 15 ;
-            sh:path openlabel_v2:IlluminationArtificial ],
-        [ sh:description "Zone type. Refer to BSI PAS-1883 Section 5.2.1.a."@en ;
-            sh:in ( openlabel_v2:ZoneGeoFenced openlabel_v2:ZoneInterference openlabel_v2:ZoneRegion openlabel_v2:ZoneSchool openlabel_v2:ZoneTrafficManagement ) ;
-            sh:maxCount 0 ;
-            sh:message "SceneryZone (OddDynamicElements): Zone type. Refer to BSI PAS-1883 Section 5.2.1.a."@en ;
-            sh:order 43 ;
-            sh:path openlabel_v2:SceneryZone ],
-        [ sh:description "Drivable area edge type. Refer to BSI PAS-1883 Section 5.2.3.1.e."@en ;
-            sh:in ( openlabel_v2:EdgeLineMarkers openlabel_v2:EdgeNone openlabel_v2:EdgeShoulderGrass openlabel_v2:EdgeShoulderPavedOrGravel openlabel_v2:EdgeSolidBarriers openlabel_v2:EdgeTemporaryLineMarkers ) ;
-            sh:maxCount 0 ;
-            sh:message "DrivableAreaEdge (OddDynamicElements): Drivable area edge type. Refer to BSI PAS-1883 Section 5.2.3.1.e."@en ;
-            sh:order 5 ;
-            sh:path openlabel_v2:DrivableAreaEdge ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Cloud cover (okta). Refer to BSI PAS-1883 Section 5.3.3.c."@en ;
-            sh:maxCount 0 ;
-            sh:message "illuminationCloudinessValue (OddDynamicElements): Cloud cover (okta). Refer to BSI PAS-1883 Section 5.3.3.c."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 17 ;
-            sh:path openlabel_v2:illuminationCloudinessValue ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Curve radius (m). Refer to BSI PAS-1883 Section 5.2.3.3."@en ;
-            sh:maxCount 0 ;
-            sh:message "horizontalCurvesValue (OddDynamicElements): Curve radius (m). Refer to BSI PAS-1883 Section 5.2.3.3."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 13 ;
-            sh:path openlabel_v2:horizontalCurvesValue ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Non-precipitating water droplets or ice crystals (mist/fog) flag. Refer to BSI PAS-1883 Section 5.3.2.b."@en ;
-            sh:maxCount 0 ;
-            sh:message "ParticulatesWater (OddDynamicElements): Non-precipitating water droplets or ice crystals (mist/fog) flag. Refer to BSI PAS-1883 Section 5.3.2.b."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 37 ;
-            sh:path openlabel_v2:ParticulatesWater ],
-        [ sh:description "Lane type. Refer to BSI PAS-1883 Section 5.2.3.4.c."@en ;
-            sh:in ( openlabel_v2:LaneTypeBus openlabel_v2:LaneTypeCycle openlabel_v2:LaneTypeEmergency openlabel_v2:LaneTypeSpecial openlabel_v2:LaneTypeTraffic openlabel_v2:LaneTypeTram ) ;
-            sh:maxCount 0 ;
-            sh:message "LaneSpecificationType (OddDynamicElements): Lane type. Refer to BSI PAS-1883 Section 5.2.3.4.c."@en ;
-            sh:order 27 ;
-            sh:path openlabel_v2:LaneSpecificationType ],
-        [ sh:description "Information sign type. Refer to BSI PAS-1883 Section 5.2.3.5.a."@en ;
-            sh:in ( openlabel_v2:InformationSignsUniformFullTime openlabel_v2:InformationSignsUniformTemporary openlabel_v2:InformationSignsVariableFullTime openlabel_v2:InformationSignsVariableTemporary ) ;
-            sh:maxCount 0 ;
-            sh:message "SignsInformation (OddDynamicElements): Information sign type. Refer to BSI PAS-1883 Section 5.2.3.5.a."@en ;
-            sh:order 44 ;
-            sh:path openlabel_v2:SignsInformation ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Subject vehicle speed flag. Refer to BSI PAS-1883 Section 5.4.b."@en ;
-            sh:maxCount 1 ;
-            sh:message "SubjectVehicleSpeed (OddDynamicElements): Subject vehicle speed flag. Refer to BSI PAS-1883 Section 5.4.b."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 47 ;
-            sh:path openlabel_v2:SubjectVehicleSpeed ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Presence of special vehicles flag. Refer to BSI PAS-1883 Section 5.4.a.5."@en ;
-            sh:maxCount 1 ;
-            sh:message "TrafficSpecialVehicle (OddDynamicElements): Presence of special vehicles flag. Refer to BSI PAS-1883 Section 5.4.a.5."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 55 ;
-            sh:path openlabel_v2:TrafficSpecialVehicle ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Marine (coastal areas only) flag. Refer to BSI PAS-1883 Section 5.3.2.a."@en ;
-            sh:maxCount 0 ;
-            sh:message "ParticulatesMarine (OddDynamicElements): Marine (coastal areas only) flag. Refer to BSI PAS-1883 Section 5.3.2.a."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 34 ;
-            sh:path openlabel_v2:ParticulatesMarine ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Elevation of the sun above the horizon flag. Refer to BSI PAS-1883 Section 5.3.3.a.1."@en ;
-            sh:maxCount 0 ;
-            sh:message "DaySunElevation (OddDynamicElements): Elevation of the sun above the horizon flag. Refer to BSI PAS-1883 Section 5.3.3.a.1."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 2 ;
-            sh:path openlabel_v2:DaySunElevation ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Rainfall intensity (mm/h). Refer to BSI PAS-1883 Section 5.3.1.2."@en ;
-            sh:maxCount 0 ;
-            sh:message "weatherRainValue (OddDynamicElements): Rainfall intensity (mm/h). Refer to BSI PAS-1883 Section 5.3.1.2."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 59 ;
-            sh:path openlabel_v2:weatherRainValue ],
-        [ sh:datatype xsd:integer ;
-            sh:description "Rate (vehicles/h). Refer to BSI PAS-1883 Section 5.4.a.3."@en ;
-            sh:maxCount 1 ;
-            sh:message "trafficFlowRateValue (OddDynamicElements): Rate (vehicles/h). Refer to BSI PAS-1883 Section 5.4.a.3."@en ;
-            sh:minInclusive 0 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 54 ;
-            sh:path openlabel_v2:trafficFlowRateValue ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Level plane flag. Refer to BSI PAS-1883 Section 5.2.3.3.iii."@en ;
-            sh:maxCount 0 ;
-            sh:message "LongitudinalLevelPlane (OddDynamicElements): Level plane flag. Refer to BSI PAS-1883 Section 5.2.3.3.iii."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 30 ;
-            sh:path openlabel_v2:LongitudinalLevelPlane ],
-        [ sh:description "Intersection type. Refer to BSI PAS-1883 Section 5.2.4."@en ;
-            sh:in ( openlabel_v2:IntersectionCrossroad openlabel_v2:IntersectionGradeSeperated openlabel_v2:IntersectionStaggered openlabel_v2:IntersectionTJunction openlabel_v2:IntersectionYJunction ) ;
-            sh:maxCount 0 ;
-            sh:message "JunctionIntersection (OddDynamicElements): Intersection type. Refer to BSI PAS-1883 Section 5.2.4."@en ;
-            sh:order 19 ;
-            sh:path openlabel_v2:JunctionIntersection ],
-        [ sh:description "Fixed road structure. Refer to BSI PAS-1883 Section 5.2.1.e."@en ;
-            sh:in ( openlabel_v2:FixedStructureBuilding openlabel_v2:FixedStructureStreetFurniture openlabel_v2:FixedStructureStreetlight openlabel_v2:FixedStructureVegetation ) ;
-            sh:maxCount 0 ;
-            sh:message "SceneryFixedStructure (OddDynamicElements): Fixed road structure. Refer to BSI PAS-1883 Section 5.2.1.e."@en ;
-            sh:order 40 ;
-            sh:path openlabel_v2:SceneryFixedStructure ],
-        [ sh:description "Speed (km/h). Refer to BSI PAS-1883 Section 5.4.b."@en ;
-            sh:maxCount 1 ;
-            sh:message "subjectVehicleSpeedValue (OddDynamicElements): Speed (km/h). Refer to BSI PAS-1883 Section 5.4.b."@en ;
-            sh:or ( [ sh:datatype xsd:integer ;
-                        sh:nodeKind sh:Literal ] [ sh:class schema:QuantitativeValue ] ) ;
-            sh:order 48 ;
-            sh:path openlabel_v2:subjectVehicleSpeedValue ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Down-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.ii."@en ;
-            sh:maxCount 0 ;
-            sh:message "LongitudinalDownSlope (OddDynamicElements): Down-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.ii."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 28 ;
-            sh:path openlabel_v2:LongitudinalDownSlope ],
-        [ sh:description "Position of the sun. Refer to BSI PAS-1883 Section 5.3.3.a.2."@en ;
-            sh:in ( openlabel_v2:SunPositionBehind openlabel_v2:SunPositionFront openlabel_v2:SunPositionLeft openlabel_v2:SunPositionRight ) ;
-            sh:maxCount 0 ;
-            sh:message "DaySunPosition (OddDynamicElements): Position of the sun. Refer to BSI PAS-1883 Section 5.3.3.a.2."@en ;
-            sh:order 4 ;
-            sh:path openlabel_v2:DaySunPosition ],
-        [ sh:description "Regulatory sign type. Refer to BSI PAS-1883 Section 5.2.3.5.b."@en ;
-            sh:in ( openlabel_v2:RegulatorySignsUniformFullTime openlabel_v2:RegulatorySignsUniformTemporary openlabel_v2:RegulatorySignsVariableFullTime openlabel_v2:RegulatorySignsVariableTemporary ) ;
-            sh:maxCount 0 ;
-            sh:message "SignsRegulatory (OddDynamicElements): Regulatory sign type. Refer to BSI PAS-1883 Section 5.2.3.5.b."@en ;
-            sh:order 45 ;
-            sh:path openlabel_v2:SignsRegulatory ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Lane dimensions flag. Refer to BSI PAS-1883 Section 5.2.3.4.a."@en ;
-            sh:maxCount 0 ;
-            sh:message "LaneSpecificationDimensions (OddDynamicElements): Lane dimensions flag. Refer to BSI PAS-1883 Section 5.2.3.4.a."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 21 ;
-            sh:path openlabel_v2:LaneSpecificationDimensions ],
-        [ sh:description "Road surface condition. Refer to BSI PAS-1883 Section 5.2.3.7.c."@en ;
-            sh:in ( openlabel_v2:SurfaceConditionContamination openlabel_v2:SurfaceConditionFlooded openlabel_v2:SurfaceConditionIcy openlabel_v2:SurfaceConditionMirage openlabel_v2:SurfaceConditionSnow openlabel_v2:SurfaceConditionStandingWater openlabel_v2:SurfaceConditionWet ) ;
-            sh:maxCount 0 ;
-            sh:message "DrivableAreaSurfaceCondition (OddDynamicElements): Road surface condition. Refer to BSI PAS-1883 Section 5.2.3.7.c."@en ;
-            sh:order 6 ;
-            sh:path openlabel_v2:DrivableAreaSurfaceCondition ],
-        [ sh:description "Roundabout type. Refer to BSI PAS-1883 Section 5.2.4."@en ;
-            sh:in ( openlabel_v2:RoundaboutCompactNosignal openlabel_v2:RoundaboutCompactSignal openlabel_v2:RoundaboutDoubleNosignal openlabel_v2:RoundaboutDoubleSignal openlabel_v2:RoundaboutLargeNosignal openlabel_v2:RoundaboutLargeSignal openlabel_v2:RoundaboutMiniNosignal openlabel_v2:RoundaboutMiniSignal openlabel_v2:RoundaboutNormalNosignal openlabel_v2:RoundaboutNormalSignal ) ;
-            sh:maxCount 0 ;
-            sh:message "JunctionRoundabout (OddDynamicElements): Roundabout type. Refer to BSI PAS-1883 Section 5.2.4."@en ;
-            sh:order 20 ;
-            sh:path openlabel_v2:JunctionRoundabout ],
-        [ sh:description "Road surface feature. Refer to BSI PAS-1883 Section 5.2.3.7.b."@en ;
-            sh:in ( openlabel_v2:SurfaceFeatureCrack openlabel_v2:SurfaceFeaturePothole openlabel_v2:SurfaceFeatureRut openlabel_v2:SurfaceFeatureSwell ) ;
-            sh:maxCount 0 ;
-            sh:message "DrivableAreaSurfaceFeature (OddDynamicElements): Road surface feature. Refer to BSI PAS-1883 Section 5.2.3.7.b."@en ;
-            sh:order 7 ;
-            sh:path openlabel_v2:DrivableAreaSurfaceFeature ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Curves flag. Refer to BSI PAS-1883 Section 5.2.3.3."@en ;
-            sh:maxCount 0 ;
-            sh:message "HorizontalCurves (OddDynamicElements): Curves flag. Refer to BSI PAS-1883 Section 5.2.3.3."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 12 ;
-            sh:path openlabel_v2:HorizontalCurves ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Traffic volume flag. Refer to BSI PAS-1883 Section 5.4.a.2."@en ;
-            sh:maxCount 1 ;
-            sh:message "TrafficVolume (OddDynamicElements): Traffic volume flag. Refer to BSI PAS-1883 Section 5.4.a.2."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 56 ;
-            sh:path openlabel_v2:TrafficVolume ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Up-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.i."@en ;
-            sh:maxCount 0 ;
-            sh:message "LongitudinalUpSlope (OddDynamicElements): Up-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.i."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 31 ;
-            sh:path openlabel_v2:LongitudinalUpSlope ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Traffic agent type classification flag. Refer to BSI PAS-1883 Section 5.4.a.4."@en ;
-            sh:maxCount 1 ;
-            sh:message "TrafficAgentType (OddDynamicElements): Traffic agent type classification flag. Refer to BSI PAS-1883 Section 5.4.a.4."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 51 ;
-            sh:path openlabel_v2:TrafficAgentType ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Visibility (km). Refer to BSI PAS-1883 Section 5.3.1.3."@en ;
-            sh:maxCount 0 ;
-            sh:message "weatherSnowValue (OddDynamicElements): Visibility (km). Refer to BSI PAS-1883 Section 5.3.1.3."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 61 ;
-            sh:path openlabel_v2:weatherSnowValue ],
-        [ sh:description "Low light condition. Refer to BSI PAS-1883 Section 5.3.3.b."@en ;
-            sh:in ( openlabel_v2:LowLightAmbient openlabel_v2:LowLightNight ) ;
-            sh:maxCount 0 ;
-            sh:message "IlluminationLowLight (OddDynamicElements): Low light condition. Refer to BSI PAS-1883 Section 5.3.3.b."@en ;
-            sh:order 18 ;
-            sh:path openlabel_v2:IlluminationLowLight ],
-        [ sh:description "Road type. Refer to BSI PAS-1883 Section 5.2.3.2."@en ;
-            sh:in ( openlabel_v2:MotorwayManaged openlabel_v2:MotorwayUnmanaged openlabel_v2:RoadTypeDistributor openlabel_v2:RoadTypeMinor openlabel_v2:RoadTypeMotorway openlabel_v2:RoadTypeParking openlabel_v2:RoadTypeRadial openlabel_v2:RoadTypeShared openlabel_v2:RoadTypeSlip ) ;
-            sh:maxCount 0 ;
-            sh:message "DrivableAreaType (OddDynamicElements): Road type. Refer to BSI PAS-1883 Section 5.2.3.2."@en ;
-            sh:order 9 ;
-            sh:path openlabel_v2:DrivableAreaType ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Snowfall flag. Refer to BSI PAS-1883 Section 5.3.1.3."@en ;
-            sh:maxCount 0 ;
-            sh:message "WeatherSnow (OddDynamicElements): Snowfall flag. Refer to BSI PAS-1883 Section 5.3.1.3."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 60 ;
-            sh:path openlabel_v2:WeatherSnow ],
-        [ sh:description "Number of lanes (unit). Refer to BSI PAS-1883 Section 5.2.3.4.d."@en ;
-            sh:maxCount 0 ;
-            sh:message "laneSpecificationLaneCountValue (OddDynamicElements): Number of lanes (unit). Refer to BSI PAS-1883 Section 5.2.3.4.d."@en ;
-            sh:or ( [ sh:datatype xsd:integer ;
-                        sh:nodeKind sh:Literal ] [ sh:class schema:QuantitativeValue ] ) ;
-            sh:order 24 ;
-            sh:path openlabel_v2:laneSpecificationLaneCountValue ],
-        [ sh:datatype xsd:integer ;
-            sh:description "Density (vehicles/km). Refer to BSI PAS-1883 Section 5.4.a.1."@en ;
-            sh:maxCount 1 ;
-            sh:message "trafficAgentDensityValue (OddDynamicElements): Density (vehicles/km). Refer to BSI PAS-1883 Section 5.4.a.1."@en ;
-            sh:minInclusive 0 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 50 ;
-            sh:path openlabel_v2:trafficAgentDensityValue ],
-        [ sh:description "Temporary road structure. Refer to BSI PAS-1883 Section 5.2.1.f."@en ;
-            sh:in ( openlabel_v2:TemporaryStructureConstructionDetour openlabel_v2:TemporaryStructureRefuseCollection openlabel_v2:TemporaryStructureRoadSignage openlabel_v2:TemporaryStructureRoadWorks ) ;
-            sh:maxCount 0 ;
-            sh:message "SceneryTemporaryStructure (OddDynamicElements): Temporary road structure. Refer to BSI PAS-1883 Section 5.2.1.f."@en ;
-            sh:order 42 ;
-            sh:path openlabel_v2:SceneryTemporaryStructure ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Meteorological Optical Range (MOR) (m). Refer to BSI PAS-1883 Section 5.3.2.b."@en ;
-            sh:maxCount 0 ;
-            sh:message "particulatesWaterValue (OddDynamicElements): Meteorological Optical Range (MOR) (m). Refer to BSI PAS-1883 Section 5.3.2.b."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 38 ;
-            sh:path openlabel_v2:particulatesWaterValue ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Cloudiness flag. Refer to BSI PAS-1883 Section 5.3.3.c."@en ;
-            sh:maxCount 0 ;
-            sh:message "IlluminationCloudiness (OddDynamicElements): Cloudiness flag. Refer to BSI PAS-1883 Section 5.3.3.c."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 16 ;
-            sh:path openlabel_v2:IlluminationCloudiness ] ;
-    sh:targetClass openlabel_v2:OddDynamicElements .
-
-openlabel_v2:OddEnvironment a sh:NodeShape ;
-    rdfs:comment "Environment-related subset of the Operational Design Domain. Covers weather, illumination, connectivity, and particulates. Refer to BSI PAS-1883 Section 5.3."@en ;
-    sh:closed true ;
-    sh:ignoredProperties ( rdf:type ) ;
-    sh:property [ sh:datatype xsd:integer ;
-            sh:description "Density (vehicles/km). Refer to BSI PAS-1883 Section 5.4.a.1."@en ;
-            sh:maxCount 0 ;
-            sh:message "trafficAgentDensityValue (OddEnvironment): Density (vehicles/km). Refer to BSI PAS-1883 Section 5.4.a.1."@en ;
-            sh:minInclusive 0 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 50 ;
-            sh:path openlabel_v2:trafficAgentDensityValue ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Wind flag. Refer to BSI PAS-1883 Section 5.3.1.1."@en ;
-            sh:maxCount 1 ;
-            sh:message "WeatherWind (OddEnvironment): Wind flag. Refer to BSI PAS-1883 Section 5.3.1.1."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 62 ;
-            sh:path openlabel_v2:WeatherWind ],
-        [ sh:datatype xsd:integer ;
-            sh:description "Volume (vehicle km). Refer to BSI PAS-1883 Section 5.4.a.2."@en ;
-            sh:maxCount 0 ;
-            sh:message "trafficVolumeValue (OddEnvironment): Volume (vehicle km). Refer to BSI PAS-1883 Section 5.4.a.2."@en ;
-            sh:minInclusive 0 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 57 ;
-            sh:path openlabel_v2:trafficVolumeValue ],
-        [ sh:description "Direction of travel. Refer to BSI PAS-1883 Section 5.2.3.4.e."@en ;
-            sh:in ( openlabel_v2:TravelDirectionLeft openlabel_v2:TravelDirectionRight ) ;
-            sh:maxCount 0 ;
-            sh:message "LaneSpecificationTravelDirection (OddEnvironment): Direction of travel. Refer to BSI PAS-1883 Section 5.2.3.4.e."@en ;
-            sh:order 26 ;
-            sh:path openlabel_v2:LaneSpecificationTravelDirection ],
-        [ sh:description "Regulatory sign type. Refer to BSI PAS-1883 Section 5.2.3.5.b."@en ;
-            sh:in ( openlabel_v2:RegulatorySignsUniformFullTime openlabel_v2:RegulatorySignsUniformTemporary openlabel_v2:RegulatorySignsVariableFullTime openlabel_v2:RegulatorySignsVariableTemporary ) ;
-            sh:maxCount 0 ;
-            sh:message "SignsRegulatory (OddEnvironment): Regulatory sign type. Refer to BSI PAS-1883 Section 5.2.3.5.b."@en ;
-            sh:order 45 ;
-            sh:path openlabel_v2:SignsRegulatory ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Rainfall flag. Refer to BSI PAS-1883 Section 5.3.1.2."@en ;
-            sh:maxCount 1 ;
-            sh:message "WeatherRain (OddEnvironment): Rainfall flag. Refer to BSI PAS-1883 Section 5.3.1.2."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 58 ;
-            sh:path openlabel_v2:WeatherRain ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Sun elevation (degrees). Refer to BSI PAS-1883 Section 5.3.3.a.1."@en ;
-            sh:maxCount 1 ;
-            sh:message "daySunElevationValue (OddEnvironment): Sun elevation (degrees). Refer to BSI PAS-1883 Section 5.3.3.a.1."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 3 ;
-            sh:path openlabel_v2:daySunElevationValue ],
-        [ sh:description "Road surface type. Refer to BSI PAS-1883 Section 5.2.3.7.a."@en ;
-            sh:in ( openlabel_v2:SurfaceTypeLoose openlabel_v2:SurfaceTypeSegmented openlabel_v2:SurfaceTypeUniform ) ;
-            sh:maxCount 0 ;
-            sh:message "DrivableAreaSurfaceType (OddEnvironment): Road surface type. Refer to BSI PAS-1883 Section 5.2.3.7.a."@en ;
-            sh:order 8 ;
-            sh:path openlabel_v2:DrivableAreaSurfaceType ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Elevation of the sun above the horizon flag. Refer to BSI PAS-1883 Section 5.3.3.a.1."@en ;
-            sh:maxCount 1 ;
-            sh:message "DaySunElevation (OddEnvironment): Elevation of the sun above the horizon flag. Refer to BSI PAS-1883 Section 5.3.3.a.1."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 2 ;
-            sh:path openlabel_v2:DaySunElevation ],
-        [ sh:description "Road surface feature. Refer to BSI PAS-1883 Section 5.2.3.7.b."@en ;
-            sh:in ( openlabel_v2:SurfaceFeatureCrack openlabel_v2:SurfaceFeaturePothole openlabel_v2:SurfaceFeatureRut openlabel_v2:SurfaceFeatureSwell ) ;
-            sh:maxCount 0 ;
-            sh:message "DrivableAreaSurfaceFeature (OddEnvironment): Road surface feature. Refer to BSI PAS-1883 Section 5.2.3.7.b."@en ;
-            sh:order 7 ;
-            sh:path openlabel_v2:DrivableAreaSurfaceFeature ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Traffic agent density flag. Refer to BSI PAS-1883 Section 5.4.a.1."@en ;
-            sh:maxCount 0 ;
-            sh:message "TrafficAgentDensity (OddEnvironment): Traffic agent density flag. Refer to BSI PAS-1883 Section 5.4.a.1."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 49 ;
-            sh:path openlabel_v2:TrafficAgentDensity ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.i."@en ;
-            sh:maxCount 0 ;
-            sh:message "longitudinalUpSlopeValue (OddEnvironment): Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.i."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 32 ;
-            sh:path openlabel_v2:longitudinalUpSlopeValue ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Wind speed (m/s). Refer to BSI PAS-1883 Section 5.3.1.1."@en ;
-            sh:maxCount 1 ;
-            sh:message "weatherWindValue (OddEnvironment): Wind speed (m/s). Refer to BSI PAS-1883 Section 5.3.1.1."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 63 ;
-            sh:path openlabel_v2:weatherWindValue ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Non-precipitating water droplets or ice crystals (mist/fog) flag. Refer to BSI PAS-1883 Section 5.3.2.b."@en ;
-            sh:maxCount 1 ;
-            sh:message "ParticulatesWater (OddEnvironment): Non-precipitating water droplets or ice crystals (mist/fog) flag. Refer to BSI PAS-1883 Section 5.3.2.b."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 37 ;
-            sh:path openlabel_v2:ParticulatesWater ],
-        [ sh:description "Position of the sun. Refer to BSI PAS-1883 Section 5.3.3.a.2."@en ;
-            sh:in ( openlabel_v2:SunPositionBehind openlabel_v2:SunPositionFront openlabel_v2:SunPositionLeft openlabel_v2:SunPositionRight ) ;
-            sh:maxCount 1 ;
-            sh:message "DaySunPosition (OddEnvironment): Position of the sun. Refer to BSI PAS-1883 Section 5.3.3.a.2."@en ;
-            sh:order 4 ;
-            sh:path openlabel_v2:DaySunPosition ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Rainfall intensity (mm/h). Refer to BSI PAS-1883 Section 5.3.1.2."@en ;
-            sh:maxCount 1 ;
-            sh:message "weatherRainValue (OddEnvironment): Rainfall intensity (mm/h). Refer to BSI PAS-1883 Section 5.3.1.2."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 59 ;
-            sh:path openlabel_v2:weatherRainValue ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Subject vehicle speed flag. Refer to BSI PAS-1883 Section 5.4.b."@en ;
-            sh:maxCount 0 ;
-            sh:message "SubjectVehicleSpeed (OddEnvironment): Subject vehicle speed flag. Refer to BSI PAS-1883 Section 5.4.b."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 47 ;
-            sh:path openlabel_v2:SubjectVehicleSpeed ],
-        [ sh:description "Drivable area edge type. Refer to BSI PAS-1883 Section 5.2.3.1.e."@en ;
-            sh:in ( openlabel_v2:EdgeLineMarkers openlabel_v2:EdgeNone openlabel_v2:EdgeShoulderGrass openlabel_v2:EdgeShoulderPavedOrGravel openlabel_v2:EdgeSolidBarriers openlabel_v2:EdgeTemporaryLineMarkers ) ;
-            sh:maxCount 0 ;
-            sh:message "DrivableAreaEdge (OddEnvironment): Drivable area edge type. Refer to BSI PAS-1883 Section 5.2.3.1.e."@en ;
-            sh:order 5 ;
-            sh:path openlabel_v2:DrivableAreaEdge ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Marine (coastal areas only) flag. Refer to BSI PAS-1883 Section 5.3.2.a."@en ;
-            sh:maxCount 1 ;
-            sh:message "ParticulatesMarine (OddEnvironment): Marine (coastal areas only) flag. Refer to BSI PAS-1883 Section 5.3.2.a."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 34 ;
-            sh:path openlabel_v2:ParticulatesMarine ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Down-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.ii."@en ;
-            sh:maxCount 0 ;
-            sh:message "LongitudinalDownSlope (OddEnvironment): Down-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.ii."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 28 ;
-            sh:path openlabel_v2:LongitudinalDownSlope ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Cloud cover (okta). Refer to BSI PAS-1883 Section 5.3.3.c."@en ;
-            sh:maxCount 1 ;
-            sh:message "illuminationCloudinessValue (OddEnvironment): Cloud cover (okta). Refer to BSI PAS-1883 Section 5.3.3.c."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 17 ;
-            sh:path openlabel_v2:illuminationCloudinessValue ],
-        [ sh:description "Fixed road structure. Refer to BSI PAS-1883 Section 5.2.1.e."@en ;
-            sh:in ( openlabel_v2:FixedStructureBuilding openlabel_v2:FixedStructureStreetFurniture openlabel_v2:FixedStructureStreetlight openlabel_v2:FixedStructureVegetation ) ;
-            sh:maxCount 0 ;
-            sh:message "SceneryFixedStructure (OddEnvironment): Fixed road structure. Refer to BSI PAS-1883 Section 5.2.1.e."@en ;
-            sh:order 40 ;
-            sh:path openlabel_v2:SceneryFixedStructure ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Lane dimensions flag. Refer to BSI PAS-1883 Section 5.2.3.4.a."@en ;
-            sh:maxCount 0 ;
-            sh:message "LaneSpecificationDimensions (OddEnvironment): Lane dimensions flag. Refer to BSI PAS-1883 Section 5.2.3.4.a."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 21 ;
-            sh:path openlabel_v2:LaneSpecificationDimensions ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Up-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.i."@en ;
-            sh:maxCount 0 ;
-            sh:message "LongitudinalUpSlope (OddEnvironment): Up-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.i."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 31 ;
-            sh:path openlabel_v2:LongitudinalUpSlope ],
-        [ sh:datatype xsd:integer ;
-            sh:description "Rate (vehicles/h). Refer to BSI PAS-1883 Section 5.4.a.3."@en ;
-            sh:maxCount 0 ;
-            sh:message "trafficFlowRateValue (OddEnvironment): Rate (vehicles/h). Refer to BSI PAS-1883 Section 5.4.a.3."@en ;
-            sh:minInclusive 0 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 54 ;
-            sh:path openlabel_v2:trafficFlowRateValue ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Sand and dust flag. Refer to BSI PAS-1883 Section 5.3.2.c."@en ;
-            sh:maxCount 1 ;
-            sh:message "ParticulatesDust (OddEnvironment): Sand and dust flag. Refer to BSI PAS-1883 Section 5.3.2.c."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 33 ;
-            sh:path openlabel_v2:ParticulatesDust ],
-        [ sh:description "Positioning system type. Refer to BSI PAS-1883 Section 5.3.4.b."@en ;
-            sh:in ( openlabel_v2:PositioningGalileo openlabel_v2:PositioningGlonass openlabel_v2:PositioningGps ) ;
-            sh:maxCount 1 ;
-            sh:message "ConnectivityPositioning (OddEnvironment): Positioning system type. Refer to BSI PAS-1883 Section 5.3.4.b."@en ;
-            sh:order 1 ;
-            sh:path openlabel_v2:ConnectivityPositioning ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Curve radius (m). Refer to BSI PAS-1883 Section 5.2.3.3."@en ;
-            sh:maxCount 0 ;
-            sh:message "horizontalCurvesValue (OddEnvironment): Curve radius (m). Refer to BSI PAS-1883 Section 5.2.3.3."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 13 ;
-            sh:path openlabel_v2:horizontalCurvesValue ],
-        [ sh:description "Information sign type. Refer to BSI PAS-1883 Section 5.2.3.5.a."@en ;
-            sh:in ( openlabel_v2:InformationSignsUniformFullTime openlabel_v2:InformationSignsUniformTemporary openlabel_v2:InformationSignsVariableFullTime openlabel_v2:InformationSignsVariableTemporary ) ;
-            sh:maxCount 0 ;
-            sh:message "SignsInformation (OddEnvironment): Information sign type. Refer to BSI PAS-1883 Section 5.2.3.5.a."@en ;
-            sh:order 44 ;
-            sh:path openlabel_v2:SignsInformation ],
-        [ sh:description "Artificial illumination type. Refer to BSI PAS-1883 Section 5.3.3.d."@en ;
-            sh:in ( openlabel_v2:ArtificialStreetLighting openlabel_v2:ArtificialVehicleLighting ) ;
-            sh:maxCount 1 ;
-            sh:message "IlluminationArtificial (OddEnvironment): Artificial illumination type. Refer to BSI PAS-1883 Section 5.3.3.d."@en ;
-            sh:order 15 ;
-            sh:path openlabel_v2:IlluminationArtificial ],
-        [ sh:description "Agent type. Refer to BSI PAS-1883 Section 5.4.a.4."@en ;
-            sh:maxCount 0 ;
-            sh:message "trafficAgentTypeValue (OddEnvironment): Agent type. Refer to BSI PAS-1883 Section 5.4.a.4."@en ;
-            sh:or ( [ sh:in ( openlabel_v2:HumanAnimalRider openlabel_v2:HumanCyclist openlabel_v2:HumanDriver openlabel_v2:HumanMotorcyclist openlabel_v2:HumanPassenger openlabel_v2:HumanPedestrian openlabel_v2:HumanWheelchairUser ) ] [ sh:in ( openlabel_v2:VehicleAgricultural openlabel_v2:VehicleBus openlabel_v2:VehicleCar openlabel_v2:VehicleConstruction openlabel_v2:VehicleCycle openlabel_v2:VehicleEmergency openlabel_v2:VehicleMotorcycle openlabel_v2:VehicleTrailer openlabel_v2:VehicleTruck openlabel_v2:VehicleVan openlabel_v2:VehicleWheelchair ) ] ) ;
-            sh:order 52 ;
-            sh:path openlabel_v2:trafficAgentTypeValue ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Volcanic ash flag. Refer to BSI PAS-1883 Section 5.3.2.e."@en ;
-            sh:maxCount 1 ;
-            sh:message "ParticulatesVolcanic (OddEnvironment): Volcanic ash flag. Refer to BSI PAS-1883 Section 5.3.2.e."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 36 ;
-            sh:path openlabel_v2:ParticulatesVolcanic ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Smoke and pollution flag. Refer to BSI PAS-1883 Section 5.3.2.d."@en ;
-            sh:maxCount 1 ;
-            sh:message "ParticulatesPollution (OddEnvironment): Smoke and pollution flag. Refer to BSI PAS-1883 Section 5.3.2.d."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 35 ;
-            sh:path openlabel_v2:ParticulatesPollution ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Visibility (km). Refer to BSI PAS-1883 Section 5.3.1.3."@en ;
-            sh:maxCount 1 ;
-            sh:message "weatherSnowValue (OddEnvironment): Visibility (km). Refer to BSI PAS-1883 Section 5.3.1.3."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 61 ;
-            sh:path openlabel_v2:weatherSnowValue ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Number of lanes flag. Refer to BSI PAS-1883 Section 5.2.3.4.d."@en ;
-            sh:maxCount 0 ;
-            sh:message "LaneSpecificationLaneCount (OddEnvironment): Number of lanes flag. Refer to BSI PAS-1883 Section 5.2.3.4.d."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 23 ;
-            sh:path openlabel_v2:LaneSpecificationLaneCount ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Lane marking flag. Refer to BSI PAS-1883 Section 5.2.3.4.b."@en ;
-            sh:maxCount 0 ;
-            sh:message "LaneSpecificationMarking (OddEnvironment): Lane marking flag. Refer to BSI PAS-1883 Section 5.2.3.4.b."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 25 ;
-            sh:path openlabel_v2:LaneSpecificationMarking ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Presence of special vehicles flag. Refer to BSI PAS-1883 Section 5.4.a.5."@en ;
-            sh:maxCount 0 ;
-            sh:message "TrafficSpecialVehicle (OddEnvironment): Presence of special vehicles flag. Refer to BSI PAS-1883 Section 5.4.a.5."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 55 ;
-            sh:path openlabel_v2:TrafficSpecialVehicle ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Traffic volume flag. Refer to BSI PAS-1883 Section 5.4.a.2."@en ;
-            sh:maxCount 0 ;
-            sh:message "TrafficVolume (OddEnvironment): Traffic volume flag. Refer to BSI PAS-1883 Section 5.4.a.2."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 56 ;
-            sh:path openlabel_v2:TrafficVolume ],
-        [ sh:description "Communication connectivity type. Refer to BSI PAS-1883 Section 5.3.4.a."@en ;
-            sh:in ( openlabel_v2:CommunicationV2i openlabel_v2:CommunicationV2v openlabel_v2:V2iCellular openlabel_v2:V2iSatellite openlabel_v2:V2iWifi openlabel_v2:V2vCellular openlabel_v2:V2vSatellite openlabel_v2:V2vWifi ) ;
-            sh:maxCount 1 ;
-            sh:message "ConnectivityCommunication (OddEnvironment): Communication connectivity type. Refer to BSI PAS-1883 Section 5.3.4.a."@en ;
-            sh:order 0 ;
-            sh:path openlabel_v2:ConnectivityCommunication ],
-        [ sh:description "Roundabout type. Refer to BSI PAS-1883 Section 5.2.4."@en ;
-            sh:in ( openlabel_v2:RoundaboutCompactNosignal openlabel_v2:RoundaboutCompactSignal openlabel_v2:RoundaboutDoubleNosignal openlabel_v2:RoundaboutDoubleSignal openlabel_v2:RoundaboutLargeNosignal openlabel_v2:RoundaboutLargeSignal openlabel_v2:RoundaboutMiniNosignal openlabel_v2:RoundaboutMiniSignal openlabel_v2:RoundaboutNormalNosignal openlabel_v2:RoundaboutNormalSignal ) ;
-            sh:maxCount 0 ;
-            sh:message "JunctionRoundabout (OddEnvironment): Roundabout type. Refer to BSI PAS-1883 Section 5.2.4."@en ;
-            sh:order 20 ;
-            sh:path openlabel_v2:JunctionRoundabout ],
-        [ sh:description "Low light condition. Refer to BSI PAS-1883 Section 5.3.3.b."@en ;
-            sh:in ( openlabel_v2:LowLightAmbient openlabel_v2:LowLightNight ) ;
-            sh:maxCount 1 ;
-            sh:message "IlluminationLowLight (OddEnvironment): Low light condition. Refer to BSI PAS-1883 Section 5.3.3.b."@en ;
-            sh:order 18 ;
-            sh:path openlabel_v2:IlluminationLowLight ],
-        [ sh:description "Speed (km/h). Refer to BSI PAS-1883 Section 5.4.b."@en ;
-            sh:maxCount 0 ;
-            sh:message "subjectVehicleSpeedValue (OddEnvironment): Speed (km/h). Refer to BSI PAS-1883 Section 5.4.b."@en ;
-            sh:or ( [ sh:datatype xsd:integer ;
-                        sh:nodeKind sh:Literal ] [ sh:class schema:QuantitativeValue ] ) ;
-            sh:order 48 ;
-            sh:path openlabel_v2:subjectVehicleSpeedValue ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Level plane flag. Refer to BSI PAS-1883 Section 5.2.3.3.iii."@en ;
-            sh:maxCount 0 ;
-            sh:message "LongitudinalLevelPlane (OddEnvironment): Level plane flag. Refer to BSI PAS-1883 Section 5.2.3.3.iii."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 30 ;
-            sh:path openlabel_v2:LongitudinalLevelPlane ],
-        [ sh:description "Zone type. Refer to BSI PAS-1883 Section 5.2.1.a."@en ;
-            sh:in ( openlabel_v2:ZoneGeoFenced openlabel_v2:ZoneInterference openlabel_v2:ZoneRegion openlabel_v2:ZoneSchool openlabel_v2:ZoneTrafficManagement ) ;
-            sh:maxCount 0 ;
-            sh:message "SceneryZone (OddEnvironment): Zone type. Refer to BSI PAS-1883 Section 5.2.1.a."@en ;
-            sh:order 43 ;
-            sh:path openlabel_v2:SceneryZone ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Cloudiness flag. Refer to BSI PAS-1883 Section 5.3.3.c."@en ;
-            sh:maxCount 1 ;
-            sh:message "IlluminationCloudiness (OddEnvironment): Cloudiness flag. Refer to BSI PAS-1883 Section 5.3.3.c."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 16 ;
-            sh:path openlabel_v2:IlluminationCloudiness ],
-        [ sh:description "Particulate type. Refer to BSI PAS-1883 Section 5.3.2."@en ;
-            sh:in ( openlabel_v2:ParticulatesDust openlabel_v2:ParticulatesMarine openlabel_v2:ParticulatesPollution openlabel_v2:ParticulatesVolcanic openlabel_v2:ParticulatesWater ) ;
-            sh:maxCount 1 ;
-            sh:message "EnvironmentParticulates (OddEnvironment): Particulate type. Refer to BSI PAS-1883 Section 5.3.2."@en ;
-            sh:order 10 ;
-            sh:path openlabel_v2:EnvironmentParticulates ],
-        [ sh:description "Warning sign type. Refer to BSI PAS-1883 Section 5.2.3.5.c."@en ;
-            sh:in ( openlabel_v2:WarningSignsUniform openlabel_v2:WarningSignsUniformFullTime openlabel_v2:WarningSignsUniformTemporary openlabel_v2:WarningSignsVariableFullTime openlabel_v2:WarningSignsVariableTemporary ) ;
-            sh:maxCount 0 ;
-            sh:message "SignsWarning (OddEnvironment): Warning sign type. Refer to BSI PAS-1883 Section 5.2.3.5.c."@en ;
-            sh:order 46 ;
-            sh:path openlabel_v2:SignsWarning ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.ii."@en ;
-            sh:maxCount 0 ;
-            sh:message "longitudinalDownSlopeValue (OddEnvironment): Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.ii."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 29 ;
-            sh:path openlabel_v2:longitudinalDownSlopeValue ],
-        [ sh:description "Transverse geometry type. Refer to BSI PAS-1883 Section 5.2.3.3.b."@en ;
-            sh:in ( openlabel_v2:TransverseBarriers openlabel_v2:TransverseDivided openlabel_v2:TransverseLanesTogether openlabel_v2:TransversePavements openlabel_v2:TransverseUndivided ) ;
-            sh:maxCount 0 ;
-            sh:message "GeometryTransverse (OddEnvironment): Transverse geometry type. Refer to BSI PAS-1883 Section 5.2.3.3.b."@en ;
-            sh:order 11 ;
-            sh:path openlabel_v2:GeometryTransverse ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Traffic flow rate flag. Refer to BSI PAS-1883 Section 5.4.a.3."@en ;
-            sh:maxCount 0 ;
-            sh:message "TrafficFlowRate (OddEnvironment): Traffic flow rate flag. Refer to BSI PAS-1883 Section 5.4.a.3."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 53 ;
-            sh:path openlabel_v2:TrafficFlowRate ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Snowfall flag. Refer to BSI PAS-1883 Section 5.3.1.3."@en ;
-            sh:maxCount 1 ;
-            sh:message "WeatherSnow (OddEnvironment): Snowfall flag. Refer to BSI PAS-1883 Section 5.3.1.3."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 60 ;
-            sh:path openlabel_v2:WeatherSnow ],
-        [ sh:description "Number of lanes (unit). Refer to BSI PAS-1883 Section 5.2.3.4.d."@en ;
-            sh:maxCount 0 ;
-            sh:message "laneSpecificationLaneCountValue (OddEnvironment): Number of lanes (unit). Refer to BSI PAS-1883 Section 5.2.3.4.d."@en ;
-            sh:or ( [ sh:datatype xsd:integer ;
-                        sh:nodeKind sh:Literal ] [ sh:class schema:QuantitativeValue ] ) ;
-            sh:order 24 ;
-            sh:path openlabel_v2:laneSpecificationLaneCountValue ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Meteorological Optical Range (MOR) (m). Refer to BSI PAS-1883 Section 5.3.2.b."@en ;
-            sh:maxCount 1 ;
-            sh:message "particulatesWaterValue (OddEnvironment): Meteorological Optical Range (MOR) (m). Refer to BSI PAS-1883 Section 5.3.2.b."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 38 ;
-            sh:path openlabel_v2:particulatesWaterValue ],
-        [ sh:description "Lane type. Refer to BSI PAS-1883 Section 5.2.3.4.c."@en ;
-            sh:in ( openlabel_v2:LaneTypeBus openlabel_v2:LaneTypeCycle openlabel_v2:LaneTypeEmergency openlabel_v2:LaneTypeSpecial openlabel_v2:LaneTypeTraffic openlabel_v2:LaneTypeTram ) ;
-            sh:maxCount 0 ;
-            sh:message "LaneSpecificationType (OddEnvironment): Lane type. Refer to BSI PAS-1883 Section 5.2.3.4.c."@en ;
-            sh:order 27 ;
-            sh:path openlabel_v2:LaneSpecificationType ],
-        [ sh:description "Lane width (m). Refer to BSI PAS-1883 Section 5.2.3.4.a."@en ;
-            sh:maxCount 0 ;
-            sh:message "laneSpecificationDimensionsValue (OddEnvironment): Lane width (m). Refer to BSI PAS-1883 Section 5.2.3.4.a."@en ;
-            sh:or ( [ sh:datatype xsd:decimal ;
-                        sh:nodeKind sh:Literal ] [ sh:class schema:QuantitativeValue ] ) ;
-            sh:order 22 ;
-            sh:path openlabel_v2:laneSpecificationDimensionsValue ],
-        [ sh:description "Road surface condition. Refer to BSI PAS-1883 Section 5.2.3.7.c."@en ;
-            sh:in ( openlabel_v2:SurfaceConditionContamination openlabel_v2:SurfaceConditionFlooded openlabel_v2:SurfaceConditionIcy openlabel_v2:SurfaceConditionMirage openlabel_v2:SurfaceConditionSnow openlabel_v2:SurfaceConditionStandingWater openlabel_v2:SurfaceConditionWet ) ;
-            sh:maxCount 0 ;
-            sh:message "DrivableAreaSurfaceCondition (OddEnvironment): Road surface condition. Refer to BSI PAS-1883 Section 5.2.3.7.c."@en ;
-            sh:order 6 ;
-            sh:path openlabel_v2:DrivableAreaSurfaceCondition ],
-        [ sh:description "Temporary road structure. Refer to BSI PAS-1883 Section 5.2.1.f."@en ;
-            sh:in ( openlabel_v2:TemporaryStructureConstructionDetour openlabel_v2:TemporaryStructureRefuseCollection openlabel_v2:TemporaryStructureRoadSignage openlabel_v2:TemporaryStructureRoadWorks ) ;
-            sh:maxCount 0 ;
-            sh:message "SceneryTemporaryStructure (OddEnvironment): Temporary road structure. Refer to BSI PAS-1883 Section 5.2.1.f."@en ;
-            sh:order 42 ;
-            sh:path openlabel_v2:SceneryTemporaryStructure ],
-        [ sh:description "Road type. Refer to BSI PAS-1883 Section 5.2.3.2."@en ;
-            sh:in ( openlabel_v2:MotorwayManaged openlabel_v2:MotorwayUnmanaged openlabel_v2:RoadTypeDistributor openlabel_v2:RoadTypeMinor openlabel_v2:RoadTypeMotorway openlabel_v2:RoadTypeParking openlabel_v2:RoadTypeRadial openlabel_v2:RoadTypeShared openlabel_v2:RoadTypeSlip ) ;
-            sh:maxCount 0 ;
-            sh:message "DrivableAreaType (OddEnvironment): Road type. Refer to BSI PAS-1883 Section 5.2.3.2."@en ;
-            sh:order 9 ;
-            sh:path openlabel_v2:DrivableAreaType ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Curves flag. Refer to BSI PAS-1883 Section 5.2.3.3."@en ;
-            sh:maxCount 0 ;
-            sh:message "HorizontalCurves (OddEnvironment): Curves flag. Refer to BSI PAS-1883 Section 5.2.3.3."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 12 ;
-            sh:path openlabel_v2:HorizontalCurves ],
-        [ sh:description "Rainfall type. Refer to BSI PAS-1883 Section 5.3.1.2."@en ;
-            sh:in ( openlabel_v2:RainTypeConvective openlabel_v2:RainTypeDynamic openlabel_v2:RainTypeOrographic ) ;
-            sh:maxCount 1 ;
-            sh:message "RainType (OddEnvironment): Rainfall type. Refer to BSI PAS-1883 Section 5.3.1.2."@en ;
-            sh:order 39 ;
-            sh:path openlabel_v2:RainType ],
-        [ sh:description "Intersection type. Refer to BSI PAS-1883 Section 5.2.4."@en ;
-            sh:in ( openlabel_v2:IntersectionCrossroad openlabel_v2:IntersectionGradeSeperated openlabel_v2:IntersectionStaggered openlabel_v2:IntersectionTJunction openlabel_v2:IntersectionYJunction ) ;
-            sh:maxCount 0 ;
-            sh:message "JunctionIntersection (OddEnvironment): Intersection type. Refer to BSI PAS-1883 Section 5.2.4."@en ;
-            sh:order 19 ;
-            sh:path openlabel_v2:JunctionIntersection ],
-        [ sh:description "Special road structure. Refer to BSI PAS-1883 Section 5.2.1.d."@en ;
-            sh:in ( openlabel_v2:SpecialStructureAutoAccess openlabel_v2:SpecialStructureBridge openlabel_v2:SpecialStructurePedestrianCrossing openlabel_v2:SpecialStructureRailCrossing openlabel_v2:SpecialStructureTollPlaza openlabel_v2:SpecialStructureTunnel ) ;
-            sh:maxCount 0 ;
-            sh:message "ScenerySpecialStructure (OddEnvironment): Special road structure. Refer to BSI PAS-1883 Section 5.2.1.d."@en ;
-            sh:order 41 ;
-            sh:path openlabel_v2:ScenerySpecialStructure ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Straight lines flag. Refer to BSI PAS-1883 Section 5.2.3.3."@en ;
-            sh:maxCount 0 ;
-            sh:message "HorizontalStraights (OddEnvironment): Straight lines flag. Refer to BSI PAS-1883 Section 5.2.3.3."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 14 ;
-            sh:path openlabel_v2:HorizontalStraights ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Traffic agent type classification flag. Refer to BSI PAS-1883 Section 5.4.a.4."@en ;
-            sh:maxCount 0 ;
-            sh:message "TrafficAgentType (OddEnvironment): Traffic agent type classification flag. Refer to BSI PAS-1883 Section 5.4.a.4."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 51 ;
-            sh:path openlabel_v2:TrafficAgentType ] ;
-    sh:targetClass openlabel_v2:OddEnvironment .
-
-openlabel_v2:OddScenery a sh:NodeShape ;
-    rdfs:comment "Scenery-related subset of the Operational Design Domain. Covers drivable area, geometry, lane specifications, junctions, signs, and structures. Refer to BSI PAS-1883 Section 5.2."@en ;
-    sh:closed true ;
-    sh:ignoredProperties ( rdf:type ) ;
-    sh:property [ sh:datatype xsd:boolean ;
-            sh:description "Subject vehicle speed flag. Refer to BSI PAS-1883 Section 5.4.b."@en ;
-            sh:maxCount 0 ;
-            sh:message "SubjectVehicleSpeed (OddScenery): Subject vehicle speed flag. Refer to BSI PAS-1883 Section 5.4.b."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 47 ;
-            sh:path openlabel_v2:SubjectVehicleSpeed ],
-        [ sh:description "Direction of travel. Refer to BSI PAS-1883 Section 5.2.3.4.e."@en ;
-            sh:in ( openlabel_v2:TravelDirectionLeft openlabel_v2:TravelDirectionRight ) ;
-            sh:maxCount 1 ;
-            sh:message "LaneSpecificationTravelDirection (OddScenery): Direction of travel. Refer to BSI PAS-1883 Section 5.2.3.4.e."@en ;
-            sh:order 26 ;
-            sh:path openlabel_v2:LaneSpecificationTravelDirection ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Curve radius (m). Refer to BSI PAS-1883 Section 5.2.3.3."@en ;
-            sh:maxCount 1 ;
-            sh:message "horizontalCurvesValue (OddScenery): Curve radius (m). Refer to BSI PAS-1883 Section 5.2.3.3."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 13 ;
-            sh:path openlabel_v2:horizontalCurvesValue ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Traffic agent type classification flag. Refer to BSI PAS-1883 Section 5.4.a.4."@en ;
-            sh:maxCount 0 ;
-            sh:message "TrafficAgentType (OddScenery): Traffic agent type classification flag. Refer to BSI PAS-1883 Section 5.4.a.4."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 51 ;
-            sh:path openlabel_v2:TrafficAgentType ],
-        [ sh:description "Lane width (m). Refer to BSI PAS-1883 Section 5.2.3.4.a."@en ;
-            sh:maxCount 1 ;
-            sh:message "laneSpecificationDimensionsValue (OddScenery): Lane width (m). Refer to BSI PAS-1883 Section 5.2.3.4.a."@en ;
-            sh:or ( [ sh:datatype xsd:decimal ;
-                        sh:nodeKind sh:Literal ] [ sh:class schema:QuantitativeValue ] ) ;
-            sh:order 22 ;
-            sh:path openlabel_v2:laneSpecificationDimensionsValue ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Meteorological Optical Range (MOR) (m). Refer to BSI PAS-1883 Section 5.3.2.b."@en ;
-            sh:maxCount 0 ;
-            sh:message "particulatesWaterValue (OddScenery): Meteorological Optical Range (MOR) (m). Refer to BSI PAS-1883 Section 5.3.2.b."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 38 ;
-            sh:path openlabel_v2:particulatesWaterValue ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Traffic agent density flag. Refer to BSI PAS-1883 Section 5.4.a.1."@en ;
-            sh:maxCount 0 ;
-            sh:message "TrafficAgentDensity (OddScenery): Traffic agent density flag. Refer to BSI PAS-1883 Section 5.4.a.1."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 49 ;
-            sh:path openlabel_v2:TrafficAgentDensity ],
-        [ sh:description "Rainfall type. Refer to BSI PAS-1883 Section 5.3.1.2."@en ;
-            sh:in ( openlabel_v2:RainTypeConvective openlabel_v2:RainTypeDynamic openlabel_v2:RainTypeOrographic ) ;
-            sh:maxCount 0 ;
-            sh:message "RainType (OddScenery): Rainfall type. Refer to BSI PAS-1883 Section 5.3.1.2."@en ;
-            sh:order 39 ;
-            sh:path openlabel_v2:RainType ],
-        [ sh:description "Position of the sun. Refer to BSI PAS-1883 Section 5.3.3.a.2."@en ;
-            sh:in ( openlabel_v2:SunPositionBehind openlabel_v2:SunPositionFront openlabel_v2:SunPositionLeft openlabel_v2:SunPositionRight ) ;
-            sh:maxCount 0 ;
-            sh:message "DaySunPosition (OddScenery): Position of the sun. Refer to BSI PAS-1883 Section 5.3.3.a.2."@en ;
-            sh:order 4 ;
-            sh:path openlabel_v2:DaySunPosition ],
-        [ sh:description "Road type. Refer to BSI PAS-1883 Section 5.2.3.2."@en ;
-            sh:in ( openlabel_v2:MotorwayManaged openlabel_v2:MotorwayUnmanaged openlabel_v2:RoadTypeDistributor openlabel_v2:RoadTypeMinor openlabel_v2:RoadTypeMotorway openlabel_v2:RoadTypeParking openlabel_v2:RoadTypeRadial openlabel_v2:RoadTypeShared openlabel_v2:RoadTypeSlip ) ;
-            sh:maxCount 1 ;
-            sh:message "DrivableAreaType (OddScenery): Road type. Refer to BSI PAS-1883 Section 5.2.3.2."@en ;
-            sh:order 9 ;
-            sh:path openlabel_v2:DrivableAreaType ],
-        [ sh:description "Regulatory sign type. Refer to BSI PAS-1883 Section 5.2.3.5.b."@en ;
-            sh:in ( openlabel_v2:RegulatorySignsUniformFullTime openlabel_v2:RegulatorySignsUniformTemporary openlabel_v2:RegulatorySignsVariableFullTime openlabel_v2:RegulatorySignsVariableTemporary ) ;
-            sh:maxCount 1 ;
-            sh:message "SignsRegulatory (OddScenery): Regulatory sign type. Refer to BSI PAS-1883 Section 5.2.3.5.b."@en ;
-            sh:order 45 ;
-            sh:path openlabel_v2:SignsRegulatory ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Straight lines flag. Refer to BSI PAS-1883 Section 5.2.3.3."@en ;
-            sh:maxCount 1 ;
-            sh:message "HorizontalStraights (OddScenery): Straight lines flag. Refer to BSI PAS-1883 Section 5.2.3.3."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 14 ;
-            sh:path openlabel_v2:HorizontalStraights ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Sun elevation (degrees). Refer to BSI PAS-1883 Section 5.3.3.a.1."@en ;
-            sh:maxCount 0 ;
-            sh:message "daySunElevationValue (OddScenery): Sun elevation (degrees). Refer to BSI PAS-1883 Section 5.3.3.a.1."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 3 ;
-            sh:path openlabel_v2:daySunElevationValue ],
-        [ sh:description "Road surface condition. Refer to BSI PAS-1883 Section 5.2.3.7.c."@en ;
-            sh:in ( openlabel_v2:SurfaceConditionContamination openlabel_v2:SurfaceConditionFlooded openlabel_v2:SurfaceConditionIcy openlabel_v2:SurfaceConditionMirage openlabel_v2:SurfaceConditionSnow openlabel_v2:SurfaceConditionStandingWater openlabel_v2:SurfaceConditionWet ) ;
-            sh:maxCount 1 ;
-            sh:message "DrivableAreaSurfaceCondition (OddScenery): Road surface condition. Refer to BSI PAS-1883 Section 5.2.3.7.c."@en ;
-            sh:order 6 ;
-            sh:path openlabel_v2:DrivableAreaSurfaceCondition ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Traffic volume flag. Refer to BSI PAS-1883 Section 5.4.a.2."@en ;
-            sh:maxCount 0 ;
-            sh:message "TrafficVolume (OddScenery): Traffic volume flag. Refer to BSI PAS-1883 Section 5.4.a.2."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 56 ;
-            sh:path openlabel_v2:TrafficVolume ],
-        [ sh:datatype xsd:integer ;
-            sh:description "Rate (vehicles/h). Refer to BSI PAS-1883 Section 5.4.a.3."@en ;
-            sh:maxCount 0 ;
-            sh:message "trafficFlowRateValue (OddScenery): Rate (vehicles/h). Refer to BSI PAS-1883 Section 5.4.a.3."@en ;
-            sh:minInclusive 0 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 54 ;
-            sh:path openlabel_v2:trafficFlowRateValue ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Smoke and pollution flag. Refer to BSI PAS-1883 Section 5.3.2.d."@en ;
-            sh:maxCount 0 ;
-            sh:message "ParticulatesPollution (OddScenery): Smoke and pollution flag. Refer to BSI PAS-1883 Section 5.3.2.d."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 35 ;
-            sh:path openlabel_v2:ParticulatesPollution ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Traffic flow rate flag. Refer to BSI PAS-1883 Section 5.4.a.3."@en ;
-            sh:maxCount 0 ;
-            sh:message "TrafficFlowRate (OddScenery): Traffic flow rate flag. Refer to BSI PAS-1883 Section 5.4.a.3."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 53 ;
-            sh:path openlabel_v2:TrafficFlowRate ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Down-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.ii."@en ;
-            sh:maxCount 1 ;
-            sh:message "LongitudinalDownSlope (OddScenery): Down-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.ii."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 28 ;
-            sh:path openlabel_v2:LongitudinalDownSlope ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Wind speed (m/s). Refer to BSI PAS-1883 Section 5.3.1.1."@en ;
-            sh:maxCount 0 ;
-            sh:message "weatherWindValue (OddScenery): Wind speed (m/s). Refer to BSI PAS-1883 Section 5.3.1.1."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 63 ;
-            sh:path openlabel_v2:weatherWindValue ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Sand and dust flag. Refer to BSI PAS-1883 Section 5.3.2.c."@en ;
-            sh:maxCount 0 ;
-            sh:message "ParticulatesDust (OddScenery): Sand and dust flag. Refer to BSI PAS-1883 Section 5.3.2.c."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 33 ;
-            sh:path openlabel_v2:ParticulatesDust ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Non-precipitating water droplets or ice crystals (mist/fog) flag. Refer to BSI PAS-1883 Section 5.3.2.b."@en ;
-            sh:maxCount 0 ;
-            sh:message "ParticulatesWater (OddScenery): Non-precipitating water droplets or ice crystals (mist/fog) flag. Refer to BSI PAS-1883 Section 5.3.2.b."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 37 ;
-            sh:path openlabel_v2:ParticulatesWater ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Lane marking flag. Refer to BSI PAS-1883 Section 5.2.3.4.b."@en ;
-            sh:maxCount 1 ;
-            sh:message "LaneSpecificationMarking (OddScenery): Lane marking flag. Refer to BSI PAS-1883 Section 5.2.3.4.b."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 25 ;
-            sh:path openlabel_v2:LaneSpecificationMarking ],
-        [ sh:description "Speed (km/h). Refer to BSI PAS-1883 Section 5.4.b."@en ;
-            sh:maxCount 0 ;
-            sh:message "subjectVehicleSpeedValue (OddScenery): Speed (km/h). Refer to BSI PAS-1883 Section 5.4.b."@en ;
-            sh:or ( [ sh:datatype xsd:integer ;
-                        sh:nodeKind sh:Literal ] [ sh:class schema:QuantitativeValue ] ) ;
-            sh:order 48 ;
-            sh:path openlabel_v2:subjectVehicleSpeedValue ],
-        [ sh:description "Road surface type. Refer to BSI PAS-1883 Section 5.2.3.7.a."@en ;
-            sh:in ( openlabel_v2:SurfaceTypeLoose openlabel_v2:SurfaceTypeSegmented openlabel_v2:SurfaceTypeUniform ) ;
-            sh:maxCount 1 ;
-            sh:message "DrivableAreaSurfaceType (OddScenery): Road surface type. Refer to BSI PAS-1883 Section 5.2.3.7.a."@en ;
-            sh:order 8 ;
-            sh:path openlabel_v2:DrivableAreaSurfaceType ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Volcanic ash flag. Refer to BSI PAS-1883 Section 5.3.2.e."@en ;
-            sh:maxCount 0 ;
-            sh:message "ParticulatesVolcanic (OddScenery): Volcanic ash flag. Refer to BSI PAS-1883 Section 5.3.2.e."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 36 ;
-            sh:path openlabel_v2:ParticulatesVolcanic ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Up-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.i."@en ;
-            sh:maxCount 1 ;
-            sh:message "LongitudinalUpSlope (OddScenery): Up-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.i."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 31 ;
-            sh:path openlabel_v2:LongitudinalUpSlope ],
-        [ sh:description "Lane type. Refer to BSI PAS-1883 Section 5.2.3.4.c."@en ;
-            sh:in ( openlabel_v2:LaneTypeBus openlabel_v2:LaneTypeCycle openlabel_v2:LaneTypeEmergency openlabel_v2:LaneTypeSpecial openlabel_v2:LaneTypeTraffic openlabel_v2:LaneTypeTram ) ;
-            sh:message "LaneSpecificationType (OddScenery): Lane type. Refer to BSI PAS-1883 Section 5.2.3.4.c."@en ;
-            sh:order 27 ;
-            sh:path openlabel_v2:LaneSpecificationType ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Presence of special vehicles flag. Refer to BSI PAS-1883 Section 5.4.a.5."@en ;
-            sh:maxCount 0 ;
-            sh:message "TrafficSpecialVehicle (OddScenery): Presence of special vehicles flag. Refer to BSI PAS-1883 Section 5.4.a.5."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 55 ;
-            sh:path openlabel_v2:TrafficSpecialVehicle ],
-        [ sh:description "Communication connectivity type. Refer to BSI PAS-1883 Section 5.3.4.a."@en ;
-            sh:in ( openlabel_v2:CommunicationV2i openlabel_v2:CommunicationV2v openlabel_v2:V2iCellular openlabel_v2:V2iSatellite openlabel_v2:V2iWifi openlabel_v2:V2vCellular openlabel_v2:V2vSatellite openlabel_v2:V2vWifi ) ;
-            sh:maxCount 0 ;
-            sh:message "ConnectivityCommunication (OddScenery): Communication connectivity type. Refer to BSI PAS-1883 Section 5.3.4.a."@en ;
-            sh:order 0 ;
-            sh:path openlabel_v2:ConnectivityCommunication ],
-        [ sh:description "Zone type. Refer to BSI PAS-1883 Section 5.2.1.a."@en ;
-            sh:in ( openlabel_v2:ZoneGeoFenced openlabel_v2:ZoneInterference openlabel_v2:ZoneRegion openlabel_v2:ZoneSchool openlabel_v2:ZoneTrafficManagement ) ;
-            sh:maxCount 1 ;
-            sh:message "SceneryZone (OddScenery): Zone type. Refer to BSI PAS-1883 Section 5.2.1.a."@en ;
-            sh:order 43 ;
-            sh:path openlabel_v2:SceneryZone ],
-        [ sh:description "Warning sign type. Refer to BSI PAS-1883 Section 5.2.3.5.c."@en ;
-            sh:in ( openlabel_v2:WarningSignsUniform openlabel_v2:WarningSignsUniformFullTime openlabel_v2:WarningSignsUniformTemporary openlabel_v2:WarningSignsVariableFullTime openlabel_v2:WarningSignsVariableTemporary ) ;
-            sh:maxCount 1 ;
-            sh:message "SignsWarning (OddScenery): Warning sign type. Refer to BSI PAS-1883 Section 5.2.3.5.c."@en ;
-            sh:order 46 ;
-            sh:path openlabel_v2:SignsWarning ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Cloudiness flag. Refer to BSI PAS-1883 Section 5.3.3.c."@en ;
-            sh:maxCount 0 ;
-            sh:message "IlluminationCloudiness (OddScenery): Cloudiness flag. Refer to BSI PAS-1883 Section 5.3.3.c."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 16 ;
-            sh:path openlabel_v2:IlluminationCloudiness ],
-        [ sh:description "Low light condition. Refer to BSI PAS-1883 Section 5.3.3.b."@en ;
-            sh:in ( openlabel_v2:LowLightAmbient openlabel_v2:LowLightNight ) ;
-            sh:maxCount 0 ;
-            sh:message "IlluminationLowLight (OddScenery): Low light condition. Refer to BSI PAS-1883 Section 5.3.3.b."@en ;
-            sh:order 18 ;
-            sh:path openlabel_v2:IlluminationLowLight ],
-        [ sh:description "Number of lanes (unit). Refer to BSI PAS-1883 Section 5.2.3.4.d."@en ;
-            sh:maxCount 1 ;
-            sh:message "laneSpecificationLaneCountValue (OddScenery): Number of lanes (unit). Refer to BSI PAS-1883 Section 5.2.3.4.d."@en ;
-            sh:or ( [ sh:datatype xsd:integer ;
-                        sh:nodeKind sh:Literal ] [ sh:class schema:QuantitativeValue ] ) ;
-            sh:order 24 ;
-            sh:path openlabel_v2:laneSpecificationLaneCountValue ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.i."@en ;
-            sh:maxCount 1 ;
-            sh:message "longitudinalUpSlopeValue (OddScenery): Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.i."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 32 ;
-            sh:path openlabel_v2:longitudinalUpSlopeValue ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Rainfall intensity (mm/h). Refer to BSI PAS-1883 Section 5.3.1.2."@en ;
-            sh:maxCount 0 ;
-            sh:message "weatherRainValue (OddScenery): Rainfall intensity (mm/h). Refer to BSI PAS-1883 Section 5.3.1.2."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 59 ;
-            sh:path openlabel_v2:weatherRainValue ],
-        [ sh:datatype xsd:integer ;
-            sh:description "Volume (vehicle km). Refer to BSI PAS-1883 Section 5.4.a.2."@en ;
-            sh:maxCount 0 ;
-            sh:message "trafficVolumeValue (OddScenery): Volume (vehicle km). Refer to BSI PAS-1883 Section 5.4.a.2."@en ;
-            sh:minInclusive 0 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 57 ;
-            sh:path openlabel_v2:trafficVolumeValue ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Wind flag. Refer to BSI PAS-1883 Section 5.3.1.1."@en ;
-            sh:maxCount 0 ;
-            sh:message "WeatherWind (OddScenery): Wind flag. Refer to BSI PAS-1883 Section 5.3.1.1."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 62 ;
-            sh:path openlabel_v2:WeatherWind ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Curves flag. Refer to BSI PAS-1883 Section 5.2.3.3."@en ;
-            sh:maxCount 1 ;
-            sh:message "HorizontalCurves (OddScenery): Curves flag. Refer to BSI PAS-1883 Section 5.2.3.3."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 12 ;
-            sh:path openlabel_v2:HorizontalCurves ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Lane dimensions flag. Refer to BSI PAS-1883 Section 5.2.3.4.a."@en ;
-            sh:maxCount 1 ;
-            sh:message "LaneSpecificationDimensions (OddScenery): Lane dimensions flag. Refer to BSI PAS-1883 Section 5.2.3.4.a."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 21 ;
-            sh:path openlabel_v2:LaneSpecificationDimensions ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Number of lanes flag. Refer to BSI PAS-1883 Section 5.2.3.4.d."@en ;
-            sh:maxCount 1 ;
-            sh:message "LaneSpecificationLaneCount (OddScenery): Number of lanes flag. Refer to BSI PAS-1883 Section 5.2.3.4.d."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 23 ;
-            sh:path openlabel_v2:LaneSpecificationLaneCount ],
-        [ sh:description "Information sign type. Refer to BSI PAS-1883 Section 5.2.3.5.a."@en ;
-            sh:in ( openlabel_v2:InformationSignsUniformFullTime openlabel_v2:InformationSignsUniformTemporary openlabel_v2:InformationSignsVariableFullTime openlabel_v2:InformationSignsVariableTemporary ) ;
-            sh:maxCount 1 ;
-            sh:message "SignsInformation (OddScenery): Information sign type. Refer to BSI PAS-1883 Section 5.2.3.5.a."@en ;
-            sh:order 44 ;
-            sh:path openlabel_v2:SignsInformation ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Level plane flag. Refer to BSI PAS-1883 Section 5.2.3.3.iii."@en ;
-            sh:maxCount 1 ;
-            sh:message "LongitudinalLevelPlane (OddScenery): Level plane flag. Refer to BSI PAS-1883 Section 5.2.3.3.iii."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 30 ;
-            sh:path openlabel_v2:LongitudinalLevelPlane ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Visibility (km). Refer to BSI PAS-1883 Section 5.3.1.3."@en ;
-            sh:maxCount 0 ;
-            sh:message "weatherSnowValue (OddScenery): Visibility (km). Refer to BSI PAS-1883 Section 5.3.1.3."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 61 ;
-            sh:path openlabel_v2:weatherSnowValue ],
-        [ sh:description "Drivable area edge type. Refer to BSI PAS-1883 Section 5.2.3.1.e."@en ;
-            sh:in ( openlabel_v2:EdgeLineMarkers openlabel_v2:EdgeNone openlabel_v2:EdgeShoulderGrass openlabel_v2:EdgeShoulderPavedOrGravel openlabel_v2:EdgeSolidBarriers openlabel_v2:EdgeTemporaryLineMarkers ) ;
-            sh:message "DrivableAreaEdge (OddScenery): Drivable area edge type. Refer to BSI PAS-1883 Section 5.2.3.1.e."@en ;
-            sh:order 5 ;
-            sh:path openlabel_v2:DrivableAreaEdge ],
-        [ sh:description "Particulate type. Refer to BSI PAS-1883 Section 5.3.2."@en ;
-            sh:in ( openlabel_v2:ParticulatesDust openlabel_v2:ParticulatesMarine openlabel_v2:ParticulatesPollution openlabel_v2:ParticulatesVolcanic openlabel_v2:ParticulatesWater ) ;
-            sh:maxCount 0 ;
-            sh:message "EnvironmentParticulates (OddScenery): Particulate type. Refer to BSI PAS-1883 Section 5.3.2."@en ;
-            sh:order 10 ;
-            sh:path openlabel_v2:EnvironmentParticulates ],
-        [ sh:description "Artificial illumination type. Refer to BSI PAS-1883 Section 5.3.3.d."@en ;
-            sh:in ( openlabel_v2:ArtificialStreetLighting openlabel_v2:ArtificialVehicleLighting ) ;
-            sh:maxCount 0 ;
-            sh:message "IlluminationArtificial (OddScenery): Artificial illumination type. Refer to BSI PAS-1883 Section 5.3.3.d."@en ;
-            sh:order 15 ;
-            sh:path openlabel_v2:IlluminationArtificial ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Marine (coastal areas only) flag. Refer to BSI PAS-1883 Section 5.3.2.a."@en ;
-            sh:maxCount 0 ;
-            sh:message "ParticulatesMarine (OddScenery): Marine (coastal areas only) flag. Refer to BSI PAS-1883 Section 5.3.2.a."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 34 ;
-            sh:path openlabel_v2:ParticulatesMarine ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Snowfall flag. Refer to BSI PAS-1883 Section 5.3.1.3."@en ;
-            sh:maxCount 0 ;
-            sh:message "WeatherSnow (OddScenery): Snowfall flag. Refer to BSI PAS-1883 Section 5.3.1.3."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 60 ;
-            sh:path openlabel_v2:WeatherSnow ],
-        [ sh:description "Special road structure. Refer to BSI PAS-1883 Section 5.2.1.d."@en ;
-            sh:in ( openlabel_v2:SpecialStructureAutoAccess openlabel_v2:SpecialStructureBridge openlabel_v2:SpecialStructurePedestrianCrossing openlabel_v2:SpecialStructureRailCrossing openlabel_v2:SpecialStructureTollPlaza openlabel_v2:SpecialStructureTunnel ) ;
-            sh:maxCount 1 ;
-            sh:message "ScenerySpecialStructure (OddScenery): Special road structure. Refer to BSI PAS-1883 Section 5.2.1.d."@en ;
-            sh:order 41 ;
-            sh:path openlabel_v2:ScenerySpecialStructure ],
-        [ sh:description "Roundabout type. Refer to BSI PAS-1883 Section 5.2.4."@en ;
-            sh:in ( openlabel_v2:RoundaboutCompactNosignal openlabel_v2:RoundaboutCompactSignal openlabel_v2:RoundaboutDoubleNosignal openlabel_v2:RoundaboutDoubleSignal openlabel_v2:RoundaboutLargeNosignal openlabel_v2:RoundaboutLargeSignal openlabel_v2:RoundaboutMiniNosignal openlabel_v2:RoundaboutMiniSignal openlabel_v2:RoundaboutNormalNosignal openlabel_v2:RoundaboutNormalSignal ) ;
-            sh:maxCount 1 ;
-            sh:message "JunctionRoundabout (OddScenery): Roundabout type. Refer to BSI PAS-1883 Section 5.2.4."@en ;
-            sh:order 20 ;
-            sh:path openlabel_v2:JunctionRoundabout ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Cloud cover (okta). Refer to BSI PAS-1883 Section 5.3.3.c."@en ;
-            sh:maxCount 0 ;
-            sh:message "illuminationCloudinessValue (OddScenery): Cloud cover (okta). Refer to BSI PAS-1883 Section 5.3.3.c."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 17 ;
-            sh:path openlabel_v2:illuminationCloudinessValue ],
-        [ sh:description "Agent type. Refer to BSI PAS-1883 Section 5.4.a.4."@en ;
-            sh:maxCount 0 ;
-            sh:message "trafficAgentTypeValue (OddScenery): Agent type. Refer to BSI PAS-1883 Section 5.4.a.4."@en ;
-            sh:or ( [ sh:in ( openlabel_v2:HumanAnimalRider openlabel_v2:HumanCyclist openlabel_v2:HumanDriver openlabel_v2:HumanMotorcyclist openlabel_v2:HumanPassenger openlabel_v2:HumanPedestrian openlabel_v2:HumanWheelchairUser ) ] [ sh:in ( openlabel_v2:VehicleAgricultural openlabel_v2:VehicleBus openlabel_v2:VehicleCar openlabel_v2:VehicleConstruction openlabel_v2:VehicleCycle openlabel_v2:VehicleEmergency openlabel_v2:VehicleMotorcycle openlabel_v2:VehicleTrailer openlabel_v2:VehicleTruck openlabel_v2:VehicleVan openlabel_v2:VehicleWheelchair ) ] ) ;
-            sh:order 52 ;
-            sh:path openlabel_v2:trafficAgentTypeValue ],
-        [ sh:description "Positioning system type. Refer to BSI PAS-1883 Section 5.3.4.b."@en ;
-            sh:in ( openlabel_v2:PositioningGalileo openlabel_v2:PositioningGlonass openlabel_v2:PositioningGps ) ;
-            sh:maxCount 0 ;
-            sh:message "ConnectivityPositioning (OddScenery): Positioning system type. Refer to BSI PAS-1883 Section 5.3.4.b."@en ;
-            sh:order 1 ;
-            sh:path openlabel_v2:ConnectivityPositioning ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.ii."@en ;
-            sh:maxCount 1 ;
-            sh:message "longitudinalDownSlopeValue (OddScenery): Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.ii."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 29 ;
-            sh:path openlabel_v2:longitudinalDownSlopeValue ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Elevation of the sun above the horizon flag. Refer to BSI PAS-1883 Section 5.3.3.a.1."@en ;
-            sh:maxCount 0 ;
-            sh:message "DaySunElevation (OddScenery): Elevation of the sun above the horizon flag. Refer to BSI PAS-1883 Section 5.3.3.a.1."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 2 ;
-            sh:path openlabel_v2:DaySunElevation ],
-        [ sh:description "Fixed road structure. Refer to BSI PAS-1883 Section 5.2.1.e."@en ;
-            sh:in ( openlabel_v2:FixedStructureBuilding openlabel_v2:FixedStructureStreetFurniture openlabel_v2:FixedStructureStreetlight openlabel_v2:FixedStructureVegetation ) ;
-            sh:maxCount 1 ;
-            sh:message "SceneryFixedStructure (OddScenery): Fixed road structure. Refer to BSI PAS-1883 Section 5.2.1.e."@en ;
-            sh:order 40 ;
-            sh:path openlabel_v2:SceneryFixedStructure ],
-        [ sh:description "Intersection type. Refer to BSI PAS-1883 Section 5.2.4."@en ;
-            sh:in ( openlabel_v2:IntersectionCrossroad openlabel_v2:IntersectionGradeSeperated openlabel_v2:IntersectionStaggered openlabel_v2:IntersectionTJunction openlabel_v2:IntersectionYJunction ) ;
-            sh:maxCount 1 ;
-            sh:message "JunctionIntersection (OddScenery): Intersection type. Refer to BSI PAS-1883 Section 5.2.4."@en ;
-            sh:order 19 ;
-            sh:path openlabel_v2:JunctionIntersection ],
-        [ sh:description "Road surface feature. Refer to BSI PAS-1883 Section 5.2.3.7.b."@en ;
-            sh:in ( openlabel_v2:SurfaceFeatureCrack openlabel_v2:SurfaceFeaturePothole openlabel_v2:SurfaceFeatureRut openlabel_v2:SurfaceFeatureSwell ) ;
-            sh:maxCount 1 ;
-            sh:message "DrivableAreaSurfaceFeature (OddScenery): Road surface feature. Refer to BSI PAS-1883 Section 5.2.3.7.b."@en ;
-            sh:order 7 ;
-            sh:path openlabel_v2:DrivableAreaSurfaceFeature ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Rainfall flag. Refer to BSI PAS-1883 Section 5.3.1.2."@en ;
-            sh:maxCount 0 ;
-            sh:message "WeatherRain (OddScenery): Rainfall flag. Refer to BSI PAS-1883 Section 5.3.1.2."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 58 ;
-            sh:path openlabel_v2:WeatherRain ],
-        [ sh:description "Temporary road structure. Refer to BSI PAS-1883 Section 5.2.1.f."@en ;
-            sh:in ( openlabel_v2:TemporaryStructureConstructionDetour openlabel_v2:TemporaryStructureRefuseCollection openlabel_v2:TemporaryStructureRoadSignage openlabel_v2:TemporaryStructureRoadWorks ) ;
-            sh:maxCount 1 ;
-            sh:message "SceneryTemporaryStructure (OddScenery): Temporary road structure. Refer to BSI PAS-1883 Section 5.2.1.f."@en ;
-            sh:order 42 ;
-            sh:path openlabel_v2:SceneryTemporaryStructure ],
-        [ sh:description "Transverse geometry type. Refer to BSI PAS-1883 Section 5.2.3.3.b."@en ;
-            sh:in ( openlabel_v2:TransverseBarriers openlabel_v2:TransverseDivided openlabel_v2:TransverseLanesTogether openlabel_v2:TransversePavements openlabel_v2:TransverseUndivided ) ;
-            sh:maxCount 1 ;
-            sh:message "GeometryTransverse (OddScenery): Transverse geometry type. Refer to BSI PAS-1883 Section 5.2.3.3.b."@en ;
-            sh:order 11 ;
-            sh:path openlabel_v2:GeometryTransverse ],
-        [ sh:datatype xsd:integer ;
-            sh:description "Density (vehicles/km). Refer to BSI PAS-1883 Section 5.4.a.1."@en ;
-            sh:maxCount 0 ;
-            sh:message "trafficAgentDensityValue (OddScenery): Density (vehicles/km). Refer to BSI PAS-1883 Section 5.4.a.1."@en ;
-            sh:minInclusive 0 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 50 ;
-            sh:path openlabel_v2:trafficAgentDensityValue ] ;
-    sh:targetClass openlabel_v2:OddScenery .
-
-openlabel_v2:Scenario a sh:NodeShape ;
-    rdfs:comment "A scenario that can be tagged with OpenLABEL tags."@en ;
-    sh:closed true ;
-    sh:ignoredProperties ( rdf:type ) ;
-    sh:property [ sh:class openlabel_v2:Tag ;
-            sh:description "A tag associated with a scenario."@en ;
-            sh:maxCount 1 ;
-            sh:message "hasTag (Scenario): A tag associated with a scenario."@en ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 0 ;
-            sh:path openlabel_v2:hasTag ] ;
-    sh:targetClass openlabel_v2:Scenario .
-
-openlabel_v2:Tag a sh:NodeShape ;
-    rdfs:comment "The base tag."@en ;
-    sh:closed true ;
-    sh:ignoredProperties ( rdf:type ) ;
-    sh:property [ sh:class openlabel_v2:RoadUser ;
-            sh:description "Road user tag."@en ;
-            sh:maxCount 1 ;
-            sh:message "RoadUser (Tag): Road user tag."@en ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 3 ;
-            sh:path openlabel_v2:RoadUser ],
-        [ sh:class openlabel_v2:AdminTag ;
-            sh:description "Administration tag."@en ;
-            sh:maxCount 1 ;
-            sh:message "AdminTag (Tag): Administration tag."@en ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 0 ;
-            sh:path openlabel_v2:AdminTag ],
-        [ sh:class openlabel_v2:Behaviour ;
-            sh:description "Behaviour tag."@en ;
-            sh:maxCount 1 ;
-            sh:message "Behaviour (Tag): Behaviour tag."@en ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 1 ;
-            sh:path openlabel_v2:Behaviour ],
-        [ sh:class openlabel_v2:Odd ;
-            sh:description "Operational Design Domain tag."@en ;
-            sh:maxCount 1 ;
-            sh:message "Odd (Tag): Operational Design Domain tag."@en ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 2 ;
-            sh:path openlabel_v2:Odd ] ;
-    sh:targetClass openlabel_v2:Tag .
-
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix prof: <http://www.w3.org/ns/dx/prof/> .
+@prefix dcmitype: <http://purl.org/dc/dcmitype/> .
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix sosa: <http://www.w3.org/ns/sosa/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix ssn: <http://www.w3.org/ns/ssn/> .
+@prefix dcam: <http://purl.org/dc/dcam/> .
+@prefix linkml: <https://w3id.org/linkml/> .
+@prefix void: <http://rdfs.org/ns/void#> .
+@prefix sdo: <https://schema.org/> .
+sdo:QuantitativeValue a sh:NodeShape ;
+	rdfs:comment "A point value or interval for quantitative measurements. Requires minValue and maxValue." ;
+	sh:closed true ;
+	sh:ignoredProperties _:c14n102 ;
+	sh:property _:c14n113 , _:c14n138 , _:c14n193 , _:c14n91 ;
+	sh:targetClass sdo:QuantitativeValue .
 openlabel_v2:AdminTag a sh:NodeShape ;
-    rdfs:comment "The base tag to use when extending the Administration tags with new classes."@en ;
-    sh:closed true ;
-    sh:ignoredProperties ( rdf:type ) ;
-    sh:property [ sh:datatype xsd:dateTime ;
-            sh:description "The date that the scenario was created/published."@en ;
-            sh:maxCount 1 ;
-            sh:message "scenarioCreatedDate (AdminTag): The date that the scenario was created/published."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 4 ;
-            sh:path openlabel_v2:scenarioCreatedDate ],
-        [ sh:datatype xsd:string ;
-            sh:description "URI of SDL language used for the definition of the scenario."@en ;
-            sh:maxCount 1 ;
-            sh:message "scenarioDefinitionLanguageURI (AdminTag): URI of SDL language used for the definition of the scenario."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 6 ;
-            sh:path openlabel_v2:scenarioDefinitionLanguageURI ],
-        [ sh:datatype xsd:string ;
-            sh:description "SDL definition of the scenario."@en ;
-            sh:maxCount 1 ;
-            sh:message "scenarioDefinition (AdminTag): SDL definition of the scenario."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 5 ;
-            sh:path openlabel_v2:scenarioDefinition ],
-        [ sh:datatype xsd:string ;
-            sh:description "Universally unique identifier (UUID) which identifies the scenario which this one has been derived from."@en ;
-            sh:maxCount 1 ;
-            sh:message "scenarioParentReference (AdminTag): Universally unique identifier (UUID) which identifies the scenario which this one has been derived from."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 9 ;
-            sh:path openlabel_v2:scenarioParentReference ],
-        [ sh:datatype xsd:string ;
-            sh:description "A description of the scenario."@en ;
-            sh:maxCount 1 ;
-            sh:message "scenarioDescription (AdminTag): A description of the scenario."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 7 ;
-            sh:path openlabel_v2:scenarioDescription ],
-        [ sh:datatype xsd:string ;
-            sh:description "The email address of the legal entity who owns the rights to the scenario."@en ;
-            sh:maxCount 1 ;
-            sh:message "ownerEmail (AdminTag): The email address of the legal entity who owns the rights to the scenario."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 1 ;
-            sh:path openlabel_v2:ownerEmail ],
-        [ sh:datatype xsd:string ;
-            sh:description "Universally unique identifier (UUID) assigned to the scenario which allows the scenario to be identified."@en ;
-            sh:maxCount 1 ;
-            sh:message "scenarioUniqueReference (AdminTag): Universally unique identifier (UUID) assigned to the scenario which allows the scenario to be identified."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 10 ;
-            sh:path openlabel_v2:scenarioUniqueReference ],
-        [ sh:datatype xsd:string ;
-            sh:description "The type of license which governs usage of the scenario."@en ;
-            sh:maxCount 1 ;
-            sh:message "licenseURI (AdminTag): The type of license which governs usage of the scenario."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 0 ;
-            sh:path openlabel_v2:licenseURI ],
-        [ sh:datatype xsd:string ;
-            sh:description "Relative or absolute URL of a static image or animation of the scenario to allow users to easily see what the scenario represents."@en ;
-            sh:maxCount 1 ;
-            sh:message "scenarioVisualisationURL (AdminTag): Relative or absolute URL of a static image or animation of the scenario to allow users to easily see what the scenario represents."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 12 ;
-            sh:path openlabel_v2:scenarioVisualisationURL ],
-        [ sh:datatype xsd:string ;
-            sh:description "The name of the legal entity who owns the rights to the scenario."@en ;
-            sh:maxCount 1 ;
-            sh:message "ownerName (AdminTag): The name of the legal entity who owns the rights to the scenario."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 2 ;
-            sh:path openlabel_v2:ownerName ],
-        [ sh:datatype xsd:string ;
-            sh:description "The version number of the scenario."@en ;
-            sh:maxCount 1 ;
-            sh:message "scenarioVersion (AdminTag): The version number of the scenario."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 11 ;
-            sh:path openlabel_v2:scenarioVersion ],
-        [ sh:datatype xsd:string ;
-            sh:description "The URL of the legal entity who owns the rights to the scenario."@en ;
-            sh:maxCount 1 ;
-            sh:message "ownerURL (AdminTag): The URL of the legal entity who owns the rights to the scenario."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 3 ;
-            sh:path openlabel_v2:ownerURL ],
-        [ sh:datatype xsd:string ;
-            sh:description "The name of the scenario."@en ;
-            sh:maxCount 1 ;
-            sh:message "scenarioName (AdminTag): The name of the scenario."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 8 ;
-            sh:path openlabel_v2:scenarioName ] ;
-    sh:targetClass openlabel_v2:AdminTag .
-
+	rdfs:comment "The base tag to use when extending the Administration tags with new classes." ;
+	sh:closed true ;
+	sh:ignoredProperties _:c14n204 ;
+	sh:property _:c14n133 , _:c14n151 , _:c14n164 , _:c14n186 , _:c14n219 , _:c14n246 , _:c14n265 , _:c14n297 , _:c14n299 , _:c14n4 , _:c14n52 , _:c14n58 , _:c14n69 ;
+	sh:targetClass openlabel_v2:AdminTag .
 openlabel_v2:Behaviour a sh:NodeShape ;
-    rdfs:comment "An activity performed by a road user."@en ;
-    sh:closed true ;
-    sh:ignoredProperties ( rdf:type ) ;
-    sh:property [ sh:datatype xsd:boolean ;
-            sh:description "An activity where the road user changes their heading."@en ;
-            sh:maxCount 1 ;
-            sh:message "MotionTurn (Behaviour): An activity where the road user changes their heading."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 19 ;
-            sh:path openlabel_v2:MotionTurn ],
-        [ sh:description "Rate of deceleration (ms-2)."@en ;
-            sh:maxCount 1 ;
-            sh:message "motionDecelerateValue (Behaviour): Rate of deceleration (ms-2)."@en ;
-            sh:or ( [ sh:datatype xsd:decimal ;
-                        sh:nodeKind sh:Literal ] [ sh:class schema:QuantitativeValue ] ) ;
-            sh:order 8 ;
-            sh:path openlabel_v2:motionDecelerateValue ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "An activity where the subject vehicle is moving in the opposite direction to which it is facing."@en ;
-            sh:maxCount 1 ;
-            sh:message "MotionReverse (Behaviour): An activity where the subject vehicle is moving in the opposite direction to which it is facing."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 14 ;
-            sh:path openlabel_v2:MotionReverse ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "An activity where the subject vehicle ends up directly in front of the object vehicle."@en ;
-            sh:maxCount 1 ;
-            sh:message "MotionCutIn (Behaviour): An activity where the subject vehicle ends up directly in front of the object vehicle."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 5 ;
-            sh:path openlabel_v2:MotionCutIn ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "An activity where the road user is stationary."@en ;
-            sh:maxCount 1 ;
-            sh:message "MotionStop (Behaviour): An activity where the road user is stationary."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 17 ;
-            sh:path openlabel_v2:MotionStop ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "An activity where the road user decreases their velocity."@en ;
-            sh:maxCount 1 ;
-            sh:message "MotionDecelerate (Behaviour): An activity where the road user decreases their velocity."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 7 ;
-            sh:path openlabel_v2:MotionDecelerate ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "An activity where the subject vehicle is in a lane right of the original."@en ;
-            sh:maxCount 1 ;
-            sh:message "MotionLaneChangeRight (Behaviour): An activity where the subject vehicle is in a lane right of the original."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 12 ;
-            sh:path openlabel_v2:MotionLaneChangeRight ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Locomotion mode where at a specific point no foot touches the ground."@en ;
-            sh:maxCount 1 ;
-            sh:message "MotionRun (Behaviour): Locomotion mode where at a specific point no foot touches the ground."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 15 ;
-            sh:path openlabel_v2:MotionRun ],
-        [ sh:description "Rate of acceleration (ms-2)."@en ;
-            sh:maxCount 1 ;
-            sh:message "motionAccelerateValue (Behaviour): Rate of acceleration (ms-2)."@en ;
-            sh:or ( [ sh:datatype xsd:decimal ;
-                        sh:nodeKind sh:Literal ] [ sh:class schema:QuantitativeValue ] ) ;
-            sh:order 2 ;
-            sh:path openlabel_v2:motionAccelerateValue ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "An activity where the road user is closer to the object by the end."@en ;
-            sh:maxCount 1 ;
-            sh:message "MotionTowards (Behaviour): An activity where the road user is closer to the object by the end."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 18 ;
-            sh:path openlabel_v2:MotionTowards ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Subject exits the intersection on a road to the right of the original."@en ;
-            sh:maxCount 1 ;
-            sh:message "MotionTurnRight (Behaviour): Subject exits the intersection on a road to the right of the original."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 21 ;
-            sh:path openlabel_v2:MotionTurnRight ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "An activity where the road user increases their velocity."@en ;
-            sh:maxCount 1 ;
-            sh:message "MotionAccelerate (Behaviour): An activity where the road user increases their velocity."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 1 ;
-            sh:path openlabel_v2:MotionAccelerate ],
-        [ sh:description "Communication type of road user behaviour."@en ;
-            sh:in ( openlabel_v2:CommunicationHeadlightFlash openlabel_v2:CommunicationHorn openlabel_v2:CommunicationSignalEmergency openlabel_v2:CommunicationSignalHazard openlabel_v2:CommunicationSignalLeft openlabel_v2:CommunicationSignalRight openlabel_v2:CommunicationSignalSlowing openlabel_v2:CommunicationWave ) ;
-            sh:message "BehaviourCommunication (Behaviour): Communication type of road user behaviour."@en ;
-            sh:order 0 ;
-            sh:path openlabel_v2:BehaviourCommunication ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "An activity where the subject vehicle is in a lane left of the original."@en ;
-            sh:maxCount 1 ;
-            sh:message "MotionLaneChangeLeft (Behaviour): An activity where the subject vehicle is in a lane left of the original."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 11 ;
-            sh:path openlabel_v2:MotionLaneChangeLeft ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Subject performs a turn resulting in heading in the opposite direction."@en ;
-            sh:maxCount 1 ;
-            sh:message "MotionUTurn (Behaviour): Subject performs a turn resulting in heading in the opposite direction."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 22 ;
-            sh:path openlabel_v2:MotionUTurn ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "An activity where the road user is further away from the object by the end."@en ;
-            sh:maxCount 1 ;
-            sh:message "MotionAway (Behaviour): An activity where the road user is further away from the object by the end."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 3 ;
-            sh:path openlabel_v2:MotionAway ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "An activity where the subject starts behind and ends up in front by changing lanes."@en ;
-            sh:maxCount 1 ;
-            sh:message "MotionOvertake (Behaviour): An activity where the subject starts behind and ends up in front by changing lanes."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 13 ;
-            sh:path openlabel_v2:MotionOvertake ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "An activity where the subject vehicle is moving in the direction it is facing."@en ;
-            sh:maxCount 1 ;
-            sh:message "MotionDrive (Behaviour): An activity where the subject vehicle is moving in the direction it is facing."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 9 ;
-            sh:path openlabel_v2:MotionDrive ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Subject exits the intersection on a road to the left of the original."@en ;
-            sh:maxCount 1 ;
-            sh:message "MotionTurnLeft (Behaviour): Subject exits the intersection on a road to the left of the original."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 20 ;
-            sh:path openlabel_v2:MotionTurnLeft ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Locomotion mode where at least one foot is always on the ground."@en ;
-            sh:maxCount 1 ;
-            sh:message "MotionWalk (Behaviour): Locomotion mode where at least one foot is always on the ground."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 23 ;
-            sh:path openlabel_v2:MotionWalk ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "An activity where a pedestrian is slipping/sliding on the road."@en ;
-            sh:maxCount 1 ;
-            sh:message "MotionSlide (Behaviour): An activity where a pedestrian is slipping/sliding on the road."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 16 ;
-            sh:path openlabel_v2:MotionSlide ],
-        [ sh:description "Speed (km/h)."@en ;
-            sh:maxCount 1 ;
-            sh:message "motionDriveValue (Behaviour): Speed (km/h)."@en ;
-            sh:or ( [ sh:datatype xsd:decimal ;
-                        sh:nodeKind sh:Literal ] [ sh:class schema:QuantitativeValue ] ) ;
-            sh:order 10 ;
-            sh:path openlabel_v2:motionDriveValue ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "An activity where the object vehicle suddenly moves out of the lane."@en ;
-            sh:maxCount 1 ;
-            sh:message "MotionCutOut (Behaviour): An activity where the object vehicle suddenly moves out of the lane."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 6 ;
-            sh:path openlabel_v2:MotionCutOut ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "An activity where the trajectory of the road user crosses the trajectory of the object."@en ;
-            sh:maxCount 1 ;
-            sh:message "MotionCross (Behaviour): An activity where the trajectory of the road user crosses the trajectory of the object."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 4 ;
-            sh:path openlabel_v2:MotionCross ] ;
-    sh:sparql [ a sh:SPARQLConstraint ;
-            sh:message "If motionDriveValue is provided, MotionDrive must be true. Corresponds to BSI PAS-1883 conditional constraint."@en ;
-            sh:select """SELECT $this WHERE {
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/MotionDrive> ?flag . }
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/motionDriveValue> ?value . }
-    FILTER (
-        ( !BOUND(?flag) || ?flag != true ) &&
-        BOUND(?value)
-    )
-}""" ],
-        [ a sh:SPARQLConstraint ;
-            sh:message "If motionAccelerateValue is provided, MotionAccelerate must be true. Corresponds to BSI PAS-1883 conditional constraint."@en ;
-            sh:select """SELECT $this WHERE {
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/MotionAccelerate> ?flag . }
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/motionAccelerateValue> ?value . }
-    FILTER (
-        ( !BOUND(?flag) || ?flag != true ) &&
-        BOUND(?value)
-    )
-}""" ],
-        [ a sh:SPARQLConstraint ;
-            sh:message "If motionDecelerateValue is provided, MotionDecelerate must be true. Corresponds to BSI PAS-1883 conditional constraint."@en ;
-            sh:select """SELECT $this WHERE {
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/MotionDecelerate> ?flag . }
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/motionDecelerateValue> ?value . }
-    FILTER (
-        ( !BOUND(?flag) || ?flag != true ) &&
-        BOUND(?value)
-    )
-}""" ] ;
-    sh:targetClass openlabel_v2:Behaviour .
-
+	rdfs:comment "An activity performed by a road user." ;
+	sh:closed true ;
+	sh:ignoredProperties _:c14n39 ;
+	sh:property _:c14n106 , _:c14n110 , _:c14n111 , _:c14n115 , _:c14n117 , _:c14n149 , _:c14n160 , _:c14n167 , _:c14n17 , _:c14n180 , _:c14n19 , _:c14n220 , _:c14n224 , _:c14n228 , _:c14n233 , _:c14n253 , _:c14n269 , _:c14n273 , _:c14n284 , _:c14n309 , _:c14n40 , _:c14n42 , _:c14n54 , _:c14n63 ;
+	sh:targetClass openlabel_v2:Behaviour .
 openlabel_v2:Odd a sh:NodeShape ;
-    rdfs:comment "Operational Design Domain. Refer to BSI PAS-1883 Section 5."@en ;
-    sh:closed true ;
-    sh:ignoredProperties ( rdf:type ) ;
-    sh:property [ sh:datatype xsd:boolean ;
-            sh:description "Up-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.i."@en ;
-            sh:maxCount 1 ;
-            sh:message "LongitudinalUpSlope (Odd): Up-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.i."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 31 ;
-            sh:path openlabel_v2:LongitudinalUpSlope ],
-        [ sh:description "Transverse geometry type. Refer to BSI PAS-1883 Section 5.2.3.3.b."@en ;
-            sh:in ( openlabel_v2:TransverseBarriers openlabel_v2:TransverseDivided openlabel_v2:TransverseLanesTogether openlabel_v2:TransversePavements openlabel_v2:TransverseUndivided ) ;
-            sh:maxCount 1 ;
-            sh:message "GeometryTransverse (Odd): Transverse geometry type. Refer to BSI PAS-1883 Section 5.2.3.3.b."@en ;
-            sh:order 11 ;
-            sh:path openlabel_v2:GeometryTransverse ],
-        [ sh:description "Artificial illumination type. Refer to BSI PAS-1883 Section 5.3.3.d."@en ;
-            sh:in ( openlabel_v2:ArtificialStreetLighting openlabel_v2:ArtificialVehicleLighting ) ;
-            sh:maxCount 1 ;
-            sh:message "IlluminationArtificial (Odd): Artificial illumination type. Refer to BSI PAS-1883 Section 5.3.3.d."@en ;
-            sh:order 15 ;
-            sh:path openlabel_v2:IlluminationArtificial ],
-        [ sh:description "Road surface type. Refer to BSI PAS-1883 Section 5.2.3.7.a."@en ;
-            sh:in ( openlabel_v2:SurfaceTypeLoose openlabel_v2:SurfaceTypeSegmented openlabel_v2:SurfaceTypeUniform ) ;
-            sh:maxCount 1 ;
-            sh:message "DrivableAreaSurfaceType (Odd): Road surface type. Refer to BSI PAS-1883 Section 5.2.3.7.a."@en ;
-            sh:order 8 ;
-            sh:path openlabel_v2:DrivableAreaSurfaceType ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Visibility (km). Refer to BSI PAS-1883 Section 5.3.1.3."@en ;
-            sh:maxCount 1 ;
-            sh:message "weatherSnowValue (Odd): Visibility (km). Refer to BSI PAS-1883 Section 5.3.1.3."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 61 ;
-            sh:path openlabel_v2:weatherSnowValue ],
-        [ sh:description "Roundabout type. Refer to BSI PAS-1883 Section 5.2.4."@en ;
-            sh:in ( openlabel_v2:RoundaboutCompactNosignal openlabel_v2:RoundaboutCompactSignal openlabel_v2:RoundaboutDoubleNosignal openlabel_v2:RoundaboutDoubleSignal openlabel_v2:RoundaboutLargeNosignal openlabel_v2:RoundaboutLargeSignal openlabel_v2:RoundaboutMiniNosignal openlabel_v2:RoundaboutMiniSignal openlabel_v2:RoundaboutNormalNosignal openlabel_v2:RoundaboutNormalSignal ) ;
-            sh:maxCount 1 ;
-            sh:message "JunctionRoundabout (Odd): Roundabout type. Refer to BSI PAS-1883 Section 5.2.4."@en ;
-            sh:order 20 ;
-            sh:path openlabel_v2:JunctionRoundabout ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Cloud cover (okta). Refer to BSI PAS-1883 Section 5.3.3.c."@en ;
-            sh:maxCount 1 ;
-            sh:message "illuminationCloudinessValue (Odd): Cloud cover (okta). Refer to BSI PAS-1883 Section 5.3.3.c."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 17 ;
-            sh:path openlabel_v2:illuminationCloudinessValue ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Lane dimensions flag. Refer to BSI PAS-1883 Section 5.2.3.4.a."@en ;
-            sh:maxCount 1 ;
-            sh:message "LaneSpecificationDimensions (Odd): Lane dimensions flag. Refer to BSI PAS-1883 Section 5.2.3.4.a."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 21 ;
-            sh:path openlabel_v2:LaneSpecificationDimensions ],
-        [ sh:description "Agent type. Refer to BSI PAS-1883 Section 5.4.a.4."@en ;
-            sh:message "trafficAgentTypeValue (Odd): Agent type. Refer to BSI PAS-1883 Section 5.4.a.4."@en ;
-            sh:or ( [ sh:in ( openlabel_v2:HumanAnimalRider openlabel_v2:HumanCyclist openlabel_v2:HumanDriver openlabel_v2:HumanMotorcyclist openlabel_v2:HumanPassenger openlabel_v2:HumanPedestrian openlabel_v2:HumanWheelchairUser ) ] [ sh:in ( openlabel_v2:VehicleAgricultural openlabel_v2:VehicleBus openlabel_v2:VehicleCar openlabel_v2:VehicleConstruction openlabel_v2:VehicleCycle openlabel_v2:VehicleEmergency openlabel_v2:VehicleMotorcycle openlabel_v2:VehicleTrailer openlabel_v2:VehicleTruck openlabel_v2:VehicleVan openlabel_v2:VehicleWheelchair ) ] ) ;
-            sh:order 52 ;
-            sh:path openlabel_v2:trafficAgentTypeValue ],
-        [ sh:description "Speed (km/h). Refer to BSI PAS-1883 Section 5.4.b."@en ;
-            sh:maxCount 1 ;
-            sh:message "subjectVehicleSpeedValue (Odd): Speed (km/h). Refer to BSI PAS-1883 Section 5.4.b."@en ;
-            sh:or ( [ sh:datatype xsd:integer ;
-                        sh:nodeKind sh:Literal ] [ sh:class schema:QuantitativeValue ] ) ;
-            sh:order 48 ;
-            sh:path openlabel_v2:subjectVehicleSpeedValue ],
-        [ sh:description "Road type. Refer to BSI PAS-1883 Section 5.2.3.2."@en ;
-            sh:in ( openlabel_v2:MotorwayManaged openlabel_v2:MotorwayUnmanaged openlabel_v2:RoadTypeDistributor openlabel_v2:RoadTypeMinor openlabel_v2:RoadTypeMotorway openlabel_v2:RoadTypeParking openlabel_v2:RoadTypeRadial openlabel_v2:RoadTypeShared openlabel_v2:RoadTypeSlip ) ;
-            sh:maxCount 1 ;
-            sh:message "DrivableAreaType (Odd): Road type. Refer to BSI PAS-1883 Section 5.2.3.2."@en ;
-            sh:order 9 ;
-            sh:path openlabel_v2:DrivableAreaType ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Traffic flow rate flag. Refer to BSI PAS-1883 Section 5.4.a.3."@en ;
-            sh:maxCount 1 ;
-            sh:message "TrafficFlowRate (Odd): Traffic flow rate flag. Refer to BSI PAS-1883 Section 5.4.a.3."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 53 ;
-            sh:path openlabel_v2:TrafficFlowRate ],
-        [ sh:description "Zone type. Refer to BSI PAS-1883 Section 5.2.1.a."@en ;
-            sh:in ( openlabel_v2:ZoneGeoFenced openlabel_v2:ZoneInterference openlabel_v2:ZoneRegion openlabel_v2:ZoneSchool openlabel_v2:ZoneTrafficManagement ) ;
-            sh:maxCount 1 ;
-            sh:message "SceneryZone (Odd): Zone type. Refer to BSI PAS-1883 Section 5.2.1.a."@en ;
-            sh:order 43 ;
-            sh:path openlabel_v2:SceneryZone ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Rainfall flag. Refer to BSI PAS-1883 Section 5.3.1.2."@en ;
-            sh:maxCount 1 ;
-            sh:message "WeatherRain (Odd): Rainfall flag. Refer to BSI PAS-1883 Section 5.3.1.2."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 58 ;
-            sh:path openlabel_v2:WeatherRain ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Traffic volume flag. Refer to BSI PAS-1883 Section 5.4.a.2."@en ;
-            sh:maxCount 1 ;
-            sh:message "TrafficVolume (Odd): Traffic volume flag. Refer to BSI PAS-1883 Section 5.4.a.2."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 56 ;
-            sh:path openlabel_v2:TrafficVolume ],
-        [ sh:description "Warning sign type. Refer to BSI PAS-1883 Section 5.2.3.5.c."@en ;
-            sh:in ( openlabel_v2:WarningSignsUniform openlabel_v2:WarningSignsUniformFullTime openlabel_v2:WarningSignsUniformTemporary openlabel_v2:WarningSignsVariableFullTime openlabel_v2:WarningSignsVariableTemporary ) ;
-            sh:maxCount 1 ;
-            sh:message "SignsWarning (Odd): Warning sign type. Refer to BSI PAS-1883 Section 5.2.3.5.c."@en ;
-            sh:order 46 ;
-            sh:path openlabel_v2:SignsWarning ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Meteorological Optical Range (MOR) (m). Refer to BSI PAS-1883 Section 5.3.2.b."@en ;
-            sh:maxCount 1 ;
-            sh:message "particulatesWaterValue (Odd): Meteorological Optical Range (MOR) (m). Refer to BSI PAS-1883 Section 5.3.2.b."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 38 ;
-            sh:path openlabel_v2:particulatesWaterValue ],
-        [ sh:description "Intersection type. Refer to BSI PAS-1883 Section 5.2.4."@en ;
-            sh:in ( openlabel_v2:IntersectionCrossroad openlabel_v2:IntersectionGradeSeperated openlabel_v2:IntersectionStaggered openlabel_v2:IntersectionTJunction openlabel_v2:IntersectionYJunction ) ;
-            sh:maxCount 1 ;
-            sh:message "JunctionIntersection (Odd): Intersection type. Refer to BSI PAS-1883 Section 5.2.4."@en ;
-            sh:order 19 ;
-            sh:path openlabel_v2:JunctionIntersection ],
-        [ sh:description "Lane type. Refer to BSI PAS-1883 Section 5.2.3.4.c."@en ;
-            sh:in ( openlabel_v2:LaneTypeBus openlabel_v2:LaneTypeCycle openlabel_v2:LaneTypeEmergency openlabel_v2:LaneTypeSpecial openlabel_v2:LaneTypeTraffic openlabel_v2:LaneTypeTram ) ;
-            sh:message "LaneSpecificationType (Odd): Lane type. Refer to BSI PAS-1883 Section 5.2.3.4.c."@en ;
-            sh:order 27 ;
-            sh:path openlabel_v2:LaneSpecificationType ],
-        [ sh:description "Communication connectivity type. Refer to BSI PAS-1883 Section 5.3.4.a."@en ;
-            sh:in ( openlabel_v2:CommunicationV2i openlabel_v2:CommunicationV2v openlabel_v2:V2iCellular openlabel_v2:V2iSatellite openlabel_v2:V2iWifi openlabel_v2:V2vCellular openlabel_v2:V2vSatellite openlabel_v2:V2vWifi ) ;
-            sh:maxCount 1 ;
-            sh:message "ConnectivityCommunication (Odd): Communication connectivity type. Refer to BSI PAS-1883 Section 5.3.4.a."@en ;
-            sh:order 0 ;
-            sh:path openlabel_v2:ConnectivityCommunication ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Elevation of the sun above the horizon flag. Refer to BSI PAS-1883 Section 5.3.3.a.1."@en ;
-            sh:maxCount 1 ;
-            sh:message "DaySunElevation (Odd): Elevation of the sun above the horizon flag. Refer to BSI PAS-1883 Section 5.3.3.a.1."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 2 ;
-            sh:path openlabel_v2:DaySunElevation ],
-        [ sh:datatype xsd:integer ;
-            sh:description "Density (vehicles/km). Refer to BSI PAS-1883 Section 5.4.a.1."@en ;
-            sh:maxCount 1 ;
-            sh:message "trafficAgentDensityValue (Odd): Density (vehicles/km). Refer to BSI PAS-1883 Section 5.4.a.1."@en ;
-            sh:minInclusive 0 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 50 ;
-            sh:path openlabel_v2:trafficAgentDensityValue ],
-        [ sh:description "Regulatory sign type. Refer to BSI PAS-1883 Section 5.2.3.5.b."@en ;
-            sh:in ( openlabel_v2:RegulatorySignsUniformFullTime openlabel_v2:RegulatorySignsUniformTemporary openlabel_v2:RegulatorySignsVariableFullTime openlabel_v2:RegulatorySignsVariableTemporary ) ;
-            sh:maxCount 1 ;
-            sh:message "SignsRegulatory (Odd): Regulatory sign type. Refer to BSI PAS-1883 Section 5.2.3.5.b."@en ;
-            sh:order 45 ;
-            sh:path openlabel_v2:SignsRegulatory ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Traffic agent type classification flag. Refer to BSI PAS-1883 Section 5.4.a.4."@en ;
-            sh:maxCount 1 ;
-            sh:message "TrafficAgentType (Odd): Traffic agent type classification flag. Refer to BSI PAS-1883 Section 5.4.a.4."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 51 ;
-            sh:path openlabel_v2:TrafficAgentType ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Lane marking flag. Refer to BSI PAS-1883 Section 5.2.3.4.b."@en ;
-            sh:maxCount 1 ;
-            sh:message "LaneSpecificationMarking (Odd): Lane marking flag. Refer to BSI PAS-1883 Section 5.2.3.4.b."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 25 ;
-            sh:path openlabel_v2:LaneSpecificationMarking ],
-        [ sh:datatype xsd:integer ;
-            sh:description "Volume (vehicle km). Refer to BSI PAS-1883 Section 5.4.a.2."@en ;
-            sh:maxCount 1 ;
-            sh:message "trafficVolumeValue (Odd): Volume (vehicle km). Refer to BSI PAS-1883 Section 5.4.a.2."@en ;
-            sh:minInclusive 0 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 57 ;
-            sh:path openlabel_v2:trafficVolumeValue ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Level plane flag. Refer to BSI PAS-1883 Section 5.2.3.3.iii."@en ;
-            sh:maxCount 1 ;
-            sh:message "LongitudinalLevelPlane (Odd): Level plane flag. Refer to BSI PAS-1883 Section 5.2.3.3.iii."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 30 ;
-            sh:path openlabel_v2:LongitudinalLevelPlane ],
-        [ sh:description "Road surface condition. Refer to BSI PAS-1883 Section 5.2.3.7.c."@en ;
-            sh:in ( openlabel_v2:SurfaceConditionContamination openlabel_v2:SurfaceConditionFlooded openlabel_v2:SurfaceConditionIcy openlabel_v2:SurfaceConditionMirage openlabel_v2:SurfaceConditionSnow openlabel_v2:SurfaceConditionStandingWater openlabel_v2:SurfaceConditionWet ) ;
-            sh:maxCount 1 ;
-            sh:message "DrivableAreaSurfaceCondition (Odd): Road surface condition. Refer to BSI PAS-1883 Section 5.2.3.7.c."@en ;
-            sh:order 6 ;
-            sh:path openlabel_v2:DrivableAreaSurfaceCondition ],
-        [ sh:description "Particulate type. Refer to BSI PAS-1883 Section 5.3.2."@en ;
-            sh:in ( openlabel_v2:ParticulatesDust openlabel_v2:ParticulatesMarine openlabel_v2:ParticulatesPollution openlabel_v2:ParticulatesVolcanic openlabel_v2:ParticulatesWater ) ;
-            sh:maxCount 1 ;
-            sh:message "EnvironmentParticulates (Odd): Particulate type. Refer to BSI PAS-1883 Section 5.3.2."@en ;
-            sh:order 10 ;
-            sh:path openlabel_v2:EnvironmentParticulates ],
-        [ sh:description "Position of the sun. Refer to BSI PAS-1883 Section 5.3.3.a.2."@en ;
-            sh:in ( openlabel_v2:SunPositionBehind openlabel_v2:SunPositionFront openlabel_v2:SunPositionLeft openlabel_v2:SunPositionRight ) ;
-            sh:maxCount 1 ;
-            sh:message "DaySunPosition (Odd): Position of the sun. Refer to BSI PAS-1883 Section 5.3.3.a.2."@en ;
-            sh:order 4 ;
-            sh:path openlabel_v2:DaySunPosition ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.i."@en ;
-            sh:maxCount 1 ;
-            sh:message "longitudinalUpSlopeValue (Odd): Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.i."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 32 ;
-            sh:path openlabel_v2:longitudinalUpSlopeValue ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Volcanic ash flag. Refer to BSI PAS-1883 Section 5.3.2.e."@en ;
-            sh:maxCount 1 ;
-            sh:message "ParticulatesVolcanic (Odd): Volcanic ash flag. Refer to BSI PAS-1883 Section 5.3.2.e."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 36 ;
-            sh:path openlabel_v2:ParticulatesVolcanic ],
-        [ sh:description "Lane width (m). Refer to BSI PAS-1883 Section 5.2.3.4.a."@en ;
-            sh:maxCount 1 ;
-            sh:message "laneSpecificationDimensionsValue (Odd): Lane width (m). Refer to BSI PAS-1883 Section 5.2.3.4.a."@en ;
-            sh:or ( [ sh:datatype xsd:decimal ;
-                        sh:nodeKind sh:Literal ] [ sh:class schema:QuantitativeValue ] ) ;
-            sh:order 22 ;
-            sh:path openlabel_v2:laneSpecificationDimensionsValue ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Traffic agent density flag. Refer to BSI PAS-1883 Section 5.4.a.1."@en ;
-            sh:maxCount 1 ;
-            sh:message "TrafficAgentDensity (Odd): Traffic agent density flag. Refer to BSI PAS-1883 Section 5.4.a.1."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 49 ;
-            sh:path openlabel_v2:TrafficAgentDensity ],
-        [ sh:description "Drivable area edge type. Refer to BSI PAS-1883 Section 5.2.3.1.e."@en ;
-            sh:in ( openlabel_v2:EdgeLineMarkers openlabel_v2:EdgeNone openlabel_v2:EdgeShoulderGrass openlabel_v2:EdgeShoulderPavedOrGravel openlabel_v2:EdgeSolidBarriers openlabel_v2:EdgeTemporaryLineMarkers ) ;
-            sh:message "DrivableAreaEdge (Odd): Drivable area edge type. Refer to BSI PAS-1883 Section 5.2.3.1.e."@en ;
-            sh:order 5 ;
-            sh:path openlabel_v2:DrivableAreaEdge ],
-        [ sh:description "Road surface feature. Refer to BSI PAS-1883 Section 5.2.3.7.b."@en ;
-            sh:in ( openlabel_v2:SurfaceFeatureCrack openlabel_v2:SurfaceFeaturePothole openlabel_v2:SurfaceFeatureRut openlabel_v2:SurfaceFeatureSwell ) ;
-            sh:maxCount 1 ;
-            sh:message "DrivableAreaSurfaceFeature (Odd): Road surface feature. Refer to BSI PAS-1883 Section 5.2.3.7.b."@en ;
-            sh:order 7 ;
-            sh:path openlabel_v2:DrivableAreaSurfaceFeature ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Number of lanes flag. Refer to BSI PAS-1883 Section 5.2.3.4.d."@en ;
-            sh:maxCount 1 ;
-            sh:message "LaneSpecificationLaneCount (Odd): Number of lanes flag. Refer to BSI PAS-1883 Section 5.2.3.4.d."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 23 ;
-            sh:path openlabel_v2:LaneSpecificationLaneCount ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Curves flag. Refer to BSI PAS-1883 Section 5.2.3.3."@en ;
-            sh:maxCount 1 ;
-            sh:message "HorizontalCurves (Odd): Curves flag. Refer to BSI PAS-1883 Section 5.2.3.3."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 12 ;
-            sh:path openlabel_v2:HorizontalCurves ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Wind flag. Refer to BSI PAS-1883 Section 5.3.1.1."@en ;
-            sh:maxCount 1 ;
-            sh:message "WeatherWind (Odd): Wind flag. Refer to BSI PAS-1883 Section 5.3.1.1."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 62 ;
-            sh:path openlabel_v2:WeatherWind ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Rainfall intensity (mm/h). Refer to BSI PAS-1883 Section 5.3.1.2."@en ;
-            sh:maxCount 1 ;
-            sh:message "weatherRainValue (Odd): Rainfall intensity (mm/h). Refer to BSI PAS-1883 Section 5.3.1.2."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 59 ;
-            sh:path openlabel_v2:weatherRainValue ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.ii."@en ;
-            sh:maxCount 1 ;
-            sh:message "longitudinalDownSlopeValue (Odd): Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.ii."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 29 ;
-            sh:path openlabel_v2:longitudinalDownSlopeValue ],
-        [ sh:description "Low light condition. Refer to BSI PAS-1883 Section 5.3.3.b."@en ;
-            sh:in ( openlabel_v2:LowLightAmbient openlabel_v2:LowLightNight ) ;
-            sh:maxCount 1 ;
-            sh:message "IlluminationLowLight (Odd): Low light condition. Refer to BSI PAS-1883 Section 5.3.3.b."@en ;
-            sh:order 18 ;
-            sh:path openlabel_v2:IlluminationLowLight ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Sand and dust flag. Refer to BSI PAS-1883 Section 5.3.2.c."@en ;
-            sh:maxCount 1 ;
-            sh:message "ParticulatesDust (Odd): Sand and dust flag. Refer to BSI PAS-1883 Section 5.3.2.c."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 33 ;
-            sh:path openlabel_v2:ParticulatesDust ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Down-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.ii."@en ;
-            sh:maxCount 1 ;
-            sh:message "LongitudinalDownSlope (Odd): Down-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.ii."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 28 ;
-            sh:path openlabel_v2:LongitudinalDownSlope ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Subject vehicle speed flag. Refer to BSI PAS-1883 Section 5.4.b."@en ;
-            sh:maxCount 1 ;
-            sh:message "SubjectVehicleSpeed (Odd): Subject vehicle speed flag. Refer to BSI PAS-1883 Section 5.4.b."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 47 ;
-            sh:path openlabel_v2:SubjectVehicleSpeed ],
-        [ sh:description "Positioning system type. Refer to BSI PAS-1883 Section 5.3.4.b."@en ;
-            sh:in ( openlabel_v2:PositioningGalileo openlabel_v2:PositioningGlonass openlabel_v2:PositioningGps ) ;
-            sh:maxCount 1 ;
-            sh:message "ConnectivityPositioning (Odd): Positioning system type. Refer to BSI PAS-1883 Section 5.3.4.b."@en ;
-            sh:order 1 ;
-            sh:path openlabel_v2:ConnectivityPositioning ],
-        [ sh:description "Number of lanes (unit). Refer to BSI PAS-1883 Section 5.2.3.4.d."@en ;
-            sh:maxCount 1 ;
-            sh:message "laneSpecificationLaneCountValue (Odd): Number of lanes (unit). Refer to BSI PAS-1883 Section 5.2.3.4.d."@en ;
-            sh:or ( [ sh:datatype xsd:integer ;
-                        sh:nodeKind sh:Literal ] [ sh:class schema:QuantitativeValue ] ) ;
-            sh:order 24 ;
-            sh:path openlabel_v2:laneSpecificationLaneCountValue ],
-        [ sh:description "Direction of travel. Refer to BSI PAS-1883 Section 5.2.3.4.e."@en ;
-            sh:in ( openlabel_v2:TravelDirectionLeft openlabel_v2:TravelDirectionRight ) ;
-            sh:maxCount 1 ;
-            sh:message "LaneSpecificationTravelDirection (Odd): Direction of travel. Refer to BSI PAS-1883 Section 5.2.3.4.e."@en ;
-            sh:order 26 ;
-            sh:path openlabel_v2:LaneSpecificationTravelDirection ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Straight lines flag. Refer to BSI PAS-1883 Section 5.2.3.3."@en ;
-            sh:maxCount 1 ;
-            sh:message "HorizontalStraights (Odd): Straight lines flag. Refer to BSI PAS-1883 Section 5.2.3.3."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 14 ;
-            sh:path openlabel_v2:HorizontalStraights ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Presence of special vehicles flag. Refer to BSI PAS-1883 Section 5.4.a.5."@en ;
-            sh:maxCount 1 ;
-            sh:message "TrafficSpecialVehicle (Odd): Presence of special vehicles flag. Refer to BSI PAS-1883 Section 5.4.a.5."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 55 ;
-            sh:path openlabel_v2:TrafficSpecialVehicle ],
-        [ sh:description "Fixed road structure. Refer to BSI PAS-1883 Section 5.2.1.e."@en ;
-            sh:in ( openlabel_v2:FixedStructureBuilding openlabel_v2:FixedStructureStreetFurniture openlabel_v2:FixedStructureStreetlight openlabel_v2:FixedStructureVegetation ) ;
-            sh:maxCount 1 ;
-            sh:message "SceneryFixedStructure (Odd): Fixed road structure. Refer to BSI PAS-1883 Section 5.2.1.e."@en ;
-            sh:order 40 ;
-            sh:path openlabel_v2:SceneryFixedStructure ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Non-precipitating water droplets or ice crystals (mist/fog) flag. Refer to BSI PAS-1883 Section 5.3.2.b."@en ;
-            sh:maxCount 1 ;
-            sh:message "ParticulatesWater (Odd): Non-precipitating water droplets or ice crystals (mist/fog) flag. Refer to BSI PAS-1883 Section 5.3.2.b."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 37 ;
-            sh:path openlabel_v2:ParticulatesWater ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Sun elevation (degrees). Refer to BSI PAS-1883 Section 5.3.3.a.1."@en ;
-            sh:maxCount 1 ;
-            sh:message "daySunElevationValue (Odd): Sun elevation (degrees). Refer to BSI PAS-1883 Section 5.3.3.a.1."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 3 ;
-            sh:path openlabel_v2:daySunElevationValue ],
-        [ sh:datatype xsd:integer ;
-            sh:description "Rate (vehicles/h). Refer to BSI PAS-1883 Section 5.4.a.3."@en ;
-            sh:maxCount 1 ;
-            sh:message "trafficFlowRateValue (Odd): Rate (vehicles/h). Refer to BSI PAS-1883 Section 5.4.a.3."@en ;
-            sh:minInclusive 0 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 54 ;
-            sh:path openlabel_v2:trafficFlowRateValue ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Curve radius (m). Refer to BSI PAS-1883 Section 5.2.3.3."@en ;
-            sh:maxCount 1 ;
-            sh:message "horizontalCurvesValue (Odd): Curve radius (m). Refer to BSI PAS-1883 Section 5.2.3.3."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 13 ;
-            sh:path openlabel_v2:horizontalCurvesValue ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Cloudiness flag. Refer to BSI PAS-1883 Section 5.3.3.c."@en ;
-            sh:maxCount 1 ;
-            sh:message "IlluminationCloudiness (Odd): Cloudiness flag. Refer to BSI PAS-1883 Section 5.3.3.c."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 16 ;
-            sh:path openlabel_v2:IlluminationCloudiness ],
-        [ sh:description "Rainfall type. Refer to BSI PAS-1883 Section 5.3.1.2."@en ;
-            sh:in ( openlabel_v2:RainTypeConvective openlabel_v2:RainTypeDynamic openlabel_v2:RainTypeOrographic ) ;
-            sh:maxCount 1 ;
-            sh:message "RainType (Odd): Rainfall type. Refer to BSI PAS-1883 Section 5.3.1.2."@en ;
-            sh:order 39 ;
-            sh:path openlabel_v2:RainType ],
-        [ sh:description "Temporary road structure. Refer to BSI PAS-1883 Section 5.2.1.f."@en ;
-            sh:in ( openlabel_v2:TemporaryStructureConstructionDetour openlabel_v2:TemporaryStructureRefuseCollection openlabel_v2:TemporaryStructureRoadSignage openlabel_v2:TemporaryStructureRoadWorks ) ;
-            sh:maxCount 1 ;
-            sh:message "SceneryTemporaryStructure (Odd): Temporary road structure. Refer to BSI PAS-1883 Section 5.2.1.f."@en ;
-            sh:order 42 ;
-            sh:path openlabel_v2:SceneryTemporaryStructure ],
-        [ sh:description "Special road structure. Refer to BSI PAS-1883 Section 5.2.1.d."@en ;
-            sh:in ( openlabel_v2:SpecialStructureAutoAccess openlabel_v2:SpecialStructureBridge openlabel_v2:SpecialStructurePedestrianCrossing openlabel_v2:SpecialStructureRailCrossing openlabel_v2:SpecialStructureTollPlaza openlabel_v2:SpecialStructureTunnel ) ;
-            sh:maxCount 1 ;
-            sh:message "ScenerySpecialStructure (Odd): Special road structure. Refer to BSI PAS-1883 Section 5.2.1.d."@en ;
-            sh:order 41 ;
-            sh:path openlabel_v2:ScenerySpecialStructure ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Snowfall flag. Refer to BSI PAS-1883 Section 5.3.1.3."@en ;
-            sh:maxCount 1 ;
-            sh:message "WeatherSnow (Odd): Snowfall flag. Refer to BSI PAS-1883 Section 5.3.1.3."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 60 ;
-            sh:path openlabel_v2:WeatherSnow ],
-        [ sh:description "Information sign type. Refer to BSI PAS-1883 Section 5.2.3.5.a."@en ;
-            sh:in ( openlabel_v2:InformationSignsUniformFullTime openlabel_v2:InformationSignsUniformTemporary openlabel_v2:InformationSignsVariableFullTime openlabel_v2:InformationSignsVariableTemporary ) ;
-            sh:maxCount 1 ;
-            sh:message "SignsInformation (Odd): Information sign type. Refer to BSI PAS-1883 Section 5.2.3.5.a."@en ;
-            sh:order 44 ;
-            sh:path openlabel_v2:SignsInformation ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Marine (coastal areas only) flag. Refer to BSI PAS-1883 Section 5.3.2.a."@en ;
-            sh:maxCount 1 ;
-            sh:message "ParticulatesMarine (Odd): Marine (coastal areas only) flag. Refer to BSI PAS-1883 Section 5.3.2.a."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 34 ;
-            sh:path openlabel_v2:ParticulatesMarine ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Smoke and pollution flag. Refer to BSI PAS-1883 Section 5.3.2.d."@en ;
-            sh:maxCount 1 ;
-            sh:message "ParticulatesPollution (Odd): Smoke and pollution flag. Refer to BSI PAS-1883 Section 5.3.2.d."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 35 ;
-            sh:path openlabel_v2:ParticulatesPollution ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Wind speed (m/s). Refer to BSI PAS-1883 Section 5.3.1.1."@en ;
-            sh:maxCount 1 ;
-            sh:message "weatherWindValue (Odd): Wind speed (m/s). Refer to BSI PAS-1883 Section 5.3.1.1."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 63 ;
-            sh:path openlabel_v2:weatherWindValue ] ;
-    sh:sparql [ a sh:SPARQLConstraint ;
-            sh:message "If trafficVolumeValue is provided, TrafficVolume must be true. Corresponds to BSI PAS-1883 conditional constraint."@en ;
-            sh:select """SELECT $this WHERE {
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/TrafficVolume> ?flag . }
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/trafficVolumeValue> ?value . }
-    FILTER (
-        ( !BOUND(?flag) || ?flag != true ) &&
-        BOUND(?value)
-    )
-}""" ],
-        [ a sh:SPARQLConstraint ;
-            sh:message "If trafficAgentTypeValue is provided, TrafficAgentType must be true. Corresponds to BSI PAS-1883 Section 5.4.a.4 conditional constraint."@en ;
-            sh:select """SELECT $this WHERE {
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/TrafficAgentType> ?flag . }
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/trafficAgentTypeValue> ?value . }
-    FILTER (
-        ( !BOUND(?flag) || ?flag != true ) &&
-        BOUND(?value)
-    )
-}""" ],
-        [ a sh:SPARQLConstraint ;
-            sh:message "If illuminationCloudinessValue is provided, IlluminationCloudiness must be true. Corresponds to BSI PAS-1883 conditional constraint."@en ;
-            sh:select """SELECT $this WHERE {
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/IlluminationCloudiness> ?flag . }
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/illuminationCloudinessValue> ?value . }
-    FILTER (
-        ( !BOUND(?flag) || ?flag != true ) &&
-        BOUND(?value)
-    )
-}""" ],
-        [ a sh:SPARQLConstraint ;
-            sh:message "If trafficAgentDensityValue is provided, TrafficAgentDensity must be true. Corresponds to BSI PAS-1883 conditional constraint."@en ;
-            sh:select """SELECT $this WHERE {
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/TrafficAgentDensity> ?flag . }
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/trafficAgentDensityValue> ?value . }
-    FILTER (
-        ( !BOUND(?flag) || ?flag != true ) &&
-        BOUND(?value)
-    )
-}""" ],
-        [ a sh:SPARQLConstraint ;
-            sh:message "If weatherRainValue is provided, WeatherRain must be true. Corresponds to BSI PAS-1883 conditional constraint."@en ;
-            sh:select """SELECT $this WHERE {
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/WeatherRain> ?flag . }
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/weatherRainValue> ?value . }
-    FILTER (
-        ( !BOUND(?flag) || ?flag != true ) &&
-        BOUND(?value)
-    )
-}""" ],
-        [ a sh:SPARQLConstraint ;
-            sh:message "If subjectVehicleSpeedValue is provided, SubjectVehicleSpeed must be true. Corresponds to BSI PAS-1883 Section 5.4.b conditional constraint."@en ;
-            sh:select """SELECT $this WHERE {
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/SubjectVehicleSpeed> ?flag . }
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/subjectVehicleSpeedValue> ?value . }
-    FILTER (
-        ( !BOUND(?flag) || ?flag != true ) &&
-        BOUND(?value)
-    )
-}""" ],
-        [ a sh:SPARQLConstraint ;
-            sh:message "If particulatesWaterValue is provided, ParticulatesWater must be true. Corresponds to BSI PAS-1883 Section 5.3.2.b conditional constraint."@en ;
-            sh:select """SELECT $this WHERE {
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/ParticulatesWater> ?flag . }
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/particulatesWaterValue> ?value . }
-    FILTER (
-        ( !BOUND(?flag) || ?flag != true ) &&
-        BOUND(?value)
-    )
-}""" ],
-        [ a sh:SPARQLConstraint ;
-            sh:message "If horizontalCurvesValue is provided, HorizontalCurves must be true. Corresponds to BSI PAS-1883 conditional constraint."@en ;
-            sh:select """SELECT $this WHERE {
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/HorizontalCurves> ?flag . }
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/horizontalCurvesValue> ?value . }
-    FILTER (
-        ( !BOUND(?flag) || ?flag != true ) &&
-        BOUND(?value)
-    )
-}""" ],
-        [ a sh:SPARQLConstraint ;
-            sh:message "If laneSpecificationDimensionsValue is provided, LaneSpecificationDimensions must be true. Corresponds to BSI PAS-1883 conditional constraint."@en ;
-            sh:select """SELECT $this WHERE {
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/LaneSpecificationDimensions> ?flag . }
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/laneSpecificationDimensionsValue> ?value . }
-    FILTER (
-        ( !BOUND(?flag) || ?flag != true ) &&
-        BOUND(?value)
-    )
-}""" ],
-        [ a sh:SPARQLConstraint ;
-            sh:message "If weatherSnowValue is provided, WeatherSnow must be true. Corresponds to BSI PAS-1883 conditional constraint."@en ;
-            sh:select """SELECT $this WHERE {
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/WeatherSnow> ?flag . }
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/weatherSnowValue> ?value . }
-    FILTER (
-        ( !BOUND(?flag) || ?flag != true ) &&
-        BOUND(?value)
-    )
-}""" ],
-        [ a sh:SPARQLConstraint ;
-            sh:message "If laneSpecificationLaneCountValue is provided, LaneSpecificationLaneCount must be true. Corresponds to BSI PAS-1883 conditional constraint."@en ;
-            sh:select """SELECT $this WHERE {
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/LaneSpecificationLaneCount> ?flag . }
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/laneSpecificationLaneCountValue> ?value . }
-    FILTER (
-        ( !BOUND(?flag) || ?flag != true ) &&
-        BOUND(?value)
-    )
-}""" ],
-        [ a sh:SPARQLConstraint ;
-            sh:message "If longitudinalDownSlopeValue is provided, LongitudinalDownSlope must be true. Corresponds to BSI PAS-1883 conditional constraint."@en ;
-            sh:select """SELECT $this WHERE {
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/LongitudinalDownSlope> ?flag . }
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/longitudinalDownSlopeValue> ?value . }
-    FILTER (
-        ( !BOUND(?flag) || ?flag != true ) &&
-        BOUND(?value)
-    )
-}""" ],
-        [ a sh:SPARQLConstraint ;
-            sh:message "If weatherWindValue is provided, WeatherWind must be true. Corresponds to BSI PAS-1883 conditional constraint."@en ;
-            sh:select """SELECT $this WHERE {
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/WeatherWind> ?flag . }
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/weatherWindValue> ?value . }
-    FILTER (
-        ( !BOUND(?flag) || ?flag != true ) &&
-        BOUND(?value)
-    )
-}""" ],
-        [ a sh:SPARQLConstraint ;
-            sh:message "If longitudinalUpSlopeValue is provided, LongitudinalUpSlope must be true. Corresponds to BSI PAS-1883 conditional constraint."@en ;
-            sh:select """SELECT $this WHERE {
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/LongitudinalUpSlope> ?flag . }
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/longitudinalUpSlopeValue> ?value . }
-    FILTER (
-        ( !BOUND(?flag) || ?flag != true ) &&
-        BOUND(?value)
-    )
-}""" ],
-        [ a sh:SPARQLConstraint ;
-            sh:message "If trafficFlowRateValue is provided, TrafficFlowRate must be true. Corresponds to BSI PAS-1883 conditional constraint."@en ;
-            sh:select """SELECT $this WHERE {
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/TrafficFlowRate> ?flag . }
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/trafficFlowRateValue> ?value . }
-    FILTER (
-        ( !BOUND(?flag) || ?flag != true ) &&
-        BOUND(?value)
-    )
-}""" ],
-        [ a sh:SPARQLConstraint ;
-            sh:message "If daySunElevationValue is provided, DaySunElevation must be true. Corresponds to BSI PAS-1883 conditional constraint."@en ;
-            sh:select """SELECT $this WHERE {
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/DaySunElevation> ?flag . }
-    OPTIONAL { $this <https://w3id.org/ascs-ev/envited-x/openlabel/v2/daySunElevationValue> ?value . }
-    FILTER (
-        ( !BOUND(?flag) || ?flag != true ) &&
-        BOUND(?value)
-    )
-}""" ] ;
-    sh:targetClass openlabel_v2:Odd .
-
+	rdfs:comment "Operational Design Domain. Refer to BSI PAS-1883 Section 5." ;
+	sh:closed true ;
+	sh:ignoredProperties _:c14n147 ;
+	sh:property _:c14n10 , _:c14n100 , _:c14n105 , _:c14n107 , _:c14n108 , _:c14n112 , _:c14n119 , _:c14n137 , _:c14n139 , _:c14n142 , _:c14n143 , _:c14n145 , _:c14n15 , _:c14n159 , _:c14n177 , _:c14n181 , _:c14n189 , _:c14n20 , _:c14n205 , _:c14n206 , _:c14n211 , _:c14n217 , _:c14n225 , _:c14n229 , _:c14n241 , _:c14n245 , _:c14n25 , _:c14n251 , _:c14n252 , _:c14n257 , _:c14n259 , _:c14n262 , _:c14n266 , _:c14n27 , _:c14n271 , _:c14n272 , _:c14n275 , _:c14n28 , _:c14n281 , _:c14n285 , _:c14n286 , _:c14n290 , _:c14n291 , _:c14n295 , _:c14n296 , _:c14n308 , _:c14n310 , _:c14n314 , _:c14n32 , _:c14n320 , _:c14n41 , _:c14n51 , _:c14n53 , _:c14n55 , _:c14n56 , _:c14n71 , _:c14n74 , _:c14n76 , _:c14n77 , _:c14n88 , _:c14n9 , _:c14n94 , _:c14n97 , _:c14n99 ;
+	sh:targetClass openlabel_v2:Odd .
+openlabel_v2:OddDynamicElements a sh:NodeShape ;
+	rdfs:comment "Dynamic elements subset of the Operational Design Domain. Covers traffic agents, flow rates, volume, and subject vehicle speed. Refer to BSI PAS-1883 Section 5.4." ;
+	sh:closed true ;
+	sh:ignoredProperties _:c14n209 ;
+	sh:property _:c14n0 , _:c14n1 , _:c14n104 , _:c14n118 , _:c14n120 , _:c14n122 , _:c14n125 , _:c14n127 , _:c14n130 , _:c14n132 , _:c14n135 , _:c14n14 , _:c14n146 , _:c14n148 , _:c14n152 , _:c14n155 , _:c14n162 , _:c14n163 , _:c14n166 , _:c14n168 , _:c14n169 , _:c14n170 , _:c14n171 , _:c14n172 , _:c14n174 , _:c14n18 , _:c14n185 , _:c14n188 , _:c14n195 , _:c14n196 , _:c14n201 , _:c14n207 , _:c14n21 , _:c14n210 , _:c14n22 , _:c14n23 , _:c14n24 , _:c14n249 , _:c14n277 , _:c14n287 , _:c14n293 , _:c14n30 , _:c14n301 , _:c14n307 , _:c14n312 , _:c14n316 , _:c14n321 , _:c14n37 , _:c14n47 , _:c14n48 , _:c14n50 , _:c14n57 , _:c14n61 , _:c14n64 , _:c14n67 , _:c14n68 , _:c14n7 , _:c14n73 , _:c14n75 , _:c14n8 , _:c14n83 , _:c14n84 , _:c14n89 , _:c14n92 ;
+	sh:targetClass openlabel_v2:OddDynamicElements .
+openlabel_v2:OddEnvironment a sh:NodeShape ;
+	rdfs:comment "Environment-related subset of the Operational Design Domain. Covers weather, illumination, connectivity, and particulates. Refer to BSI PAS-1883 Section 5.3." ;
+	sh:closed true ;
+	sh:ignoredProperties _:c14n232 ;
+	sh:property _:c14n101 , _:c14n109 , _:c14n114 , _:c14n12 , _:c14n123 , _:c14n124 , _:c14n13 , _:c14n140 , _:c14n141 , _:c14n150 , _:c14n153 , _:c14n161 , _:c14n173 , _:c14n187 , _:c14n194 , _:c14n199 , _:c14n213 , _:c14n218 , _:c14n221 , _:c14n223 , _:c14n235 , _:c14n243 , _:c14n244 , _:c14n247 , _:c14n248 , _:c14n254 , _:c14n255 , _:c14n260 , _:c14n268 , _:c14n270 , _:c14n274 , _:c14n276 , _:c14n279 , _:c14n288 , _:c14n289 , _:c14n29 , _:c14n292 , _:c14n294 , _:c14n298 , _:c14n302 , _:c14n303 , _:c14n306 , _:c14n313 , _:c14n319 , _:c14n322 , _:c14n34 , _:c14n35 , _:c14n36 , _:c14n43 , _:c14n46 , _:c14n49 , _:c14n59 , _:c14n6 , _:c14n60 , _:c14n65 , _:c14n66 , _:c14n72 , _:c14n78 , _:c14n79 , _:c14n80 , _:c14n82 , _:c14n87 , _:c14n96 , _:c14n98 ;
+	sh:targetClass openlabel_v2:OddEnvironment .
+openlabel_v2:OddScenery a sh:NodeShape ;
+	rdfs:comment "Scenery-related subset of the Operational Design Domain. Covers drivable area, geometry, lane specifications, junctions, signs, and structures. Refer to BSI PAS-1883 Section 5.2." ;
+	sh:closed true ;
+	sh:ignoredProperties _:c14n126 ;
+	sh:property _:c14n103 , _:c14n11 , _:c14n116 , _:c14n121 , _:c14n128 , _:c14n129 , _:c14n131 , _:c14n134 , _:c14n144 , _:c14n156 , _:c14n158 , _:c14n16 , _:c14n165 , _:c14n176 , _:c14n178 , _:c14n179 , _:c14n184 , _:c14n190 , _:c14n192 , _:c14n197 , _:c14n198 , _:c14n200 , _:c14n202 , _:c14n203 , _:c14n208 , _:c14n212 , _:c14n214 , _:c14n215 , _:c14n216 , _:c14n226 , _:c14n227 , _:c14n230 , _:c14n234 , _:c14n236 , _:c14n237 , _:c14n238 , _:c14n239 , _:c14n240 , _:c14n242 , _:c14n261 , _:c14n263 , _:c14n264 , _:c14n267 , _:c14n280 , _:c14n282 , _:c14n3 , _:c14n304 , _:c14n305 , _:c14n31 , _:c14n311 , _:c14n315 , _:c14n317 , _:c14n318 , _:c14n323 , _:c14n33 , _:c14n38 , _:c14n44 , _:c14n45 , _:c14n5 , _:c14n81 , _:c14n85 , _:c14n86 , _:c14n93 , _:c14n95 ;
+	sh:targetClass openlabel_v2:OddScenery .
 openlabel_v2:RoadUser a sh:NodeShape ;
-    rdfs:comment "Something which uses a road to travel."@en ;
-    sh:closed true ;
-    sh:ignoredProperties ( rdf:type ) ;
-    sh:property [ sh:description "Speed (km/h)."@en ;
-            sh:maxCount 1 ;
-            sh:message "motionDriveValue (RoadUser): Speed (km/h)."@en ;
-            sh:or ( [ sh:datatype xsd:decimal ;
-                        sh:nodeKind sh:Literal ] [ sh:class schema:QuantitativeValue ] ) ;
-            sh:order 3 ;
-            sh:path openlabel_v2:motionDriveValue ],
-        [ sh:description "Vehicle type."@en ;
-            sh:in ( openlabel_v2:VehicleAgricultural openlabel_v2:VehicleBus openlabel_v2:VehicleCar openlabel_v2:VehicleConstruction openlabel_v2:VehicleCycle openlabel_v2:VehicleEmergency openlabel_v2:VehicleMotorcycle openlabel_v2:VehicleTrailer openlabel_v2:VehicleTruck openlabel_v2:VehicleVan openlabel_v2:VehicleWheelchair ) ;
-            sh:maxCount 1 ;
-            sh:message "RoadUserVehicle (RoadUser): Vehicle type."@en ;
-            sh:order 2 ;
-            sh:path openlabel_v2:RoadUserVehicle ],
-        [ sh:datatype xsd:boolean ;
-            sh:description "Animal road user flag."@en ;
-            sh:maxCount 1 ;
-            sh:message "RoadUserAnimal (RoadUser): Animal road user flag."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 0 ;
-            sh:path openlabel_v2:RoadUserAnimal ],
-        [ sh:description "Human road user type."@en ;
-            sh:in ( openlabel_v2:HumanAnimalRider openlabel_v2:HumanCyclist openlabel_v2:HumanDriver openlabel_v2:HumanMotorcyclist openlabel_v2:HumanPassenger openlabel_v2:HumanPedestrian openlabel_v2:HumanWheelchairUser ) ;
-            sh:maxCount 1 ;
-            sh:message "RoadUserHuman (RoadUser): Human road user type."@en ;
-            sh:order 1 ;
-            sh:path openlabel_v2:RoadUserHuman ] ;
-    sh:targetClass openlabel_v2:RoadUser .
-
-schema:QuantitativeValue a sh:NodeShape ;
-    rdfs:comment "A point value or interval for quantitative measurements. Requires minValue and maxValue."@en ;
-    sh:closed true ;
-    sh:ignoredProperties ( rdf:type ) ;
-    sh:property [ sh:datatype xsd:decimal ;
-            sh:description "Upper bound inferred via RDFS from schema:maxValue being a subPropertyOf cmns-q:hasUpperBound in schema.org OWL."@en ;
-            sh:maxCount 1 ;
-            sh:message "hasUpperBound (QuantitativeValue): Upper bound inferred via RDFS from schema:maxValue being a subPropertyOf cmns-q:hasUpperBound in schema.org OWL."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 3 ;
-            sh:path cmns-q:hasUpperBound ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Minimum value of the range."@en ;
-            sh:maxCount 1 ;
-            sh:message "minValue (QuantitativeValue): Minimum value of the range."@en ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 0 ;
-            sh:path schema:minValue ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Maximum value of the range."@en ;
-            sh:maxCount 1 ;
-            sh:message "maxValue (QuantitativeValue): Maximum value of the range."@en ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 1 ;
-            sh:path schema:maxValue ],
-        [ sh:datatype xsd:decimal ;
-            sh:description "Lower bound inferred via RDFS from schema:minValue being a subPropertyOf cmns-q:hasLowerBound in schema.org OWL."@en ;
-            sh:maxCount 1 ;
-            sh:message "hasLowerBound (QuantitativeValue): Lower bound inferred via RDFS from schema:minValue being a subPropertyOf cmns-q:hasLowerBound in schema.org OWL."@en ;
-            sh:nodeKind sh:Literal ;
-            sh:order 2 ;
-            sh:path cmns-q:hasLowerBound ] ;
-    sh:targetClass schema:QuantitativeValue .
-
-
+	rdfs:comment "Something which uses a road to travel." ;
+	sh:closed true ;
+	sh:ignoredProperties _:c14n278 ;
+	sh:property _:c14n175 , _:c14n222 , _:c14n300 , _:c14n70 ;
+	sh:targetClass openlabel_v2:RoadUser .
+openlabel_v2:Scenario a sh:NodeShape ;
+	rdfs:comment "A scenario that can be tagged with OpenLABEL tags." ;
+	sh:closed true ;
+	sh:ignoredProperties _:c14n154 ;
+	sh:property _:c14n191 ;
+	sh:targetClass openlabel_v2:Scenario .
+openlabel_v2:Tag a sh:NodeShape ;
+	rdfs:comment "The base tag." ;
+	sh:closed true ;
+	sh:ignoredProperties _:c14n250 ;
+	sh:property _:c14n136 , _:c14n157 , _:c14n183 , _:c14n258 ;
+	sh:targetClass openlabel_v2:Tag .
+_:c14n0 sh:datatype xsd:boolean ;
+	sh:description "Up-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.i." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 31 ;
+	sh:path openlabel_v2:LongitudinalUpSlope .
+_:c14n1 sh:description "Direction of travel. Refer to BSI PAS-1883 Section 5.2.3.4.e." ;
+	sh:in _:c14n952 ;
+	sh:order 26 ;
+	sh:path openlabel_v2:LaneSpecificationTravelDirection .
+_:c14n10 sh:description "Temporary road structure. Refer to BSI PAS-1883 Section 5.2.1.f." ;
+	sh:in _:c14n894 ;
+	sh:maxCount 1 ;
+	sh:order 42 ;
+	sh:path openlabel_v2:SceneryTemporaryStructure .
+_:c14n100 sh:description "Agent type. Refer to BSI PAS-1883 Section 5.4.a.4." ;
+	sh:or _:c14n468 ;
+	sh:order 52 ;
+	sh:path openlabel_v2:trafficAgentTypeValue .
+_:c14n101 sh:datatype xsd:boolean ;
+	sh:description "Up-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.i." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 31 ;
+	sh:path openlabel_v2:LongitudinalUpSlope .
+_:c14n102 rdf:first rdf:type ;
+	rdf:rest rdf:nil .
+_:c14n103 sh:description "Agent type. Refer to BSI PAS-1883 Section 5.4.a.4." ;
+	sh:or _:c14n490 ;
+	sh:order 52 ;
+	sh:path openlabel_v2:trafficAgentTypeValue .
+_:c14n104 sh:description "Agent type. Refer to BSI PAS-1883 Section 5.4.a.4." ;
+	sh:or _:c14n435 ;
+	sh:order 52 ;
+	sh:path openlabel_v2:trafficAgentTypeValue .
+_:c14n105 sh:datatype xsd:boolean ;
+	sh:description "Subject vehicle speed flag. Refer to BSI PAS-1883 Section 5.4.b." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 47 ;
+	sh:path openlabel_v2:SubjectVehicleSpeed .
+_:c14n106 sh:datatype xsd:boolean ;
+	sh:description "An activity where the road user is closer to the object by the end." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 18 ;
+	sh:path openlabel_v2:MotionTowards .
+_:c14n107 sh:datatype xsd:decimal ;
+	sh:description "Visibility (km). Refer to BSI PAS-1883 Section 5.3.1.3." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 61 ;
+	sh:path openlabel_v2:weatherSnowValue .
+_:c14n108 sh:datatype xsd:boolean ;
+	sh:description "Level plane flag. Refer to BSI PAS-1883 Section 5.2.3.3.iii." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 30 ;
+	sh:path openlabel_v2:LongitudinalLevelPlane .
+_:c14n109 sh:description "Lane type. Refer to BSI PAS-1883 Section 5.2.3.4.c." ;
+	sh:in _:c14n336 ;
+	sh:order 27 ;
+	sh:path openlabel_v2:LaneSpecificationType .
+_:c14n11 sh:datatype xsd:boolean ;
+	sh:description "Level plane flag. Refer to BSI PAS-1883 Section 5.2.3.3.iii." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 30 ;
+	sh:path openlabel_v2:LongitudinalLevelPlane .
+_:c14n110 sh:datatype xsd:boolean ;
+	sh:description "An activity where a pedestrian is slipping/sliding on the road." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 16 ;
+	sh:path openlabel_v2:MotionSlide .
+_:c14n111 sh:datatype xsd:boolean ;
+	sh:description "Subject exits the intersection on a road to the left of the original." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 20 ;
+	sh:path openlabel_v2:MotionTurnLeft .
+_:c14n112 sh:description "Communication connectivity type. Refer to BSI PAS-1883 Section 5.3.4.a." ;
+	sh:in _:c14n506 ;
+	sh:maxCount 1 ;
+	sh:order 0 ;
+	sh:path openlabel_v2:ConnectivityCommunication .
+_:c14n113 sh:datatype xsd:decimal ;
+	sh:description "Upper bound inferred via RDFS from schema:maxValue being a subPropertyOf cmns-q:hasUpperBound in schema.org OWL." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 3 ;
+	sh:path cmns-q:hasUpperBound .
+_:c14n114 sh:datatype xsd:decimal ;
+	sh:description "Rainfall intensity (mm/h). Refer to BSI PAS-1883 Section 5.3.1.2." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 59 ;
+	sh:path openlabel_v2:weatherRainValue .
+_:c14n115 sh:description "Speed (km/h)." ;
+	sh:maxCount 1 ;
+	sh:or _:c14n560 ;
+	sh:order 10 ;
+	sh:path openlabel_v2:motionDriveValue .
+_:c14n116 sh:datatype xsd:decimal ;
+	sh:description "Visibility (km). Refer to BSI PAS-1883 Section 5.3.1.3." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 61 ;
+	sh:path openlabel_v2:weatherSnowValue .
+_:c14n117 sh:datatype xsd:boolean ;
+	sh:description "An activity where the trajectory of the road user crosses the trajectory of the object." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 4 ;
+	sh:path openlabel_v2:MotionCross .
+_:c14n118 sh:datatype xsd:boolean ;
+	sh:description "Lane dimensions flag. Refer to BSI PAS-1883 Section 5.2.3.4.a." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 21 ;
+	sh:path openlabel_v2:LaneSpecificationDimensions .
+_:c14n119 sh:datatype xsd:boolean ;
+	sh:description "Straight lines flag. Refer to BSI PAS-1883 Section 5.2.3.3." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 14 ;
+	sh:path openlabel_v2:HorizontalStraights .
+_:c14n12 sh:datatype xsd:boolean ;
+	sh:description "Non-precipitating water droplets or ice crystals (mist/fog) flag. Refer to BSI PAS-1883 Section 5.3.2.b." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 37 ;
+	sh:path openlabel_v2:ParticulatesWater .
+_:c14n120 sh:datatype xsd:boolean ;
+	sh:description "Elevation of the sun above the horizon flag. Refer to BSI PAS-1883 Section 5.3.3.a.1." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 2 ;
+	sh:path openlabel_v2:DaySunElevation .
+_:c14n121 sh:description "Road surface condition. Refer to BSI PAS-1883 Section 5.2.3.7.c." ;
+	sh:in _:c14n705 ;
+	sh:maxCount 1 ;
+	sh:order 6 ;
+	sh:path openlabel_v2:DrivableAreaSurfaceCondition .
+_:c14n122 sh:datatype xsd:integer ;
+	sh:description "Volume (vehicle km). Refer to BSI PAS-1883 Section 5.4.a.2." ;
+	sh:maxCount 1 ;
+	sh:minInclusive 0 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 57 ;
+	sh:path openlabel_v2:trafficVolumeValue .
+_:c14n123 sh:datatype xsd:boolean ;
+	sh:description "Elevation of the sun above the horizon flag. Refer to BSI PAS-1883 Section 5.3.3.a.1." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 2 ;
+	sh:path openlabel_v2:DaySunElevation .
+_:c14n124 sh:description "Positioning system type. Refer to BSI PAS-1883 Section 5.3.4.b." ;
+	sh:in _:c14n821 ;
+	sh:maxCount 1 ;
+	sh:order 1 ;
+	sh:path openlabel_v2:ConnectivityPositioning .
+_:c14n125 sh:description "Low light condition. Refer to BSI PAS-1883 Section 5.3.3.b." ;
+	sh:in _:c14n946 ;
+	sh:order 18 ;
+	sh:path openlabel_v2:IlluminationLowLight .
+_:c14n126 rdf:first rdf:type ;
+	rdf:rest rdf:nil .
+_:c14n127 sh:description "Position of the sun. Refer to BSI PAS-1883 Section 5.3.3.a.2." ;
+	sh:in _:c14n666 ;
+	sh:order 4 ;
+	sh:path openlabel_v2:DaySunPosition .
+_:c14n128 sh:datatype xsd:decimal ;
+	sh:description "Rainfall intensity (mm/h). Refer to BSI PAS-1883 Section 5.3.1.2." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 59 ;
+	sh:path openlabel_v2:weatherRainValue .
+_:c14n129 sh:description "Information sign type. Refer to BSI PAS-1883 Section 5.2.3.5.a." ;
+	sh:in _:c14n542 ;
+	sh:maxCount 1 ;
+	sh:order 44 ;
+	sh:path openlabel_v2:SignsInformation .
+_:c14n13 sh:description "Information sign type. Refer to BSI PAS-1883 Section 5.2.3.5.a." ;
+	sh:in _:c14n534 ;
+	sh:order 44 ;
+	sh:path openlabel_v2:SignsInformation .
+_:c14n130 sh:description "Positioning system type. Refer to BSI PAS-1883 Section 5.3.4.b." ;
+	sh:in _:c14n818 ;
+	sh:order 1 ;
+	sh:path openlabel_v2:ConnectivityPositioning .
+_:c14n131 sh:datatype xsd:decimal ;
+	sh:description "Meteorological Optical Range (MOR) (m). Refer to BSI PAS-1883 Section 5.3.2.b." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 38 ;
+	sh:path openlabel_v2:particulatesWaterValue .
+_:c14n132 sh:description "Lane type. Refer to BSI PAS-1883 Section 5.2.3.4.c." ;
+	sh:in _:c14n324 ;
+	sh:order 27 ;
+	sh:path openlabel_v2:LaneSpecificationType .
+_:c14n133 sh:datatype xsd:string ;
+	sh:description "The name of the scenario." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 8 ;
+	sh:path openlabel_v2:scenarioName .
+_:c14n134 sh:datatype xsd:boolean ;
+	sh:description "Non-precipitating water droplets or ice crystals (mist/fog) flag. Refer to BSI PAS-1883 Section 5.3.2.b." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 37 ;
+	sh:path openlabel_v2:ParticulatesWater .
+_:c14n135 sh:datatype xsd:decimal ;
+	sh:description "Rainfall intensity (mm/h). Refer to BSI PAS-1883 Section 5.3.1.2." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 59 ;
+	sh:path openlabel_v2:weatherRainValue .
+_:c14n136 sh:class openlabel_v2:Behaviour ;
+	sh:description "Behaviour tag." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:BlankNodeOrIRI ;
+	sh:order 1 ;
+	sh:path openlabel_v2:Behaviour .
+_:c14n137 sh:datatype xsd:boolean ;
+	sh:description "Elevation of the sun above the horizon flag. Refer to BSI PAS-1883 Section 5.3.3.a.1." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 2 ;
+	sh:path openlabel_v2:DaySunElevation .
+_:c14n138 sh:datatype xsd:decimal ;
+	sh:description "Maximum value of the range." ;
+	sh:maxCount 1 ;
+	sh:minCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 1 ;
+	sh:path sdo:maxValue .
+_:c14n139 sh:datatype xsd:boolean ;
+	sh:description "Traffic flow rate flag. Refer to BSI PAS-1883 Section 5.4.a.3." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 53 ;
+	sh:path openlabel_v2:TrafficFlowRate .
+_:c14n14 sh:description "Special road structure. Refer to BSI PAS-1883 Section 5.2.1.d." ;
+	sh:in _:c14n716 ;
+	sh:order 41 ;
+	sh:path openlabel_v2:ScenerySpecialStructure .
+_:c14n140 sh:description "Special road structure. Refer to BSI PAS-1883 Section 5.2.1.d." ;
+	sh:in _:c14n722 ;
+	sh:order 41 ;
+	sh:path openlabel_v2:ScenerySpecialStructure .
+_:c14n141 sh:datatype xsd:boolean ;
+	sh:description "Curves flag. Refer to BSI PAS-1883 Section 5.2.3.3." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 12 ;
+	sh:path openlabel_v2:HorizontalCurves .
+_:c14n142 sh:description "Fixed road structure. Refer to BSI PAS-1883 Section 5.2.1.e." ;
+	sh:in _:c14n907 ;
+	sh:maxCount 1 ;
+	sh:order 40 ;
+	sh:path openlabel_v2:SceneryFixedStructure .
+_:c14n143 sh:description "Special road structure. Refer to BSI PAS-1883 Section 5.2.1.d." ;
+	sh:in _:c14n728 ;
+	sh:maxCount 1 ;
+	sh:order 41 ;
+	sh:path openlabel_v2:ScenerySpecialStructure .
+_:c14n144 sh:datatype xsd:decimal ;
+	sh:description "Cloud cover (okta). Refer to BSI PAS-1883 Section 5.3.3.c." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 17 ;
+	sh:path openlabel_v2:illuminationCloudinessValue .
+_:c14n145 sh:description "Direction of travel. Refer to BSI PAS-1883 Section 5.2.3.4.e." ;
+	sh:in _:c14n954 ;
+	sh:maxCount 1 ;
+	sh:order 26 ;
+	sh:path openlabel_v2:LaneSpecificationTravelDirection .
+_:c14n146 sh:datatype xsd:boolean ;
+	sh:description "Straight lines flag. Refer to BSI PAS-1883 Section 5.2.3.3." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 14 ;
+	sh:path openlabel_v2:HorizontalStraights .
+_:c14n147 rdf:first rdf:type ;
+	rdf:rest rdf:nil .
+_:c14n148 sh:datatype xsd:boolean ;
+	sh:description "Volcanic ash flag. Refer to BSI PAS-1883 Section 5.3.2.e." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 36 ;
+	sh:path openlabel_v2:ParticulatesVolcanic .
+_:c14n149 sh:datatype xsd:boolean ;
+	sh:description "An activity where the subject vehicle is in a lane right of the original." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 12 ;
+	sh:path openlabel_v2:MotionLaneChangeRight .
+_:c14n15 sh:description "Number of lanes (unit). Refer to BSI PAS-1883 Section 5.2.3.4.d." ;
+	sh:maxCount 1 ;
+	sh:or _:c14n858 ;
+	sh:order 24 ;
+	sh:path openlabel_v2:laneSpecificationLaneCountValue .
+_:c14n150 sh:datatype xsd:boolean ;
+	sh:description "Number of lanes flag. Refer to BSI PAS-1883 Section 5.2.3.4.d." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 23 ;
+	sh:path openlabel_v2:LaneSpecificationLaneCount .
+_:c14n151 sh:datatype xsd:string ;
+	sh:description "The version number of the scenario." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 11 ;
+	sh:path openlabel_v2:scenarioVersion .
+_:c14n152 sh:description "Particulate type. Refer to BSI PAS-1883 Section 5.3.2." ;
+	sh:in _:c14n364 ;
+	sh:order 10 ;
+	sh:path openlabel_v2:EnvironmentParticulates .
+_:c14n153 sh:datatype xsd:boolean ;
+	sh:description "Level plane flag. Refer to BSI PAS-1883 Section 5.2.3.3.iii." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 30 ;
+	sh:path openlabel_v2:LongitudinalLevelPlane .
+_:c14n154 rdf:first rdf:type ;
+	rdf:rest rdf:nil .
+_:c14n155 sh:datatype xsd:boolean ;
+	sh:description "Cloudiness flag. Refer to BSI PAS-1883 Section 5.3.3.c." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 16 ;
+	sh:path openlabel_v2:IlluminationCloudiness .
+_:c14n156 sh:datatype xsd:boolean ;
+	sh:description "Straight lines flag. Refer to BSI PAS-1883 Section 5.2.3.3." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 14 ;
+	sh:path openlabel_v2:HorizontalStraights .
+_:c14n157 sh:class openlabel_v2:RoadUser ;
+	sh:description "Road user tag." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:BlankNodeOrIRI ;
+	sh:order 3 ;
+	sh:path openlabel_v2:RoadUser .
+_:c14n158 sh:description "Fixed road structure. Refer to BSI PAS-1883 Section 5.2.1.e." ;
+	sh:in _:c14n911 ;
+	sh:maxCount 1 ;
+	sh:order 40 ;
+	sh:path openlabel_v2:SceneryFixedStructure .
+_:c14n159 sh:datatype xsd:boolean ;
+	sh:description "Sand and dust flag. Refer to BSI PAS-1883 Section 5.3.2.c." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 33 ;
+	sh:path openlabel_v2:ParticulatesDust .
+_:c14n16 sh:description "Road surface feature. Refer to BSI PAS-1883 Section 5.2.3.7.b." ;
+	sh:in _:c14n592 ;
+	sh:maxCount 1 ;
+	sh:order 7 ;
+	sh:path openlabel_v2:DrivableAreaSurfaceFeature .
+_:c14n160 sh:datatype xsd:boolean ;
+	sh:description "An activity where the road user increases their velocity." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 1 ;
+	sh:path openlabel_v2:MotionAccelerate .
+_:c14n161 sh:description "Roundabout type. Refer to BSI PAS-1883 Section 5.2.4." ;
+	sh:in _:c14n638 ;
+	sh:order 20 ;
+	sh:path openlabel_v2:JunctionRoundabout .
+_:c14n162 sh:datatype xsd:boolean ;
+	sh:description "Wind flag. Refer to BSI PAS-1883 Section 5.3.1.1." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 62 ;
+	sh:path openlabel_v2:WeatherWind .
+_:c14n163 sh:description "Road type. Refer to BSI PAS-1883 Section 5.2.3.2." ;
+	sh:in _:c14n751 ;
+	sh:order 9 ;
+	sh:path openlabel_v2:DrivableAreaType .
+_:c14n164 sh:datatype xsd:string ;
+	sh:description "The name of the legal entity who owns the rights to the scenario." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 2 ;
+	sh:path openlabel_v2:ownerName .
+_:c14n165 sh:datatype xsd:boolean ;
+	sh:description "Lane marking flag. Refer to BSI PAS-1883 Section 5.2.3.4.b." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 25 ;
+	sh:path openlabel_v2:LaneSpecificationMarking .
+_:c14n166 sh:datatype xsd:boolean ;
+	sh:description "Sand and dust flag. Refer to BSI PAS-1883 Section 5.3.2.c." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 33 ;
+	sh:path openlabel_v2:ParticulatesDust .
+_:c14n167 sh:datatype xsd:boolean ;
+	sh:description "Subject performs a turn resulting in heading in the opposite direction." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 22 ;
+	sh:path openlabel_v2:MotionUTurn .
+_:c14n168 sh:description "Information sign type. Refer to BSI PAS-1883 Section 5.2.3.5.a." ;
+	sh:in _:c14n546 ;
+	sh:order 44 ;
+	sh:path openlabel_v2:SignsInformation .
+_:c14n169 sh:datatype xsd:decimal ;
+	sh:description "Wind speed (m/s). Refer to BSI PAS-1883 Section 5.3.1.1." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 63 ;
+	sh:path openlabel_v2:weatherWindValue .
+_:c14n17 sh:datatype xsd:boolean ;
+	sh:description "Locomotion mode where at least one foot is always on the ground." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 23 ;
+	sh:path openlabel_v2:MotionWalk .
+_:c14n170 sh:datatype xsd:boolean ;
+	sh:description "Subject vehicle speed flag. Refer to BSI PAS-1883 Section 5.4.b." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 47 ;
+	sh:path openlabel_v2:SubjectVehicleSpeed .
+_:c14n171 sh:description "Communication connectivity type. Refer to BSI PAS-1883 Section 5.3.4.a." ;
+	sh:in _:c14n522 ;
+	sh:order 0 ;
+	sh:path openlabel_v2:ConnectivityCommunication .
+_:c14n172 sh:datatype xsd:boolean ;
+	sh:description "Rainfall flag. Refer to BSI PAS-1883 Section 5.3.1.2." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 58 ;
+	sh:path openlabel_v2:WeatherRain .
+_:c14n173 sh:datatype xsd:boolean ;
+	sh:description "Wind flag. Refer to BSI PAS-1883 Section 5.3.1.1." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 62 ;
+	sh:path openlabel_v2:WeatherWind .
+_:c14n174 sh:description "Transverse geometry type. Refer to BSI PAS-1883 Section 5.2.3.3.b." ;
+	sh:in _:c14n919 ;
+	sh:order 11 ;
+	sh:path openlabel_v2:GeometryTransverse .
+_:c14n175 sh:description "Vehicle type." ;
+	sh:in _:c14n454 ;
+	sh:maxCount 1 ;
+	sh:order 2 ;
+	sh:path openlabel_v2:RoadUserVehicle .
+_:c14n176 sh:description "Lane type. Refer to BSI PAS-1883 Section 5.2.3.4.c." ;
+	sh:in _:c14n342 ;
+	sh:order 27 ;
+	sh:path openlabel_v2:LaneSpecificationType .
+_:c14n177 sh:description "Position of the sun. Refer to BSI PAS-1883 Section 5.3.3.a.2." ;
+	sh:in _:c14n678 ;
+	sh:maxCount 1 ;
+	sh:order 4 ;
+	sh:path openlabel_v2:DaySunPosition .
+_:c14n178 sh:description "Low light condition. Refer to BSI PAS-1883 Section 5.3.3.b." ;
+	sh:in _:c14n948 ;
+	sh:order 18 ;
+	sh:path openlabel_v2:IlluminationLowLight .
+_:c14n179 sh:description "Positioning system type. Refer to BSI PAS-1883 Section 5.3.4.b." ;
+	sh:in _:c14n812 ;
+	sh:order 1 ;
+	sh:path openlabel_v2:ConnectivityPositioning .
+_:c14n18 sh:datatype xsd:boolean ;
+	sh:description "Lane marking flag. Refer to BSI PAS-1883 Section 5.2.3.4.b." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 25 ;
+	sh:path openlabel_v2:LaneSpecificationMarking .
+_:c14n180 sh:datatype xsd:boolean ;
+	sh:description "An activity where the road user is further away from the object by the end." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 3 ;
+	sh:path openlabel_v2:MotionAway .
+_:c14n181 sh:datatype xsd:boolean ;
+	sh:description "Presence of special vehicles flag. Refer to BSI PAS-1883 Section 5.4.a.5." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 55 ;
+	sh:path openlabel_v2:TrafficSpecialVehicle .
+_:c14n182 rdf:first openlabel_v2:CommunicationWave ;
+	rdf:rest rdf:nil .
+_:c14n183 sh:class openlabel_v2:AdminTag ;
+	sh:description "Administration tag." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:BlankNodeOrIRI ;
+	sh:order 0 ;
+	sh:path openlabel_v2:AdminTag .
+_:c14n184 sh:description "Roundabout type. Refer to BSI PAS-1883 Section 5.2.4." ;
+	sh:in _:c14n628 ;
+	sh:maxCount 1 ;
+	sh:order 20 ;
+	sh:path openlabel_v2:JunctionRoundabout .
+_:c14n185 sh:datatype xsd:decimal ;
+	sh:description "Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.ii." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 29 ;
+	sh:path openlabel_v2:longitudinalDownSlopeValue .
+_:c14n186 sh:datatype xsd:string ;
+	sh:description "A description of the scenario." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 7 ;
+	sh:path openlabel_v2:scenarioDescription .
+_:c14n187 sh:description "Intersection type. Refer to BSI PAS-1883 Section 5.2.4." ;
+	sh:in _:c14n778 ;
+	sh:order 19 ;
+	sh:path openlabel_v2:JunctionIntersection .
+_:c14n188 sh:description "Number of lanes (unit). Refer to BSI PAS-1883 Section 5.2.3.4.d." ;
+	sh:or _:c14n878 ;
+	sh:order 24 ;
+	sh:path openlabel_v2:laneSpecificationLaneCountValue .
+_:c14n189 sh:datatype xsd:boolean ;
+	sh:description "Traffic volume flag. Refer to BSI PAS-1883 Section 5.4.a.2." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 56 ;
+	sh:path openlabel_v2:TrafficVolume .
+_:c14n19 sh:datatype xsd:boolean ;
+	sh:description "An activity where the object vehicle suddenly moves out of the lane." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 6 ;
+	sh:path openlabel_v2:MotionCutOut .
+_:c14n190 sh:description "Speed (km/h). Refer to BSI PAS-1883 Section 5.4.b." ;
+	sh:or _:c14n854 ;
+	sh:order 48 ;
+	sh:path openlabel_v2:subjectVehicleSpeedValue .
+_:c14n191 sh:class openlabel_v2:Tag ;
+	sh:description "A tag associated with a scenario." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:BlankNodeOrIRI ;
+	sh:order 0 ;
+	sh:path openlabel_v2:hasTag .
+_:c14n192 sh:description "Communication connectivity type. Refer to BSI PAS-1883 Section 5.3.4.a." ;
+	sh:in _:c14n514 ;
+	sh:order 0 ;
+	sh:path openlabel_v2:ConnectivityCommunication .
+_:c14n193 sh:datatype xsd:decimal ;
+	sh:description "Minimum value of the range." ;
+	sh:maxCount 1 ;
+	sh:minCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 0 ;
+	sh:path sdo:minValue .
+_:c14n194 sh:datatype xsd:decimal ;
+	sh:description "Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.ii." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 29 ;
+	sh:path openlabel_v2:longitudinalDownSlopeValue .
+_:c14n195 sh:datatype xsd:decimal ;
+	sh:description "Visibility (km). Refer to BSI PAS-1883 Section 5.3.1.3." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 61 ;
+	sh:path openlabel_v2:weatherSnowValue .
+_:c14n196 sh:description "Artificial illumination type. Refer to BSI PAS-1883 Section 5.3.3.d." ;
+	sh:in _:c14n936 ;
+	sh:order 15 ;
+	sh:path openlabel_v2:IlluminationArtificial .
+_:c14n197 sh:datatype xsd:boolean ;
+	sh:description "Elevation of the sun above the horizon flag. Refer to BSI PAS-1883 Section 5.3.3.a.1." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 2 ;
+	sh:path openlabel_v2:DaySunElevation .
+_:c14n198 sh:datatype xsd:boolean ;
+	sh:description "Up-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.i." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 31 ;
+	sh:path openlabel_v2:LongitudinalUpSlope .
+_:c14n199 sh:datatype xsd:boolean ;
+	sh:description "Subject vehicle speed flag. Refer to BSI PAS-1883 Section 5.4.b." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 47 ;
+	sh:path openlabel_v2:SubjectVehicleSpeed .
+_:c14n2 rdf:first openlabel_v2:CommunicationSignalSlowing ;
+	rdf:rest _:c14n182 .
+_:c14n20 sh:datatype xsd:boolean ;
+	sh:description "Lane marking flag. Refer to BSI PAS-1883 Section 5.2.3.4.b." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 25 ;
+	sh:path openlabel_v2:LaneSpecificationMarking .
+_:c14n200 sh:datatype xsd:boolean ;
+	sh:description "Curves flag. Refer to BSI PAS-1883 Section 5.2.3.3." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 12 ;
+	sh:path openlabel_v2:HorizontalCurves .
+_:c14n201 sh:description "Road surface type. Refer to BSI PAS-1883 Section 5.2.3.7.a." ;
+	sh:in _:c14n359 ;
+	sh:order 8 ;
+	sh:path openlabel_v2:DrivableAreaSurfaceType .
+_:c14n202 sh:description "Warning sign type. Refer to BSI PAS-1883 Section 5.2.3.5.c." ;
+	sh:in _:c14n389 ;
+	sh:maxCount 1 ;
+	sh:order 46 ;
+	sh:path openlabel_v2:SignsWarning .
+_:c14n203 sh:description "Particulate type. Refer to BSI PAS-1883 Section 5.3.2." ;
+	sh:in _:c14n379 ;
+	sh:order 10 ;
+	sh:path openlabel_v2:EnvironmentParticulates .
+_:c14n204 rdf:first rdf:type ;
+	rdf:rest rdf:nil .
+_:c14n205 sh:description "Positioning system type. Refer to BSI PAS-1883 Section 5.3.4.b." ;
+	sh:in _:c14n815 ;
+	sh:maxCount 1 ;
+	sh:order 1 ;
+	sh:path openlabel_v2:ConnectivityPositioning .
+_:c14n206 sh:datatype xsd:boolean ;
+	sh:description "Traffic agent type classification flag. Refer to BSI PAS-1883 Section 5.4.a.4." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 51 ;
+	sh:path openlabel_v2:TrafficAgentType .
+_:c14n207 sh:description "Road surface feature. Refer to BSI PAS-1883 Section 5.2.3.7.b." ;
+	sh:in _:c14n580 ;
+	sh:order 7 ;
+	sh:path openlabel_v2:DrivableAreaSurfaceFeature .
+_:c14n208 sh:datatype xsd:decimal ;
+	sh:description "Sun elevation (degrees). Refer to BSI PAS-1883 Section 5.3.3.a.1." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 3 ;
+	sh:path openlabel_v2:daySunElevationValue .
+_:c14n209 rdf:first rdf:type ;
+	rdf:rest rdf:nil .
+_:c14n21 sh:datatype xsd:boolean ;
+	sh:description "Traffic volume flag. Refer to BSI PAS-1883 Section 5.4.a.2." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 56 ;
+	sh:path openlabel_v2:TrafficVolume .
+_:c14n210 sh:datatype xsd:decimal ;
+	sh:description "Meteorological Optical Range (MOR) (m). Refer to BSI PAS-1883 Section 5.3.2.b." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 38 ;
+	sh:path openlabel_v2:particulatesWaterValue .
+_:c14n211 sh:datatype xsd:integer ;
+	sh:description "Rate (vehicles/h). Refer to BSI PAS-1883 Section 5.4.a.3." ;
+	sh:maxCount 1 ;
+	sh:minInclusive 0 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 54 ;
+	sh:path openlabel_v2:trafficFlowRateValue .
+_:c14n212 sh:description "Artificial illumination type. Refer to BSI PAS-1883 Section 5.3.3.d." ;
+	sh:in _:c14n940 ;
+	sh:order 15 ;
+	sh:path openlabel_v2:IlluminationArtificial .
+_:c14n213 sh:datatype xsd:boolean ;
+	sh:description "Traffic flow rate flag. Refer to BSI PAS-1883 Section 5.4.a.3." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 53 ;
+	sh:path openlabel_v2:TrafficFlowRate .
+_:c14n214 sh:datatype xsd:boolean ;
+	sh:description "Number of lanes flag. Refer to BSI PAS-1883 Section 5.2.3.4.d." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 23 ;
+	sh:path openlabel_v2:LaneSpecificationLaneCount .
+_:c14n215 sh:description "Number of lanes (unit). Refer to BSI PAS-1883 Section 5.2.3.4.d." ;
+	sh:maxCount 1 ;
+	sh:or _:c14n874 ;
+	sh:order 24 ;
+	sh:path openlabel_v2:laneSpecificationLaneCountValue .
+_:c14n216 sh:description "Special road structure. Refer to BSI PAS-1883 Section 5.2.1.d." ;
+	sh:in _:c14n710 ;
+	sh:maxCount 1 ;
+	sh:order 41 ;
+	sh:path openlabel_v2:ScenerySpecialStructure .
+_:c14n217 sh:datatype xsd:boolean ;
+	sh:description "Curves flag. Refer to BSI PAS-1883 Section 5.2.3.3." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 12 ;
+	sh:path openlabel_v2:HorizontalCurves .
+_:c14n218 sh:datatype xsd:decimal ;
+	sh:description "Cloud cover (okta). Refer to BSI PAS-1883 Section 5.3.3.c." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 17 ;
+	sh:path openlabel_v2:illuminationCloudinessValue .
+_:c14n219 sh:datatype xsd:string ;
+	sh:description "The email address of the legal entity who owns the rights to the scenario." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 1 ;
+	sh:path openlabel_v2:ownerEmail .
+_:c14n22 sh:datatype xsd:boolean ;
+	sh:description "Marine (coastal areas only) flag. Refer to BSI PAS-1883 Section 5.3.2.a." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 34 ;
+	sh:path openlabel_v2:ParticulatesMarine .
+_:c14n220 sh:datatype xsd:boolean ;
+	sh:description "An activity where the subject vehicle is in a lane left of the original." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 11 ;
+	sh:path openlabel_v2:MotionLaneChangeLeft .
+_:c14n221 sh:datatype xsd:boolean ;
+	sh:description "Traffic volume flag. Refer to BSI PAS-1883 Section 5.4.a.2." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 56 ;
+	sh:path openlabel_v2:TrafficVolume .
+_:c14n222 sh:datatype xsd:boolean ;
+	sh:description "Animal road user flag." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 0 ;
+	sh:path openlabel_v2:RoadUserAnimal .
+_:c14n223 sh:datatype xsd:decimal ;
+	sh:description "Curve radius (m). Refer to BSI PAS-1883 Section 5.2.3.3." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 13 ;
+	sh:path openlabel_v2:horizontalCurvesValue .
+_:c14n224 sh:datatype xsd:boolean ;
+	sh:description "An activity where the subject vehicle ends up directly in front of the object vehicle." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 5 ;
+	sh:path openlabel_v2:MotionCutIn .
+_:c14n225 sh:description "Zone type. Refer to BSI PAS-1883 Section 5.2.1.a." ;
+	sh:in _:c14n798 ;
+	sh:maxCount 1 ;
+	sh:order 43 ;
+	sh:path openlabel_v2:SceneryZone .
+_:c14n226 sh:description "Rainfall type. Refer to BSI PAS-1883 Section 5.3.1.2." ;
+	sh:in _:c14n849 ;
+	sh:order 39 ;
+	sh:path openlabel_v2:RainType .
+_:c14n227 sh:datatype xsd:boolean ;
+	sh:description "Subject vehicle speed flag. Refer to BSI PAS-1883 Section 5.4.b." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 47 ;
+	sh:path openlabel_v2:SubjectVehicleSpeed .
+_:c14n228 sh:datatype xsd:boolean ;
+	sh:description "An activity where the subject vehicle is moving in the opposite direction to which it is facing." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 14 ;
+	sh:path openlabel_v2:MotionReverse .
+_:c14n229 sh:description "Low light condition. Refer to BSI PAS-1883 Section 5.3.3.b." ;
+	sh:in _:c14n942 ;
+	sh:maxCount 1 ;
+	sh:order 18 ;
+	sh:path openlabel_v2:IlluminationLowLight .
+_:c14n23 sh:description "Temporary road structure. Refer to BSI PAS-1883 Section 5.2.1.f." ;
+	sh:in _:c14n886 ;
+	sh:order 42 ;
+	sh:path openlabel_v2:SceneryTemporaryStructure .
+_:c14n230 sh:datatype xsd:boolean ;
+	sh:description "Traffic agent type classification flag. Refer to BSI PAS-1883 Section 5.4.a.4." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 51 ;
+	sh:path openlabel_v2:TrafficAgentType .
+_:c14n231 rdf:first openlabel_v2:CommunicationSignalLeft ;
+	rdf:rest _:c14n283 .
+_:c14n232 rdf:first rdf:type ;
+	rdf:rest rdf:nil .
+_:c14n233 sh:datatype xsd:boolean ;
+	sh:description "Locomotion mode where at a specific point no foot touches the ground." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 15 ;
+	sh:path openlabel_v2:MotionRun .
+_:c14n234 sh:datatype xsd:decimal ;
+	sh:description "Curve radius (m). Refer to BSI PAS-1883 Section 5.2.3.3." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 13 ;
+	sh:path openlabel_v2:horizontalCurvesValue .
+_:c14n235 sh:datatype xsd:boolean ;
+	sh:description "Marine (coastal areas only) flag. Refer to BSI PAS-1883 Section 5.3.2.a." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 34 ;
+	sh:path openlabel_v2:ParticulatesMarine .
+_:c14n236 sh:datatype xsd:boolean ;
+	sh:description "Smoke and pollution flag. Refer to BSI PAS-1883 Section 5.3.2.d." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 35 ;
+	sh:path openlabel_v2:ParticulatesPollution .
+_:c14n237 sh:description "Temporary road structure. Refer to BSI PAS-1883 Section 5.2.1.f." ;
+	sh:in _:c14n890 ;
+	sh:maxCount 1 ;
+	sh:order 42 ;
+	sh:path openlabel_v2:SceneryTemporaryStructure .
+_:c14n238 sh:description "Regulatory sign type. Refer to BSI PAS-1883 Section 5.2.3.5.b." ;
+	sh:in _:c14n833 ;
+	sh:maxCount 1 ;
+	sh:order 45 ;
+	sh:path openlabel_v2:SignsRegulatory .
+_:c14n239 sh:description "Transverse geometry type. Refer to BSI PAS-1883 Section 5.2.3.3.b." ;
+	sh:in _:c14n929 ;
+	sh:maxCount 1 ;
+	sh:order 11 ;
+	sh:path openlabel_v2:GeometryTransverse .
+_:c14n24 sh:datatype xsd:boolean ;
+	sh:description "Traffic agent density flag. Refer to BSI PAS-1883 Section 5.4.a.1." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 49 ;
+	sh:path openlabel_v2:TrafficAgentDensity .
+_:c14n240 sh:description "Road type. Refer to BSI PAS-1883 Section 5.2.3.2." ;
+	sh:in _:c14n760 ;
+	sh:maxCount 1 ;
+	sh:order 9 ;
+	sh:path openlabel_v2:DrivableAreaType .
+_:c14n241 sh:description "Lane width (m). Refer to BSI PAS-1883 Section 5.2.3.4.a." ;
+	sh:maxCount 1 ;
+	sh:or _:c14n564 ;
+	sh:order 22 ;
+	sh:path openlabel_v2:laneSpecificationDimensionsValue .
+_:c14n242 sh:datatype xsd:boolean ;
+	sh:description "Traffic flow rate flag. Refer to BSI PAS-1883 Section 5.4.a.3." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 53 ;
+	sh:path openlabel_v2:TrafficFlowRate .
+_:c14n243 sh:description "Road surface condition. Refer to BSI PAS-1883 Section 5.2.3.7.c." ;
+	sh:in _:c14n684 ;
+	sh:order 6 ;
+	sh:path openlabel_v2:DrivableAreaSurfaceCondition .
+_:c14n244 sh:datatype xsd:boolean ;
+	sh:description "Traffic agent type classification flag. Refer to BSI PAS-1883 Section 5.4.a.4." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 51 ;
+	sh:path openlabel_v2:TrafficAgentType .
+_:c14n245 sh:description "Road surface type. Refer to BSI PAS-1883 Section 5.2.3.7.a." ;
+	sh:in _:c14n350 ;
+	sh:maxCount 1 ;
+	sh:order 8 ;
+	sh:path openlabel_v2:DrivableAreaSurfaceType .
+_:c14n246 sh:datatype xsd:string ;
+	sh:description "SDL definition of the scenario." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 5 ;
+	sh:path openlabel_v2:scenarioDefinition .
+_:c14n247 sh:description "Drivable area edge type. Refer to BSI PAS-1883 Section 5.2.3.1.e." ;
+	sh:in _:c14n606 ;
+	sh:order 5 ;
+	sh:path openlabel_v2:DrivableAreaEdge .
+_:c14n248 sh:description "Artificial illumination type. Refer to BSI PAS-1883 Section 5.3.3.d." ;
+	sh:in _:c14n934 ;
+	sh:maxCount 1 ;
+	sh:order 15 ;
+	sh:path openlabel_v2:IlluminationArtificial .
+_:c14n249 sh:datatype xsd:decimal ;
+	sh:description "Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.i." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 32 ;
+	sh:path openlabel_v2:longitudinalUpSlopeValue .
+_:c14n25 sh:datatype xsd:boolean ;
+	sh:description "Lane dimensions flag. Refer to BSI PAS-1883 Section 5.2.3.4.a." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 21 ;
+	sh:path openlabel_v2:LaneSpecificationDimensions .
+_:c14n250 rdf:first rdf:type ;
+	rdf:rest rdf:nil .
+_:c14n251 sh:datatype xsd:boolean ;
+	sh:description "Snowfall flag. Refer to BSI PAS-1883 Section 5.3.1.3." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 60 ;
+	sh:path openlabel_v2:WeatherSnow .
+_:c14n252 sh:datatype xsd:boolean ;
+	sh:description "Traffic agent density flag. Refer to BSI PAS-1883 Section 5.4.a.1." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 49 ;
+	sh:path openlabel_v2:TrafficAgentDensity .
+_:c14n253 sh:datatype xsd:boolean ;
+	sh:description "An activity where the subject vehicle is moving in the direction it is facing." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 9 ;
+	sh:path openlabel_v2:MotionDrive .
+_:c14n254 sh:datatype xsd:boolean ;
+	sh:description "Sand and dust flag. Refer to BSI PAS-1883 Section 5.3.2.c." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 33 ;
+	sh:path openlabel_v2:ParticulatesDust .
+_:c14n255 sh:description "Fixed road structure. Refer to BSI PAS-1883 Section 5.2.1.e." ;
+	sh:in _:c14n903 ;
+	sh:order 40 ;
+	sh:path openlabel_v2:SceneryFixedStructure .
+_:c14n256 rdf:first openlabel_v2:CommunicationHeadlightFlash ;
+	rdf:rest _:c14n62 .
+_:c14n257 sh:description "Rainfall type. Refer to BSI PAS-1883 Section 5.3.1.2." ;
+	sh:in _:c14n843 ;
+	sh:maxCount 1 ;
+	sh:order 39 ;
+	sh:path openlabel_v2:RainType .
+_:c14n258 sh:class openlabel_v2:Odd ;
+	sh:description "Operational Design Domain tag." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:BlankNodeOrIRI ;
+	sh:order 2 ;
+	sh:path openlabel_v2:Odd .
+_:c14n259 sh:datatype xsd:decimal ;
+	sh:description "Cloud cover (okta). Refer to BSI PAS-1883 Section 5.3.3.c." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 17 ;
+	sh:path openlabel_v2:illuminationCloudinessValue .
+_:c14n26 rdf:first openlabel_v2:CommunicationSignalHazard ;
+	rdf:rest _:c14n231 .
+_:c14n260 sh:description "Road surface type. Refer to BSI PAS-1883 Section 5.2.3.7.a." ;
+	sh:in _:c14n356 ;
+	sh:order 8 ;
+	sh:path openlabel_v2:DrivableAreaSurfaceType .
+_:c14n261 sh:datatype xsd:boolean ;
+	sh:description "Snowfall flag. Refer to BSI PAS-1883 Section 5.3.1.3." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 60 ;
+	sh:path openlabel_v2:WeatherSnow .
+_:c14n262 sh:datatype xsd:decimal ;
+	sh:description "Curve radius (m). Refer to BSI PAS-1883 Section 5.2.3.3." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 13 ;
+	sh:path openlabel_v2:horizontalCurvesValue .
+_:c14n263 sh:datatype xsd:integer ;
+	sh:description "Rate (vehicles/h). Refer to BSI PAS-1883 Section 5.4.a.3." ;
+	sh:minInclusive 0 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 54 ;
+	sh:path openlabel_v2:trafficFlowRateValue .
+_:c14n264 sh:datatype xsd:decimal ;
+	sh:description "Wind speed (m/s). Refer to BSI PAS-1883 Section 5.3.1.1." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 63 ;
+	sh:path openlabel_v2:weatherWindValue .
+_:c14n265 sh:datatype xsd:string ;
+	sh:description "Relative or absolute URL of a static image or animation of the scenario to allow users to easily see what the scenario represents." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 12 ;
+	sh:path openlabel_v2:scenarioVisualisationURL .
+_:c14n266 sh:datatype xsd:boolean ;
+	sh:description "Down-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.ii." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 28 ;
+	sh:path openlabel_v2:LongitudinalDownSlope .
+_:c14n267 sh:datatype xsd:boolean ;
+	sh:description "Lane dimensions flag. Refer to BSI PAS-1883 Section 5.2.3.4.a." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 21 ;
+	sh:path openlabel_v2:LaneSpecificationDimensions .
+_:c14n268 sh:datatype xsd:boolean ;
+	sh:description "Rainfall flag. Refer to BSI PAS-1883 Section 5.3.1.2." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 58 ;
+	sh:path openlabel_v2:WeatherRain .
+_:c14n269 sh:datatype xsd:boolean ;
+	sh:description "Subject exits the intersection on a road to the right of the original." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 21 ;
+	sh:path openlabel_v2:MotionTurnRight .
+_:c14n27 sh:description "Drivable area edge type. Refer to BSI PAS-1883 Section 5.2.3.1.e." ;
+	sh:in _:c14n600 ;
+	sh:order 5 ;
+	sh:path openlabel_v2:DrivableAreaEdge .
+_:c14n270 sh:datatype xsd:decimal ;
+	sh:description "Sun elevation (degrees). Refer to BSI PAS-1883 Section 5.3.3.a.1." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 3 ;
+	sh:path openlabel_v2:daySunElevationValue .
+_:c14n271 sh:datatype xsd:boolean ;
+	sh:description "Marine (coastal areas only) flag. Refer to BSI PAS-1883 Section 5.3.2.a." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 34 ;
+	sh:path openlabel_v2:ParticulatesMarine .
+_:c14n272 sh:datatype xsd:decimal ;
+	sh:description "Meteorological Optical Range (MOR) (m). Refer to BSI PAS-1883 Section 5.3.2.b." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 38 ;
+	sh:path openlabel_v2:particulatesWaterValue .
+_:c14n273 sh:datatype xsd:boolean ;
+	sh:description "An activity where the road user changes their heading." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 19 ;
+	sh:path openlabel_v2:MotionTurn .
+_:c14n274 sh:datatype xsd:integer ;
+	sh:description "Rate (vehicles/h). Refer to BSI PAS-1883 Section 5.4.a.3." ;
+	sh:minInclusive 0 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 54 ;
+	sh:path openlabel_v2:trafficFlowRateValue .
+_:c14n275 sh:datatype xsd:boolean ;
+	sh:description "Rainfall flag. Refer to BSI PAS-1883 Section 5.3.1.2." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 58 ;
+	sh:path openlabel_v2:WeatherRain .
+_:c14n276 sh:datatype xsd:boolean ;
+	sh:description "Cloudiness flag. Refer to BSI PAS-1883 Section 5.3.3.c." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 16 ;
+	sh:path openlabel_v2:IlluminationCloudiness .
+_:c14n277 sh:description "Lane width (m). Refer to BSI PAS-1883 Section 5.2.3.4.a." ;
+	sh:or _:c14n572 ;
+	sh:order 22 ;
+	sh:path openlabel_v2:laneSpecificationDimensionsValue .
+_:c14n278 rdf:first rdf:type ;
+	rdf:rest rdf:nil .
+_:c14n279 sh:description "Particulate type. Refer to BSI PAS-1883 Section 5.3.2." ;
+	sh:in _:c14n374 ;
+	sh:maxCount 1 ;
+	sh:order 10 ;
+	sh:path openlabel_v2:EnvironmentParticulates .
+_:c14n28 sh:description "Regulatory sign type. Refer to BSI PAS-1883 Section 5.2.3.5.b." ;
+	sh:in _:c14n825 ;
+	sh:maxCount 1 ;
+	sh:order 45 ;
+	sh:path openlabel_v2:SignsRegulatory .
+_:c14n280 sh:datatype xsd:boolean ;
+	sh:description "Traffic agent density flag. Refer to BSI PAS-1883 Section 5.4.a.1." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 49 ;
+	sh:path openlabel_v2:TrafficAgentDensity .
+_:c14n281 sh:description "Particulate type. Refer to BSI PAS-1883 Section 5.3.2." ;
+	sh:in _:c14n369 ;
+	sh:maxCount 1 ;
+	sh:order 10 ;
+	sh:path openlabel_v2:EnvironmentParticulates .
+_:c14n282 sh:description "Drivable area edge type. Refer to BSI PAS-1883 Section 5.2.3.1.e." ;
+	sh:in _:c14n612 ;
+	sh:order 5 ;
+	sh:path openlabel_v2:DrivableAreaEdge .
+_:c14n283 rdf:first openlabel_v2:CommunicationSignalRight ;
+	rdf:rest _:c14n2 .
+_:c14n284 sh:description "Communication type of road user behaviour." ;
+	sh:in _:c14n256 ;
+	sh:order 0 ;
+	sh:path openlabel_v2:BehaviourCommunication .
+_:c14n285 sh:description "Lane type. Refer to BSI PAS-1883 Section 5.2.3.4.c." ;
+	sh:in _:c14n330 ;
+	sh:order 27 ;
+	sh:path openlabel_v2:LaneSpecificationType .
+_:c14n286 sh:datatype xsd:boolean ;
+	sh:description "Non-precipitating water droplets or ice crystals (mist/fog) flag. Refer to BSI PAS-1883 Section 5.3.2.b." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 37 ;
+	sh:path openlabel_v2:ParticulatesWater .
+_:c14n287 sh:description "Roundabout type. Refer to BSI PAS-1883 Section 5.2.4." ;
+	sh:in _:c14n648 ;
+	sh:order 20 ;
+	sh:path openlabel_v2:JunctionRoundabout .
+_:c14n288 sh:datatype xsd:boolean ;
+	sh:description "Smoke and pollution flag. Refer to BSI PAS-1883 Section 5.3.2.d." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 35 ;
+	sh:path openlabel_v2:ParticulatesPollution .
+_:c14n289 sh:datatype xsd:decimal ;
+	sh:description "Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.i." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 32 ;
+	sh:path openlabel_v2:longitudinalUpSlopeValue .
+_:c14n29 sh:description "Agent type. Refer to BSI PAS-1883 Section 5.4.a.4." ;
+	sh:or _:c14n413 ;
+	sh:order 52 ;
+	sh:path openlabel_v2:trafficAgentTypeValue .
+_:c14n290 sh:datatype xsd:decimal ;
+	sh:description "Rainfall intensity (mm/h). Refer to BSI PAS-1883 Section 5.3.1.2." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 59 ;
+	sh:path openlabel_v2:weatherRainValue .
+_:c14n291 sh:description "Information sign type. Refer to BSI PAS-1883 Section 5.2.3.5.a." ;
+	sh:in _:c14n538 ;
+	sh:maxCount 1 ;
+	sh:order 44 ;
+	sh:path openlabel_v2:SignsInformation .
+_:c14n292 sh:datatype xsd:boolean ;
+	sh:description "Lane dimensions flag. Refer to BSI PAS-1883 Section 5.2.3.4.a." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 21 ;
+	sh:path openlabel_v2:LaneSpecificationDimensions .
+_:c14n293 sh:datatype xsd:boolean ;
+	sh:description "Snowfall flag. Refer to BSI PAS-1883 Section 5.3.1.3." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 60 ;
+	sh:path openlabel_v2:WeatherSnow .
+_:c14n294 sh:description "Lane width (m). Refer to BSI PAS-1883 Section 5.2.3.4.a." ;
+	sh:or _:c14n568 ;
+	sh:order 22 ;
+	sh:path openlabel_v2:laneSpecificationDimensionsValue .
+_:c14n295 sh:datatype xsd:boolean ;
+	sh:description "Cloudiness flag. Refer to BSI PAS-1883 Section 5.3.3.c." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 16 ;
+	sh:path openlabel_v2:IlluminationCloudiness .
+_:c14n296 sh:datatype xsd:decimal ;
+	sh:description "Sun elevation (degrees). Refer to BSI PAS-1883 Section 5.3.3.a.1." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 3 ;
+	sh:path openlabel_v2:daySunElevationValue .
+_:c14n297 sh:datatype xsd:string ;
+	sh:description "The URL of the legal entity who owns the rights to the scenario." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 3 ;
+	sh:path openlabel_v2:ownerURL .
+_:c14n298 sh:datatype xsd:boolean ;
+	sh:description "Snowfall flag. Refer to BSI PAS-1883 Section 5.3.1.3." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 60 ;
+	sh:path openlabel_v2:WeatherSnow .
+_:c14n299 sh:datatype xsd:string ;
+	sh:description "URI of SDL language used for the definition of the scenario." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 6 ;
+	sh:path openlabel_v2:scenarioDefinitionLanguageURI .
+_:c14n3 sh:datatype xsd:integer ;
+	sh:description "Density (vehicles/km). Refer to BSI PAS-1883 Section 5.4.a.1." ;
+	sh:minInclusive 0 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 50 ;
+	sh:path openlabel_v2:trafficAgentDensityValue .
+_:c14n30 sh:datatype xsd:boolean ;
+	sh:description "Down-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.ii." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 28 ;
+	sh:path openlabel_v2:LongitudinalDownSlope .
+_:c14n300 sh:description "Speed (km/h)." ;
+	sh:maxCount 1 ;
+	sh:or _:c14n552 ;
+	sh:order 3 ;
+	sh:path openlabel_v2:motionDriveValue .
+_:c14n301 sh:description "Zone type. Refer to BSI PAS-1883 Section 5.2.1.a." ;
+	sh:in _:c14n808 ;
+	sh:order 43 ;
+	sh:path openlabel_v2:SceneryZone .
+_:c14n302 sh:datatype xsd:integer ;
+	sh:description "Volume (vehicle km). Refer to BSI PAS-1883 Section 5.4.a.2." ;
+	sh:minInclusive 0 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 57 ;
+	sh:path openlabel_v2:trafficVolumeValue .
+_:c14n303 sh:datatype xsd:boolean ;
+	sh:description "Traffic agent density flag. Refer to BSI PAS-1883 Section 5.4.a.1." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 49 ;
+	sh:path openlabel_v2:TrafficAgentDensity .
+_:c14n304 sh:description "Road surface type. Refer to BSI PAS-1883 Section 5.2.3.7.a." ;
+	sh:in _:c14n353 ;
+	sh:maxCount 1 ;
+	sh:order 8 ;
+	sh:path openlabel_v2:DrivableAreaSurfaceType .
+_:c14n305 sh:datatype xsd:boolean ;
+	sh:description "Wind flag. Refer to BSI PAS-1883 Section 5.3.1.1." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 62 ;
+	sh:path openlabel_v2:WeatherWind .
+_:c14n306 sh:description "Zone type. Refer to BSI PAS-1883 Section 5.2.1.a." ;
+	sh:in _:c14n803 ;
+	sh:order 43 ;
+	sh:path openlabel_v2:SceneryZone .
+_:c14n307 sh:description "Drivable area edge type. Refer to BSI PAS-1883 Section 5.2.3.1.e." ;
+	sh:in _:c14n618 ;
+	sh:order 5 ;
+	sh:path openlabel_v2:DrivableAreaEdge .
+_:c14n308 sh:datatype xsd:boolean ;
+	sh:description "Volcanic ash flag. Refer to BSI PAS-1883 Section 5.3.2.e." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 36 ;
+	sh:path openlabel_v2:ParticulatesVolcanic .
+_:c14n309 sh:datatype xsd:boolean ;
+	sh:description "An activity where the road user is stationary." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 17 ;
+	sh:path openlabel_v2:MotionStop .
+_:c14n31 sh:datatype xsd:decimal ;
+	sh:description "Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.ii." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 29 ;
+	sh:path openlabel_v2:longitudinalDownSlopeValue .
+_:c14n310 sh:description "Roundabout type. Refer to BSI PAS-1883 Section 5.2.4." ;
+	sh:in _:c14n658 ;
+	sh:maxCount 1 ;
+	sh:order 20 ;
+	sh:path openlabel_v2:JunctionRoundabout .
+_:c14n311 sh:datatype xsd:boolean ;
+	sh:description "Rainfall flag. Refer to BSI PAS-1883 Section 5.3.1.2." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 58 ;
+	sh:path openlabel_v2:WeatherRain .
+_:c14n312 sh:datatype xsd:boolean ;
+	sh:description "Presence of special vehicles flag. Refer to BSI PAS-1883 Section 5.4.a.5." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 55 ;
+	sh:path openlabel_v2:TrafficSpecialVehicle .
+_:c14n313 sh:description "Number of lanes (unit). Refer to BSI PAS-1883 Section 5.2.3.4.d." ;
+	sh:or _:c14n866 ;
+	sh:order 24 ;
+	sh:path openlabel_v2:laneSpecificationLaneCountValue .
+_:c14n314 sh:description "Road surface condition. Refer to BSI PAS-1883 Section 5.2.3.7.c." ;
+	sh:in _:c14n698 ;
+	sh:maxCount 1 ;
+	sh:order 6 ;
+	sh:path openlabel_v2:DrivableAreaSurfaceCondition .
+_:c14n315 sh:datatype xsd:boolean ;
+	sh:description "Sand and dust flag. Refer to BSI PAS-1883 Section 5.3.2.c." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 33 ;
+	sh:path openlabel_v2:ParticulatesDust .
+_:c14n316 sh:datatype xsd:integer ;
+	sh:description "Rate (vehicles/h). Refer to BSI PAS-1883 Section 5.4.a.3." ;
+	sh:maxCount 1 ;
+	sh:minInclusive 0 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 54 ;
+	sh:path openlabel_v2:trafficFlowRateValue .
+_:c14n317 sh:datatype xsd:decimal ;
+	sh:description "Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.i." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 32 ;
+	sh:path openlabel_v2:longitudinalUpSlopeValue .
+_:c14n318 sh:datatype xsd:boolean ;
+	sh:description "Presence of special vehicles flag. Refer to BSI PAS-1883 Section 5.4.a.5." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 55 ;
+	sh:path openlabel_v2:TrafficSpecialVehicle .
+_:c14n319 sh:datatype xsd:boolean ;
+	sh:description "Presence of special vehicles flag. Refer to BSI PAS-1883 Section 5.4.a.5." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 55 ;
+	sh:path openlabel_v2:TrafficSpecialVehicle .
+_:c14n32 sh:description "Speed (km/h). Refer to BSI PAS-1883 Section 5.4.b." ;
+	sh:maxCount 1 ;
+	sh:or _:c14n870 ;
+	sh:order 48 ;
+	sh:path openlabel_v2:subjectVehicleSpeedValue .
+_:c14n320 sh:datatype xsd:decimal ;
+	sh:description "Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.i." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 32 ;
+	sh:path openlabel_v2:longitudinalUpSlopeValue .
+_:c14n321 sh:description "Speed (km/h). Refer to BSI PAS-1883 Section 5.4.b." ;
+	sh:maxCount 1 ;
+	sh:or _:c14n862 ;
+	sh:order 48 ;
+	sh:path openlabel_v2:subjectVehicleSpeedValue .
+_:c14n322 sh:datatype xsd:boolean ;
+	sh:description "Down-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.ii." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 28 ;
+	sh:path openlabel_v2:LongitudinalDownSlope .
+_:c14n323 sh:description "Intersection type. Refer to BSI PAS-1883 Section 5.2.4." ;
+	sh:in _:c14n783 ;
+	sh:maxCount 1 ;
+	sh:order 19 ;
+	sh:path openlabel_v2:JunctionIntersection .
+_:c14n324 rdf:first openlabel_v2:LaneTypeBus ;
+	rdf:rest _:c14n325 .
+_:c14n325 rdf:first openlabel_v2:LaneTypeCycle ;
+	rdf:rest _:c14n326 .
+_:c14n326 rdf:first openlabel_v2:LaneTypeEmergency ;
+	rdf:rest _:c14n327 .
+_:c14n327 rdf:first openlabel_v2:LaneTypeSpecial ;
+	rdf:rest _:c14n328 .
+_:c14n328 rdf:first openlabel_v2:LaneTypeTraffic ;
+	rdf:rest _:c14n329 .
+_:c14n329 rdf:first openlabel_v2:LaneTypeTram ;
+	rdf:rest rdf:nil .
+_:c14n33 sh:description "Direction of travel. Refer to BSI PAS-1883 Section 5.2.3.4.e." ;
+	sh:in _:c14n950 ;
+	sh:maxCount 1 ;
+	sh:order 26 ;
+	sh:path openlabel_v2:LaneSpecificationTravelDirection .
+_:c14n330 rdf:first openlabel_v2:LaneTypeBus ;
+	rdf:rest _:c14n331 .
+_:c14n331 rdf:first openlabel_v2:LaneTypeCycle ;
+	rdf:rest _:c14n332 .
+_:c14n332 rdf:first openlabel_v2:LaneTypeEmergency ;
+	rdf:rest _:c14n333 .
+_:c14n333 rdf:first openlabel_v2:LaneTypeSpecial ;
+	rdf:rest _:c14n334 .
+_:c14n334 rdf:first openlabel_v2:LaneTypeTraffic ;
+	rdf:rest _:c14n335 .
+_:c14n335 rdf:first openlabel_v2:LaneTypeTram ;
+	rdf:rest rdf:nil .
+_:c14n336 rdf:first openlabel_v2:LaneTypeBus ;
+	rdf:rest _:c14n337 .
+_:c14n337 rdf:first openlabel_v2:LaneTypeCycle ;
+	rdf:rest _:c14n338 .
+_:c14n338 rdf:first openlabel_v2:LaneTypeEmergency ;
+	rdf:rest _:c14n339 .
+_:c14n339 rdf:first openlabel_v2:LaneTypeSpecial ;
+	rdf:rest _:c14n340 .
+_:c14n34 sh:datatype xsd:boolean ;
+	sh:description "Lane marking flag. Refer to BSI PAS-1883 Section 5.2.3.4.b." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 25 ;
+	sh:path openlabel_v2:LaneSpecificationMarking .
+_:c14n340 rdf:first openlabel_v2:LaneTypeTraffic ;
+	rdf:rest _:c14n341 .
+_:c14n341 rdf:first openlabel_v2:LaneTypeTram ;
+	rdf:rest rdf:nil .
+_:c14n342 rdf:first openlabel_v2:LaneTypeBus ;
+	rdf:rest _:c14n343 .
+_:c14n343 rdf:first openlabel_v2:LaneTypeCycle ;
+	rdf:rest _:c14n344 .
+_:c14n344 rdf:first openlabel_v2:LaneTypeEmergency ;
+	rdf:rest _:c14n345 .
+_:c14n345 rdf:first openlabel_v2:LaneTypeSpecial ;
+	rdf:rest _:c14n346 .
+_:c14n346 rdf:first openlabel_v2:LaneTypeTraffic ;
+	rdf:rest _:c14n347 .
+_:c14n347 rdf:first openlabel_v2:LaneTypeTram ;
+	rdf:rest rdf:nil .
+_:c14n348 rdf:first openlabel_v2:SurfaceTypeUniform ;
+	rdf:rest rdf:nil .
+_:c14n349 rdf:first openlabel_v2:SurfaceTypeSegmented ;
+	rdf:rest _:c14n348 .
+_:c14n35 sh:description "Speed (km/h). Refer to BSI PAS-1883 Section 5.4.b." ;
+	sh:or _:c14n850 ;
+	sh:order 48 ;
+	sh:path openlabel_v2:subjectVehicleSpeedValue .
+_:c14n350 rdf:first openlabel_v2:SurfaceTypeLoose ;
+	rdf:rest _:c14n349 .
+_:c14n351 rdf:first openlabel_v2:SurfaceTypeUniform ;
+	rdf:rest rdf:nil .
+_:c14n352 rdf:first openlabel_v2:SurfaceTypeSegmented ;
+	rdf:rest _:c14n351 .
+_:c14n353 rdf:first openlabel_v2:SurfaceTypeLoose ;
+	rdf:rest _:c14n352 .
+_:c14n354 rdf:first openlabel_v2:SurfaceTypeUniform ;
+	rdf:rest rdf:nil .
+_:c14n355 rdf:first openlabel_v2:SurfaceTypeSegmented ;
+	rdf:rest _:c14n354 .
+_:c14n356 rdf:first openlabel_v2:SurfaceTypeLoose ;
+	rdf:rest _:c14n355 .
+_:c14n357 rdf:first openlabel_v2:SurfaceTypeUniform ;
+	rdf:rest rdf:nil .
+_:c14n358 rdf:first openlabel_v2:SurfaceTypeSegmented ;
+	rdf:rest _:c14n357 .
+_:c14n359 rdf:first openlabel_v2:SurfaceTypeLoose ;
+	rdf:rest _:c14n358 .
+_:c14n36 sh:description "Position of the sun. Refer to BSI PAS-1883 Section 5.3.3.a.2." ;
+	sh:in _:c14n674 ;
+	sh:maxCount 1 ;
+	sh:order 4 ;
+	sh:path openlabel_v2:DaySunPosition .
+_:c14n360 rdf:first openlabel_v2:ParticulatesPollution ;
+	rdf:rest _:c14n361 .
+_:c14n361 rdf:first openlabel_v2:ParticulatesVolcanic ;
+	rdf:rest _:c14n362 .
+_:c14n362 rdf:first openlabel_v2:ParticulatesWater ;
+	rdf:rest rdf:nil .
+_:c14n363 rdf:first openlabel_v2:ParticulatesMarine ;
+	rdf:rest _:c14n360 .
+_:c14n364 rdf:first openlabel_v2:ParticulatesDust ;
+	rdf:rest _:c14n363 .
+_:c14n365 rdf:first openlabel_v2:ParticulatesPollution ;
+	rdf:rest _:c14n366 .
+_:c14n366 rdf:first openlabel_v2:ParticulatesVolcanic ;
+	rdf:rest _:c14n367 .
+_:c14n367 rdf:first openlabel_v2:ParticulatesWater ;
+	rdf:rest rdf:nil .
+_:c14n368 rdf:first openlabel_v2:ParticulatesMarine ;
+	rdf:rest _:c14n365 .
+_:c14n369 rdf:first openlabel_v2:ParticulatesDust ;
+	rdf:rest _:c14n368 .
+_:c14n37 sh:datatype xsd:boolean ;
+	sh:description "Smoke and pollution flag. Refer to BSI PAS-1883 Section 5.3.2.d." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 35 ;
+	sh:path openlabel_v2:ParticulatesPollution .
+_:c14n370 rdf:first openlabel_v2:ParticulatesPollution ;
+	rdf:rest _:c14n371 .
+_:c14n371 rdf:first openlabel_v2:ParticulatesVolcanic ;
+	rdf:rest _:c14n372 .
+_:c14n372 rdf:first openlabel_v2:ParticulatesWater ;
+	rdf:rest rdf:nil .
+_:c14n373 rdf:first openlabel_v2:ParticulatesMarine ;
+	rdf:rest _:c14n370 .
+_:c14n374 rdf:first openlabel_v2:ParticulatesDust ;
+	rdf:rest _:c14n373 .
+_:c14n375 rdf:first openlabel_v2:ParticulatesPollution ;
+	rdf:rest _:c14n376 .
+_:c14n376 rdf:first openlabel_v2:ParticulatesVolcanic ;
+	rdf:rest _:c14n377 .
+_:c14n377 rdf:first openlabel_v2:ParticulatesWater ;
+	rdf:rest rdf:nil .
+_:c14n378 rdf:first openlabel_v2:ParticulatesMarine ;
+	rdf:rest _:c14n375 .
+_:c14n379 rdf:first openlabel_v2:ParticulatesDust ;
+	rdf:rest _:c14n378 .
+_:c14n38 sh:datatype xsd:boolean ;
+	sh:description "Down-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.ii." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 28 ;
+	sh:path openlabel_v2:LongitudinalDownSlope .
+_:c14n380 rdf:first openlabel_v2:WarningSignsVariableFullTime ;
+	rdf:rest _:c14n381 .
+_:c14n381 rdf:first openlabel_v2:WarningSignsVariableTemporary ;
+	rdf:rest rdf:nil .
+_:c14n382 rdf:first openlabel_v2:WarningSignsUniformTemporary ;
+	rdf:rest _:c14n380 .
+_:c14n383 rdf:first openlabel_v2:WarningSignsUniformFullTime ;
+	rdf:rest _:c14n382 .
+_:c14n384 rdf:first openlabel_v2:WarningSignsUniform ;
+	rdf:rest _:c14n383 .
+_:c14n385 rdf:first openlabel_v2:WarningSignsVariableFullTime ;
+	rdf:rest _:c14n386 .
+_:c14n386 rdf:first openlabel_v2:WarningSignsVariableTemporary ;
+	rdf:rest rdf:nil .
+_:c14n387 rdf:first openlabel_v2:WarningSignsUniformTemporary ;
+	rdf:rest _:c14n385 .
+_:c14n388 rdf:first openlabel_v2:WarningSignsUniformFullTime ;
+	rdf:rest _:c14n387 .
+_:c14n389 rdf:first openlabel_v2:WarningSignsUniform ;
+	rdf:rest _:c14n388 .
+_:c14n39 rdf:first rdf:type ;
+	rdf:rest rdf:nil .
+_:c14n390 rdf:first openlabel_v2:WarningSignsVariableFullTime ;
+	rdf:rest _:c14n391 .
+_:c14n391 rdf:first openlabel_v2:WarningSignsVariableTemporary ;
+	rdf:rest rdf:nil .
+_:c14n392 rdf:first openlabel_v2:WarningSignsUniformTemporary ;
+	rdf:rest _:c14n390 .
+_:c14n393 rdf:first openlabel_v2:WarningSignsUniformFullTime ;
+	rdf:rest _:c14n392 .
+_:c14n394 rdf:first openlabel_v2:WarningSignsUniform ;
+	rdf:rest _:c14n393 .
+_:c14n395 rdf:first openlabel_v2:WarningSignsVariableFullTime ;
+	rdf:rest _:c14n396 .
+_:c14n396 rdf:first openlabel_v2:WarningSignsVariableTemporary ;
+	rdf:rest rdf:nil .
+_:c14n397 rdf:first openlabel_v2:WarningSignsUniformTemporary ;
+	rdf:rest _:c14n395 .
+_:c14n398 rdf:first openlabel_v2:WarningSignsUniformFullTime ;
+	rdf:rest _:c14n397 .
+_:c14n399 rdf:first openlabel_v2:WarningSignsUniform ;
+	rdf:rest _:c14n398 .
+_:c14n4 sh:datatype xsd:string ;
+	sh:description "The type of license which governs usage of the scenario." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 0 ;
+	sh:path openlabel_v2:licenseURI .
+_:c14n40 sh:datatype xsd:boolean ;
+	sh:description "An activity where the road user decreases their velocity." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 7 ;
+	sh:path openlabel_v2:MotionDecelerate .
+_:c14n400 rdf:first openlabel_v2:VehicleCycle ;
+	rdf:rest _:c14n401 .
+_:c14n401 rdf:first openlabel_v2:VehicleEmergency ;
+	rdf:rest _:c14n402 .
+_:c14n402 rdf:first openlabel_v2:VehicleMotorcycle ;
+	rdf:rest _:c14n403 .
+_:c14n403 rdf:first openlabel_v2:VehicleTrailer ;
+	rdf:rest _:c14n404 .
+_:c14n404 rdf:first openlabel_v2:VehicleTruck ;
+	rdf:rest _:c14n405 .
+_:c14n405 rdf:first openlabel_v2:VehicleVan ;
+	rdf:rest _:c14n406 .
+_:c14n406 rdf:first openlabel_v2:VehicleWheelchair ;
+	rdf:rest rdf:nil .
+_:c14n407 rdf:first openlabel_v2:VehicleConstruction ;
+	rdf:rest _:c14n400 .
+_:c14n408 rdf:first openlabel_v2:VehicleCar ;
+	rdf:rest _:c14n407 .
+_:c14n409 rdf:first openlabel_v2:VehicleBus ;
+	rdf:rest _:c14n408 .
+_:c14n41 sh:description "Warning sign type. Refer to BSI PAS-1883 Section 5.2.3.5.c." ;
+	sh:in _:c14n384 ;
+	sh:maxCount 1 ;
+	sh:order 46 ;
+	sh:path openlabel_v2:SignsWarning .
+_:c14n410 rdf:first openlabel_v2:VehicleAgricultural ;
+	rdf:rest _:c14n409 .
+_:c14n411 sh:in _:c14n410 .
+_:c14n412 rdf:first _:c14n411 ;
+	rdf:rest rdf:nil .
+_:c14n413 rdf:first _:c14n414 ;
+	rdf:rest _:c14n412 .
+_:c14n414 sh:in _:c14n415 .
+_:c14n415 rdf:first openlabel_v2:HumanAnimalRider ;
+	rdf:rest _:c14n416 .
+_:c14n416 rdf:first openlabel_v2:HumanCyclist ;
+	rdf:rest _:c14n417 .
+_:c14n417 rdf:first openlabel_v2:HumanDriver ;
+	rdf:rest _:c14n418 .
+_:c14n418 rdf:first openlabel_v2:HumanMotorcyclist ;
+	rdf:rest _:c14n419 .
+_:c14n419 rdf:first openlabel_v2:HumanPassenger ;
+	rdf:rest _:c14n420 .
+_:c14n42 sh:description "Rate of deceleration (ms-2)." ;
+	sh:maxCount 1 ;
+	sh:or _:c14n548 ;
+	sh:order 8 ;
+	sh:path openlabel_v2:motionDecelerateValue .
+_:c14n420 rdf:first openlabel_v2:HumanPedestrian ;
+	rdf:rest _:c14n421 .
+_:c14n421 rdf:first openlabel_v2:HumanWheelchairUser ;
+	rdf:rest rdf:nil .
+_:c14n422 rdf:first openlabel_v2:VehicleCycle ;
+	rdf:rest _:c14n423 .
+_:c14n423 rdf:first openlabel_v2:VehicleEmergency ;
+	rdf:rest _:c14n424 .
+_:c14n424 rdf:first openlabel_v2:VehicleMotorcycle ;
+	rdf:rest _:c14n425 .
+_:c14n425 rdf:first openlabel_v2:VehicleTrailer ;
+	rdf:rest _:c14n426 .
+_:c14n426 rdf:first openlabel_v2:VehicleTruck ;
+	rdf:rest _:c14n427 .
+_:c14n427 rdf:first openlabel_v2:VehicleVan ;
+	rdf:rest _:c14n428 .
+_:c14n428 rdf:first openlabel_v2:VehicleWheelchair ;
+	rdf:rest rdf:nil .
+_:c14n429 rdf:first openlabel_v2:VehicleConstruction ;
+	rdf:rest _:c14n422 .
+_:c14n43 sh:datatype xsd:decimal ;
+	sh:description "Visibility (km). Refer to BSI PAS-1883 Section 5.3.1.3." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 61 ;
+	sh:path openlabel_v2:weatherSnowValue .
+_:c14n430 rdf:first openlabel_v2:VehicleCar ;
+	rdf:rest _:c14n429 .
+_:c14n431 rdf:first openlabel_v2:VehicleBus ;
+	rdf:rest _:c14n430 .
+_:c14n432 rdf:first openlabel_v2:VehicleAgricultural ;
+	rdf:rest _:c14n431 .
+_:c14n433 sh:in _:c14n432 .
+_:c14n434 rdf:first _:c14n433 ;
+	rdf:rest rdf:nil .
+_:c14n435 rdf:first _:c14n436 ;
+	rdf:rest _:c14n434 .
+_:c14n436 sh:in _:c14n437 .
+_:c14n437 rdf:first openlabel_v2:HumanAnimalRider ;
+	rdf:rest _:c14n438 .
+_:c14n438 rdf:first openlabel_v2:HumanCyclist ;
+	rdf:rest _:c14n439 .
+_:c14n439 rdf:first openlabel_v2:HumanDriver ;
+	rdf:rest _:c14n440 .
+_:c14n44 sh:description "Zone type. Refer to BSI PAS-1883 Section 5.2.1.a." ;
+	sh:in _:c14n793 ;
+	sh:maxCount 1 ;
+	sh:order 43 ;
+	sh:path openlabel_v2:SceneryZone .
+_:c14n440 rdf:first openlabel_v2:HumanMotorcyclist ;
+	rdf:rest _:c14n441 .
+_:c14n441 rdf:first openlabel_v2:HumanPassenger ;
+	rdf:rest _:c14n442 .
+_:c14n442 rdf:first openlabel_v2:HumanPedestrian ;
+	rdf:rest _:c14n443 .
+_:c14n443 rdf:first openlabel_v2:HumanWheelchairUser ;
+	rdf:rest rdf:nil .
+_:c14n444 rdf:first openlabel_v2:VehicleCycle ;
+	rdf:rest _:c14n445 .
+_:c14n445 rdf:first openlabel_v2:VehicleEmergency ;
+	rdf:rest _:c14n446 .
+_:c14n446 rdf:first openlabel_v2:VehicleMotorcycle ;
+	rdf:rest _:c14n447 .
+_:c14n447 rdf:first openlabel_v2:VehicleTrailer ;
+	rdf:rest _:c14n448 .
+_:c14n448 rdf:first openlabel_v2:VehicleTruck ;
+	rdf:rest _:c14n449 .
+_:c14n449 rdf:first openlabel_v2:VehicleVan ;
+	rdf:rest _:c14n450 .
+_:c14n45 sh:datatype xsd:boolean ;
+	sh:description "Cloudiness flag. Refer to BSI PAS-1883 Section 5.3.3.c." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 16 ;
+	sh:path openlabel_v2:IlluminationCloudiness .
+_:c14n450 rdf:first openlabel_v2:VehicleWheelchair ;
+	rdf:rest rdf:nil .
+_:c14n451 rdf:first openlabel_v2:VehicleConstruction ;
+	rdf:rest _:c14n444 .
+_:c14n452 rdf:first openlabel_v2:VehicleCar ;
+	rdf:rest _:c14n451 .
+_:c14n453 rdf:first openlabel_v2:VehicleBus ;
+	rdf:rest _:c14n452 .
+_:c14n454 rdf:first openlabel_v2:VehicleAgricultural ;
+	rdf:rest _:c14n453 .
+_:c14n455 rdf:first openlabel_v2:VehicleCycle ;
+	rdf:rest _:c14n456 .
+_:c14n456 rdf:first openlabel_v2:VehicleEmergency ;
+	rdf:rest _:c14n457 .
+_:c14n457 rdf:first openlabel_v2:VehicleMotorcycle ;
+	rdf:rest _:c14n458 .
+_:c14n458 rdf:first openlabel_v2:VehicleTrailer ;
+	rdf:rest _:c14n459 .
+_:c14n459 rdf:first openlabel_v2:VehicleTruck ;
+	rdf:rest _:c14n460 .
+_:c14n46 sh:description "Temporary road structure. Refer to BSI PAS-1883 Section 5.2.1.f." ;
+	sh:in _:c14n882 ;
+	sh:order 42 ;
+	sh:path openlabel_v2:SceneryTemporaryStructure .
+_:c14n460 rdf:first openlabel_v2:VehicleVan ;
+	rdf:rest _:c14n461 .
+_:c14n461 rdf:first openlabel_v2:VehicleWheelchair ;
+	rdf:rest rdf:nil .
+_:c14n462 rdf:first openlabel_v2:VehicleConstruction ;
+	rdf:rest _:c14n455 .
+_:c14n463 rdf:first openlabel_v2:VehicleCar ;
+	rdf:rest _:c14n462 .
+_:c14n464 rdf:first openlabel_v2:VehicleBus ;
+	rdf:rest _:c14n463 .
+_:c14n465 rdf:first openlabel_v2:VehicleAgricultural ;
+	rdf:rest _:c14n464 .
+_:c14n466 sh:in _:c14n465 .
+_:c14n467 rdf:first _:c14n466 ;
+	rdf:rest rdf:nil .
+_:c14n468 rdf:first _:c14n469 ;
+	rdf:rest _:c14n467 .
+_:c14n469 sh:in _:c14n470 .
+_:c14n47 sh:datatype xsd:decimal ;
+	sh:description "Curve radius (m). Refer to BSI PAS-1883 Section 5.2.3.3." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 13 ;
+	sh:path openlabel_v2:horizontalCurvesValue .
+_:c14n470 rdf:first openlabel_v2:HumanAnimalRider ;
+	rdf:rest _:c14n471 .
+_:c14n471 rdf:first openlabel_v2:HumanCyclist ;
+	rdf:rest _:c14n472 .
+_:c14n472 rdf:first openlabel_v2:HumanDriver ;
+	rdf:rest _:c14n473 .
+_:c14n473 rdf:first openlabel_v2:HumanMotorcyclist ;
+	rdf:rest _:c14n474 .
+_:c14n474 rdf:first openlabel_v2:HumanPassenger ;
+	rdf:rest _:c14n475 .
+_:c14n475 rdf:first openlabel_v2:HumanPedestrian ;
+	rdf:rest _:c14n476 .
+_:c14n476 rdf:first openlabel_v2:HumanWheelchairUser ;
+	rdf:rest rdf:nil .
+_:c14n477 rdf:first openlabel_v2:VehicleCycle ;
+	rdf:rest _:c14n478 .
+_:c14n478 rdf:first openlabel_v2:VehicleEmergency ;
+	rdf:rest _:c14n479 .
+_:c14n479 rdf:first openlabel_v2:VehicleMotorcycle ;
+	rdf:rest _:c14n480 .
+_:c14n48 sh:description "Warning sign type. Refer to BSI PAS-1883 Section 5.2.3.5.c." ;
+	sh:in _:c14n394 ;
+	sh:order 46 ;
+	sh:path openlabel_v2:SignsWarning .
+_:c14n480 rdf:first openlabel_v2:VehicleTrailer ;
+	rdf:rest _:c14n481 .
+_:c14n481 rdf:first openlabel_v2:VehicleTruck ;
+	rdf:rest _:c14n482 .
+_:c14n482 rdf:first openlabel_v2:VehicleVan ;
+	rdf:rest _:c14n483 .
+_:c14n483 rdf:first openlabel_v2:VehicleWheelchair ;
+	rdf:rest rdf:nil .
+_:c14n484 rdf:first openlabel_v2:VehicleConstruction ;
+	rdf:rest _:c14n477 .
+_:c14n485 rdf:first openlabel_v2:VehicleCar ;
+	rdf:rest _:c14n484 .
+_:c14n486 rdf:first openlabel_v2:VehicleBus ;
+	rdf:rest _:c14n485 .
+_:c14n487 rdf:first openlabel_v2:VehicleAgricultural ;
+	rdf:rest _:c14n486 .
+_:c14n488 sh:in _:c14n487 .
+_:c14n489 rdf:first _:c14n488 ;
+	rdf:rest rdf:nil .
+_:c14n49 sh:description "Road type. Refer to BSI PAS-1883 Section 5.2.3.2." ;
+	sh:in _:c14n769 ;
+	sh:order 9 ;
+	sh:path openlabel_v2:DrivableAreaType .
+_:c14n490 rdf:first _:c14n491 ;
+	rdf:rest _:c14n489 .
+_:c14n491 sh:in _:c14n492 .
+_:c14n492 rdf:first openlabel_v2:HumanAnimalRider ;
+	rdf:rest _:c14n493 .
+_:c14n493 rdf:first openlabel_v2:HumanCyclist ;
+	rdf:rest _:c14n494 .
+_:c14n494 rdf:first openlabel_v2:HumanDriver ;
+	rdf:rest _:c14n495 .
+_:c14n495 rdf:first openlabel_v2:HumanMotorcyclist ;
+	rdf:rest _:c14n496 .
+_:c14n496 rdf:first openlabel_v2:HumanPassenger ;
+	rdf:rest _:c14n497 .
+_:c14n497 rdf:first openlabel_v2:HumanPedestrian ;
+	rdf:rest _:c14n498 .
+_:c14n498 rdf:first openlabel_v2:HumanWheelchairUser ;
+	rdf:rest rdf:nil .
+_:c14n499 rdf:first openlabel_v2:V2vWifi ;
+	rdf:rest rdf:nil .
+_:c14n5 sh:datatype xsd:boolean ;
+	sh:description "Marine (coastal areas only) flag. Refer to BSI PAS-1883 Section 5.3.2.a." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 34 ;
+	sh:path openlabel_v2:ParticulatesMarine .
+_:c14n50 sh:datatype xsd:decimal ;
+	sh:description "Cloud cover (okta). Refer to BSI PAS-1883 Section 5.3.3.c." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 17 ;
+	sh:path openlabel_v2:illuminationCloudinessValue .
+_:c14n500 rdf:first openlabel_v2:V2vSatellite ;
+	rdf:rest _:c14n499 .
+_:c14n501 rdf:first openlabel_v2:V2vCellular ;
+	rdf:rest _:c14n500 .
+_:c14n502 rdf:first openlabel_v2:CommunicationV2v ;
+	rdf:rest _:c14n501 .
+_:c14n503 rdf:first openlabel_v2:V2iWifi ;
+	rdf:rest _:c14n502 .
+_:c14n504 rdf:first openlabel_v2:V2iSatellite ;
+	rdf:rest _:c14n503 .
+_:c14n505 rdf:first openlabel_v2:V2iCellular ;
+	rdf:rest _:c14n504 .
+_:c14n506 rdf:first openlabel_v2:CommunicationV2i ;
+	rdf:rest _:c14n505 .
+_:c14n507 rdf:first openlabel_v2:V2vWifi ;
+	rdf:rest rdf:nil .
+_:c14n508 rdf:first openlabel_v2:V2vSatellite ;
+	rdf:rest _:c14n507 .
+_:c14n509 rdf:first openlabel_v2:V2vCellular ;
+	rdf:rest _:c14n508 .
+_:c14n51 sh:description "Road type. Refer to BSI PAS-1883 Section 5.2.3.2." ;
+	sh:in _:c14n742 ;
+	sh:maxCount 1 ;
+	sh:order 9 ;
+	sh:path openlabel_v2:DrivableAreaType .
+_:c14n510 rdf:first openlabel_v2:CommunicationV2v ;
+	rdf:rest _:c14n509 .
+_:c14n511 rdf:first openlabel_v2:V2iWifi ;
+	rdf:rest _:c14n510 .
+_:c14n512 rdf:first openlabel_v2:V2iSatellite ;
+	rdf:rest _:c14n511 .
+_:c14n513 rdf:first openlabel_v2:V2iCellular ;
+	rdf:rest _:c14n512 .
+_:c14n514 rdf:first openlabel_v2:CommunicationV2i ;
+	rdf:rest _:c14n513 .
+_:c14n515 rdf:first openlabel_v2:V2vWifi ;
+	rdf:rest rdf:nil .
+_:c14n516 rdf:first openlabel_v2:V2vSatellite ;
+	rdf:rest _:c14n515 .
+_:c14n517 rdf:first openlabel_v2:V2vCellular ;
+	rdf:rest _:c14n516 .
+_:c14n518 rdf:first openlabel_v2:CommunicationV2v ;
+	rdf:rest _:c14n517 .
+_:c14n519 rdf:first openlabel_v2:V2iWifi ;
+	rdf:rest _:c14n518 .
+_:c14n52 sh:datatype xsd:dateTime ;
+	sh:description "The date that the scenario was created/published." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 4 ;
+	sh:path openlabel_v2:scenarioCreatedDate .
+_:c14n520 rdf:first openlabel_v2:V2iSatellite ;
+	rdf:rest _:c14n519 .
+_:c14n521 rdf:first openlabel_v2:V2iCellular ;
+	rdf:rest _:c14n520 .
+_:c14n522 rdf:first openlabel_v2:CommunicationV2i ;
+	rdf:rest _:c14n521 .
+_:c14n523 rdf:first openlabel_v2:V2vWifi ;
+	rdf:rest rdf:nil .
+_:c14n524 rdf:first openlabel_v2:V2vSatellite ;
+	rdf:rest _:c14n523 .
+_:c14n525 rdf:first openlabel_v2:V2vCellular ;
+	rdf:rest _:c14n524 .
+_:c14n526 rdf:first openlabel_v2:CommunicationV2v ;
+	rdf:rest _:c14n525 .
+_:c14n527 rdf:first openlabel_v2:V2iWifi ;
+	rdf:rest _:c14n526 .
+_:c14n528 rdf:first openlabel_v2:V2iSatellite ;
+	rdf:rest _:c14n527 .
+_:c14n529 rdf:first openlabel_v2:V2iCellular ;
+	rdf:rest _:c14n528 .
+_:c14n53 sh:datatype xsd:integer ;
+	sh:description "Density (vehicles/km). Refer to BSI PAS-1883 Section 5.4.a.1." ;
+	sh:maxCount 1 ;
+	sh:minInclusive 0 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 50 ;
+	sh:path openlabel_v2:trafficAgentDensityValue .
+_:c14n530 rdf:first openlabel_v2:CommunicationV2i ;
+	rdf:rest _:c14n529 .
+_:c14n531 rdf:first openlabel_v2:InformationSignsUniformTemporary ;
+	rdf:rest _:c14n532 .
+_:c14n532 rdf:first openlabel_v2:InformationSignsVariableFullTime ;
+	rdf:rest _:c14n533 .
+_:c14n533 rdf:first openlabel_v2:InformationSignsVariableTemporary ;
+	rdf:rest rdf:nil .
+_:c14n534 rdf:first openlabel_v2:InformationSignsUniformFullTime ;
+	rdf:rest _:c14n531 .
+_:c14n535 rdf:first openlabel_v2:InformationSignsUniformTemporary ;
+	rdf:rest _:c14n536 .
+_:c14n536 rdf:first openlabel_v2:InformationSignsVariableFullTime ;
+	rdf:rest _:c14n537 .
+_:c14n537 rdf:first openlabel_v2:InformationSignsVariableTemporary ;
+	rdf:rest rdf:nil .
+_:c14n538 rdf:first openlabel_v2:InformationSignsUniformFullTime ;
+	rdf:rest _:c14n535 .
+_:c14n539 rdf:first openlabel_v2:InformationSignsUniformTemporary ;
+	rdf:rest _:c14n540 .
+_:c14n54 sh:description "Rate of acceleration (ms-2)." ;
+	sh:maxCount 1 ;
+	sh:or _:c14n576 ;
+	sh:order 2 ;
+	sh:path openlabel_v2:motionAccelerateValue .
+_:c14n540 rdf:first openlabel_v2:InformationSignsVariableFullTime ;
+	rdf:rest _:c14n541 .
+_:c14n541 rdf:first openlabel_v2:InformationSignsVariableTemporary ;
+	rdf:rest rdf:nil .
+_:c14n542 rdf:first openlabel_v2:InformationSignsUniformFullTime ;
+	rdf:rest _:c14n539 .
+_:c14n543 rdf:first openlabel_v2:InformationSignsUniformTemporary ;
+	rdf:rest _:c14n544 .
+_:c14n544 rdf:first openlabel_v2:InformationSignsVariableFullTime ;
+	rdf:rest _:c14n545 .
+_:c14n545 rdf:first openlabel_v2:InformationSignsVariableTemporary ;
+	rdf:rest rdf:nil .
+_:c14n546 rdf:first openlabel_v2:InformationSignsUniformFullTime ;
+	rdf:rest _:c14n543 .
+_:c14n547 sh:datatype xsd:decimal ;
+	sh:nodeKind sh:Literal .
+_:c14n548 rdf:first _:c14n547 ;
+	rdf:rest _:c14n549 .
+_:c14n549 rdf:first _:c14n550 ;
+	rdf:rest rdf:nil .
+_:c14n55 sh:description "Artificial illumination type. Refer to BSI PAS-1883 Section 5.3.3.d." ;
+	sh:in _:c14n938 ;
+	sh:maxCount 1 ;
+	sh:order 15 ;
+	sh:path openlabel_v2:IlluminationArtificial .
+_:c14n550 sh:class sdo:QuantitativeValue .
+_:c14n551 sh:datatype xsd:decimal ;
+	sh:nodeKind sh:Literal .
+_:c14n552 rdf:first _:c14n551 ;
+	rdf:rest _:c14n553 .
+_:c14n553 rdf:first _:c14n554 ;
+	rdf:rest rdf:nil .
+_:c14n554 sh:class sdo:QuantitativeValue .
+_:c14n555 sh:datatype xsd:decimal ;
+	sh:nodeKind sh:Literal .
+_:c14n556 rdf:first _:c14n555 ;
+	rdf:rest _:c14n557 .
+_:c14n557 rdf:first _:c14n558 ;
+	rdf:rest rdf:nil .
+_:c14n558 sh:class sdo:QuantitativeValue .
+_:c14n559 sh:datatype xsd:decimal ;
+	sh:nodeKind sh:Literal .
+_:c14n56 sh:datatype xsd:boolean ;
+	sh:description "Up-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.i." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 31 ;
+	sh:path openlabel_v2:LongitudinalUpSlope .
+_:c14n560 rdf:first _:c14n559 ;
+	rdf:rest _:c14n561 .
+_:c14n561 rdf:first _:c14n562 ;
+	rdf:rest rdf:nil .
+_:c14n562 sh:class sdo:QuantitativeValue .
+_:c14n563 sh:datatype xsd:decimal ;
+	sh:nodeKind sh:Literal .
+_:c14n564 rdf:first _:c14n563 ;
+	rdf:rest _:c14n565 .
+_:c14n565 rdf:first _:c14n566 ;
+	rdf:rest rdf:nil .
+_:c14n566 sh:class sdo:QuantitativeValue .
+_:c14n567 sh:datatype xsd:decimal ;
+	sh:nodeKind sh:Literal .
+_:c14n568 rdf:first _:c14n567 ;
+	rdf:rest _:c14n569 .
+_:c14n569 rdf:first _:c14n570 ;
+	rdf:rest rdf:nil .
+_:c14n57 sh:datatype xsd:boolean ;
+	sh:description "Number of lanes flag. Refer to BSI PAS-1883 Section 5.2.3.4.d." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 23 ;
+	sh:path openlabel_v2:LaneSpecificationLaneCount .
+_:c14n570 sh:class sdo:QuantitativeValue .
+_:c14n571 sh:datatype xsd:decimal ;
+	sh:nodeKind sh:Literal .
+_:c14n572 rdf:first _:c14n571 ;
+	rdf:rest _:c14n573 .
+_:c14n573 rdf:first _:c14n574 ;
+	rdf:rest rdf:nil .
+_:c14n574 sh:class sdo:QuantitativeValue .
+_:c14n575 sh:datatype xsd:decimal ;
+	sh:nodeKind sh:Literal .
+_:c14n576 rdf:first _:c14n575 ;
+	rdf:rest _:c14n577 .
+_:c14n577 rdf:first _:c14n578 ;
+	rdf:rest rdf:nil .
+_:c14n578 sh:class sdo:QuantitativeValue .
+_:c14n579 rdf:first openlabel_v2:SurfaceFeaturePothole ;
+	rdf:rest _:c14n581 .
+_:c14n58 sh:datatype xsd:string ;
+	sh:description "Universally unique identifier (UUID) assigned to the scenario which allows the scenario to be identified." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 10 ;
+	sh:path openlabel_v2:scenarioUniqueReference .
+_:c14n580 rdf:first openlabel_v2:SurfaceFeatureCrack ;
+	rdf:rest _:c14n579 .
+_:c14n581 rdf:first openlabel_v2:SurfaceFeatureRut ;
+	rdf:rest _:c14n582 .
+_:c14n582 rdf:first openlabel_v2:SurfaceFeatureSwell ;
+	rdf:rest rdf:nil .
+_:c14n583 rdf:first openlabel_v2:SurfaceFeaturePothole ;
+	rdf:rest _:c14n585 .
+_:c14n584 rdf:first openlabel_v2:SurfaceFeatureCrack ;
+	rdf:rest _:c14n583 .
+_:c14n585 rdf:first openlabel_v2:SurfaceFeatureRut ;
+	rdf:rest _:c14n586 .
+_:c14n586 rdf:first openlabel_v2:SurfaceFeatureSwell ;
+	rdf:rest rdf:nil .
+_:c14n587 rdf:first openlabel_v2:SurfaceFeaturePothole ;
+	rdf:rest _:c14n589 .
+_:c14n588 rdf:first openlabel_v2:SurfaceFeatureCrack ;
+	rdf:rest _:c14n587 .
+_:c14n589 rdf:first openlabel_v2:SurfaceFeatureRut ;
+	rdf:rest _:c14n590 .
+_:c14n59 sh:description "Direction of travel. Refer to BSI PAS-1883 Section 5.2.3.4.e." ;
+	sh:in _:c14n956 ;
+	sh:order 26 ;
+	sh:path openlabel_v2:LaneSpecificationTravelDirection .
+_:c14n590 rdf:first openlabel_v2:SurfaceFeatureSwell ;
+	rdf:rest rdf:nil .
+_:c14n591 rdf:first openlabel_v2:SurfaceFeaturePothole ;
+	rdf:rest _:c14n593 .
+_:c14n592 rdf:first openlabel_v2:SurfaceFeatureCrack ;
+	rdf:rest _:c14n591 .
+_:c14n593 rdf:first openlabel_v2:SurfaceFeatureRut ;
+	rdf:rest _:c14n594 .
+_:c14n594 rdf:first openlabel_v2:SurfaceFeatureSwell ;
+	rdf:rest rdf:nil .
+_:c14n595 rdf:first openlabel_v2:EdgeNone ;
+	rdf:rest _:c14n596 .
+_:c14n596 rdf:first openlabel_v2:EdgeShoulderGrass ;
+	rdf:rest _:c14n597 .
+_:c14n597 rdf:first openlabel_v2:EdgeShoulderPavedOrGravel ;
+	rdf:rest _:c14n598 .
+_:c14n598 rdf:first openlabel_v2:EdgeSolidBarriers ;
+	rdf:rest _:c14n599 .
+_:c14n599 rdf:first openlabel_v2:EdgeTemporaryLineMarkers ;
+	rdf:rest rdf:nil .
+_:c14n6 sh:description "Low light condition. Refer to BSI PAS-1883 Section 5.3.3.b." ;
+	sh:in _:c14n944 ;
+	sh:maxCount 1 ;
+	sh:order 18 ;
+	sh:path openlabel_v2:IlluminationLowLight .
+_:c14n60 sh:description "Communication connectivity type. Refer to BSI PAS-1883 Section 5.3.4.a." ;
+	sh:in _:c14n530 ;
+	sh:maxCount 1 ;
+	sh:order 0 ;
+	sh:path openlabel_v2:ConnectivityCommunication .
+_:c14n600 rdf:first openlabel_v2:EdgeLineMarkers ;
+	rdf:rest _:c14n595 .
+_:c14n601 rdf:first openlabel_v2:EdgeNone ;
+	rdf:rest _:c14n602 .
+_:c14n602 rdf:first openlabel_v2:EdgeShoulderGrass ;
+	rdf:rest _:c14n603 .
+_:c14n603 rdf:first openlabel_v2:EdgeShoulderPavedOrGravel ;
+	rdf:rest _:c14n604 .
+_:c14n604 rdf:first openlabel_v2:EdgeSolidBarriers ;
+	rdf:rest _:c14n605 .
+_:c14n605 rdf:first openlabel_v2:EdgeTemporaryLineMarkers ;
+	rdf:rest rdf:nil .
+_:c14n606 rdf:first openlabel_v2:EdgeLineMarkers ;
+	rdf:rest _:c14n601 .
+_:c14n607 rdf:first openlabel_v2:EdgeNone ;
+	rdf:rest _:c14n608 .
+_:c14n608 rdf:first openlabel_v2:EdgeShoulderGrass ;
+	rdf:rest _:c14n609 .
+_:c14n609 rdf:first openlabel_v2:EdgeShoulderPavedOrGravel ;
+	rdf:rest _:c14n610 .
+_:c14n61 sh:description "Road surface condition. Refer to BSI PAS-1883 Section 5.2.3.7.c." ;
+	sh:in _:c14n691 ;
+	sh:order 6 ;
+	sh:path openlabel_v2:DrivableAreaSurfaceCondition .
+_:c14n610 rdf:first openlabel_v2:EdgeSolidBarriers ;
+	rdf:rest _:c14n611 .
+_:c14n611 rdf:first openlabel_v2:EdgeTemporaryLineMarkers ;
+	rdf:rest rdf:nil .
+_:c14n612 rdf:first openlabel_v2:EdgeLineMarkers ;
+	rdf:rest _:c14n607 .
+_:c14n613 rdf:first openlabel_v2:EdgeNone ;
+	rdf:rest _:c14n614 .
+_:c14n614 rdf:first openlabel_v2:EdgeShoulderGrass ;
+	rdf:rest _:c14n615 .
+_:c14n615 rdf:first openlabel_v2:EdgeShoulderPavedOrGravel ;
+	rdf:rest _:c14n616 .
+_:c14n616 rdf:first openlabel_v2:EdgeSolidBarriers ;
+	rdf:rest _:c14n617 .
+_:c14n617 rdf:first openlabel_v2:EdgeTemporaryLineMarkers ;
+	rdf:rest rdf:nil .
+_:c14n618 rdf:first openlabel_v2:EdgeLineMarkers ;
+	rdf:rest _:c14n613 .
+_:c14n619 rdf:first openlabel_v2:RoundaboutMiniSignal ;
+	rdf:rest _:c14n620 .
+_:c14n62 rdf:first openlabel_v2:CommunicationHorn ;
+	rdf:rest _:c14n90 .
+_:c14n620 rdf:first openlabel_v2:RoundaboutNormalNosignal ;
+	rdf:rest _:c14n621 .
+_:c14n621 rdf:first openlabel_v2:RoundaboutNormalSignal ;
+	rdf:rest rdf:nil .
+_:c14n622 rdf:first openlabel_v2:RoundaboutMiniNosignal ;
+	rdf:rest _:c14n619 .
+_:c14n623 rdf:first openlabel_v2:RoundaboutLargeSignal ;
+	rdf:rest _:c14n622 .
+_:c14n624 rdf:first openlabel_v2:RoundaboutLargeNosignal ;
+	rdf:rest _:c14n623 .
+_:c14n625 rdf:first openlabel_v2:RoundaboutDoubleSignal ;
+	rdf:rest _:c14n624 .
+_:c14n626 rdf:first openlabel_v2:RoundaboutDoubleNosignal ;
+	rdf:rest _:c14n625 .
+_:c14n627 rdf:first openlabel_v2:RoundaboutCompactSignal ;
+	rdf:rest _:c14n626 .
+_:c14n628 rdf:first openlabel_v2:RoundaboutCompactNosignal ;
+	rdf:rest _:c14n627 .
+_:c14n629 rdf:first openlabel_v2:RoundaboutMiniSignal ;
+	rdf:rest _:c14n630 .
+_:c14n63 sh:datatype xsd:boolean ;
+	sh:description "An activity where the subject starts behind and ends up in front by changing lanes." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 13 ;
+	sh:path openlabel_v2:MotionOvertake .
+_:c14n630 rdf:first openlabel_v2:RoundaboutNormalNosignal ;
+	rdf:rest _:c14n631 .
+_:c14n631 rdf:first openlabel_v2:RoundaboutNormalSignal ;
+	rdf:rest rdf:nil .
+_:c14n632 rdf:first openlabel_v2:RoundaboutMiniNosignal ;
+	rdf:rest _:c14n629 .
+_:c14n633 rdf:first openlabel_v2:RoundaboutLargeSignal ;
+	rdf:rest _:c14n632 .
+_:c14n634 rdf:first openlabel_v2:RoundaboutLargeNosignal ;
+	rdf:rest _:c14n633 .
+_:c14n635 rdf:first openlabel_v2:RoundaboutDoubleSignal ;
+	rdf:rest _:c14n634 .
+_:c14n636 rdf:first openlabel_v2:RoundaboutDoubleNosignal ;
+	rdf:rest _:c14n635 .
+_:c14n637 rdf:first openlabel_v2:RoundaboutCompactSignal ;
+	rdf:rest _:c14n636 .
+_:c14n638 rdf:first openlabel_v2:RoundaboutCompactNosignal ;
+	rdf:rest _:c14n637 .
+_:c14n639 rdf:first openlabel_v2:RoundaboutMiniSignal ;
+	rdf:rest _:c14n640 .
+_:c14n64 sh:datatype xsd:boolean ;
+	sh:description "Curves flag. Refer to BSI PAS-1883 Section 5.2.3.3." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 12 ;
+	sh:path openlabel_v2:HorizontalCurves .
+_:c14n640 rdf:first openlabel_v2:RoundaboutNormalNosignal ;
+	rdf:rest _:c14n641 .
+_:c14n641 rdf:first openlabel_v2:RoundaboutNormalSignal ;
+	rdf:rest rdf:nil .
+_:c14n642 rdf:first openlabel_v2:RoundaboutMiniNosignal ;
+	rdf:rest _:c14n639 .
+_:c14n643 rdf:first openlabel_v2:RoundaboutLargeSignal ;
+	rdf:rest _:c14n642 .
+_:c14n644 rdf:first openlabel_v2:RoundaboutLargeNosignal ;
+	rdf:rest _:c14n643 .
+_:c14n645 rdf:first openlabel_v2:RoundaboutDoubleSignal ;
+	rdf:rest _:c14n644 .
+_:c14n646 rdf:first openlabel_v2:RoundaboutDoubleNosignal ;
+	rdf:rest _:c14n645 .
+_:c14n647 rdf:first openlabel_v2:RoundaboutCompactSignal ;
+	rdf:rest _:c14n646 .
+_:c14n648 rdf:first openlabel_v2:RoundaboutCompactNosignal ;
+	rdf:rest _:c14n647 .
+_:c14n649 rdf:first openlabel_v2:RoundaboutMiniSignal ;
+	rdf:rest _:c14n650 .
+_:c14n65 sh:description "Regulatory sign type. Refer to BSI PAS-1883 Section 5.2.3.5.b." ;
+	sh:in _:c14n829 ;
+	sh:order 45 ;
+	sh:path openlabel_v2:SignsRegulatory .
+_:c14n650 rdf:first openlabel_v2:RoundaboutNormalNosignal ;
+	rdf:rest _:c14n651 .
+_:c14n651 rdf:first openlabel_v2:RoundaboutNormalSignal ;
+	rdf:rest rdf:nil .
+_:c14n652 rdf:first openlabel_v2:RoundaboutMiniNosignal ;
+	rdf:rest _:c14n649 .
+_:c14n653 rdf:first openlabel_v2:RoundaboutLargeSignal ;
+	rdf:rest _:c14n652 .
+_:c14n654 rdf:first openlabel_v2:RoundaboutLargeNosignal ;
+	rdf:rest _:c14n653 .
+_:c14n655 rdf:first openlabel_v2:RoundaboutDoubleSignal ;
+	rdf:rest _:c14n654 .
+_:c14n656 rdf:first openlabel_v2:RoundaboutDoubleNosignal ;
+	rdf:rest _:c14n655 .
+_:c14n657 rdf:first openlabel_v2:RoundaboutCompactSignal ;
+	rdf:rest _:c14n656 .
+_:c14n658 rdf:first openlabel_v2:RoundaboutCompactNosignal ;
+	rdf:rest _:c14n657 .
+_:c14n659 rdf:first openlabel_v2:HumanCyclist ;
+	rdf:rest _:c14n660 .
+_:c14n66 sh:description "Transverse geometry type. Refer to BSI PAS-1883 Section 5.2.3.3.b." ;
+	sh:in _:c14n914 ;
+	sh:order 11 ;
+	sh:path openlabel_v2:GeometryTransverse .
+_:c14n660 rdf:first openlabel_v2:HumanDriver ;
+	rdf:rest _:c14n661 .
+_:c14n661 rdf:first openlabel_v2:HumanMotorcyclist ;
+	rdf:rest _:c14n662 .
+_:c14n662 rdf:first openlabel_v2:HumanPassenger ;
+	rdf:rest _:c14n663 .
+_:c14n663 rdf:first openlabel_v2:HumanPedestrian ;
+	rdf:rest _:c14n664 .
+_:c14n664 rdf:first openlabel_v2:HumanWheelchairUser ;
+	rdf:rest rdf:nil .
+_:c14n665 rdf:first openlabel_v2:HumanAnimalRider ;
+	rdf:rest _:c14n659 .
+_:c14n666 rdf:first openlabel_v2:SunPositionBehind ;
+	rdf:rest _:c14n667 .
+_:c14n667 rdf:first openlabel_v2:SunPositionFront ;
+	rdf:rest _:c14n668 .
+_:c14n668 rdf:first openlabel_v2:SunPositionLeft ;
+	rdf:rest _:c14n669 .
+_:c14n669 rdf:first openlabel_v2:SunPositionRight ;
+	rdf:rest rdf:nil .
+_:c14n67 sh:datatype xsd:boolean ;
+	sh:description "Traffic agent type classification flag. Refer to BSI PAS-1883 Section 5.4.a.4." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 51 ;
+	sh:path openlabel_v2:TrafficAgentType .
+_:c14n670 rdf:first openlabel_v2:SunPositionBehind ;
+	rdf:rest _:c14n671 .
+_:c14n671 rdf:first openlabel_v2:SunPositionFront ;
+	rdf:rest _:c14n672 .
+_:c14n672 rdf:first openlabel_v2:SunPositionLeft ;
+	rdf:rest _:c14n673 .
+_:c14n673 rdf:first openlabel_v2:SunPositionRight ;
+	rdf:rest rdf:nil .
+_:c14n674 rdf:first openlabel_v2:SunPositionBehind ;
+	rdf:rest _:c14n675 .
+_:c14n675 rdf:first openlabel_v2:SunPositionFront ;
+	rdf:rest _:c14n676 .
+_:c14n676 rdf:first openlabel_v2:SunPositionLeft ;
+	rdf:rest _:c14n677 .
+_:c14n677 rdf:first openlabel_v2:SunPositionRight ;
+	rdf:rest rdf:nil .
+_:c14n678 rdf:first openlabel_v2:SunPositionBehind ;
+	rdf:rest _:c14n679 .
+_:c14n679 rdf:first openlabel_v2:SunPositionFront ;
+	rdf:rest _:c14n680 .
+_:c14n68 sh:datatype xsd:integer ;
+	sh:description "Density (vehicles/km). Refer to BSI PAS-1883 Section 5.4.a.1." ;
+	sh:maxCount 1 ;
+	sh:minInclusive 0 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 50 ;
+	sh:path openlabel_v2:trafficAgentDensityValue .
+_:c14n680 rdf:first openlabel_v2:SunPositionLeft ;
+	rdf:rest _:c14n681 .
+_:c14n681 rdf:first openlabel_v2:SunPositionRight ;
+	rdf:rest rdf:nil .
+_:c14n682 rdf:first openlabel_v2:SurfaceConditionIcy ;
+	rdf:rest _:c14n685 .
+_:c14n683 rdf:first openlabel_v2:SurfaceConditionFlooded ;
+	rdf:rest _:c14n682 .
+_:c14n684 rdf:first openlabel_v2:SurfaceConditionContamination ;
+	rdf:rest _:c14n683 .
+_:c14n685 rdf:first openlabel_v2:SurfaceConditionMirage ;
+	rdf:rest _:c14n686 .
+_:c14n686 rdf:first openlabel_v2:SurfaceConditionSnow ;
+	rdf:rest _:c14n687 .
+_:c14n687 rdf:first openlabel_v2:SurfaceConditionStandingWater ;
+	rdf:rest _:c14n688 .
+_:c14n688 rdf:first openlabel_v2:SurfaceConditionWet ;
+	rdf:rest rdf:nil .
+_:c14n689 rdf:first openlabel_v2:SurfaceConditionIcy ;
+	rdf:rest _:c14n692 .
+_:c14n69 sh:datatype xsd:string ;
+	sh:description "Universally unique identifier (UUID) which identifies the scenario which this one has been derived from." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 9 ;
+	sh:path openlabel_v2:scenarioParentReference .
+_:c14n690 rdf:first openlabel_v2:SurfaceConditionFlooded ;
+	rdf:rest _:c14n689 .
+_:c14n691 rdf:first openlabel_v2:SurfaceConditionContamination ;
+	rdf:rest _:c14n690 .
+_:c14n692 rdf:first openlabel_v2:SurfaceConditionMirage ;
+	rdf:rest _:c14n693 .
+_:c14n693 rdf:first openlabel_v2:SurfaceConditionSnow ;
+	rdf:rest _:c14n694 .
+_:c14n694 rdf:first openlabel_v2:SurfaceConditionStandingWater ;
+	rdf:rest _:c14n695 .
+_:c14n695 rdf:first openlabel_v2:SurfaceConditionWet ;
+	rdf:rest rdf:nil .
+_:c14n696 rdf:first openlabel_v2:SurfaceConditionIcy ;
+	rdf:rest _:c14n699 .
+_:c14n697 rdf:first openlabel_v2:SurfaceConditionFlooded ;
+	rdf:rest _:c14n696 .
+_:c14n698 rdf:first openlabel_v2:SurfaceConditionContamination ;
+	rdf:rest _:c14n697 .
+_:c14n699 rdf:first openlabel_v2:SurfaceConditionMirage ;
+	rdf:rest _:c14n700 .
+_:c14n7 sh:description "Fixed road structure. Refer to BSI PAS-1883 Section 5.2.1.e." ;
+	sh:in _:c14n899 ;
+	sh:order 40 ;
+	sh:path openlabel_v2:SceneryFixedStructure .
+_:c14n70 sh:description "Human road user type." ;
+	sh:in _:c14n665 ;
+	sh:maxCount 1 ;
+	sh:order 1 ;
+	sh:path openlabel_v2:RoadUserHuman .
+_:c14n700 rdf:first openlabel_v2:SurfaceConditionSnow ;
+	rdf:rest _:c14n701 .
+_:c14n701 rdf:first openlabel_v2:SurfaceConditionStandingWater ;
+	rdf:rest _:c14n702 .
+_:c14n702 rdf:first openlabel_v2:SurfaceConditionWet ;
+	rdf:rest rdf:nil .
+_:c14n703 rdf:first openlabel_v2:SurfaceConditionIcy ;
+	rdf:rest _:c14n706 .
+_:c14n704 rdf:first openlabel_v2:SurfaceConditionFlooded ;
+	rdf:rest _:c14n703 .
+_:c14n705 rdf:first openlabel_v2:SurfaceConditionContamination ;
+	rdf:rest _:c14n704 .
+_:c14n706 rdf:first openlabel_v2:SurfaceConditionMirage ;
+	rdf:rest _:c14n707 .
+_:c14n707 rdf:first openlabel_v2:SurfaceConditionSnow ;
+	rdf:rest _:c14n708 .
+_:c14n708 rdf:first openlabel_v2:SurfaceConditionStandingWater ;
+	rdf:rest _:c14n709 .
+_:c14n709 rdf:first openlabel_v2:SurfaceConditionWet ;
+	rdf:rest rdf:nil .
+_:c14n71 sh:datatype xsd:boolean ;
+	sh:description "Wind flag. Refer to BSI PAS-1883 Section 5.3.1.1." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 62 ;
+	sh:path openlabel_v2:WeatherWind .
+_:c14n710 rdf:first openlabel_v2:SpecialStructureAutoAccess ;
+	rdf:rest _:c14n711 .
+_:c14n711 rdf:first openlabel_v2:SpecialStructureBridge ;
+	rdf:rest _:c14n712 .
+_:c14n712 rdf:first openlabel_v2:SpecialStructurePedestrianCrossing ;
+	rdf:rest _:c14n713 .
+_:c14n713 rdf:first openlabel_v2:SpecialStructureRailCrossing ;
+	rdf:rest _:c14n714 .
+_:c14n714 rdf:first openlabel_v2:SpecialStructureTollPlaza ;
+	rdf:rest _:c14n715 .
+_:c14n715 rdf:first openlabel_v2:SpecialStructureTunnel ;
+	rdf:rest rdf:nil .
+_:c14n716 rdf:first openlabel_v2:SpecialStructureAutoAccess ;
+	rdf:rest _:c14n717 .
+_:c14n717 rdf:first openlabel_v2:SpecialStructureBridge ;
+	rdf:rest _:c14n718 .
+_:c14n718 rdf:first openlabel_v2:SpecialStructurePedestrianCrossing ;
+	rdf:rest _:c14n719 .
+_:c14n719 rdf:first openlabel_v2:SpecialStructureRailCrossing ;
+	rdf:rest _:c14n720 .
+_:c14n72 sh:description "Road surface feature. Refer to BSI PAS-1883 Section 5.2.3.7.b." ;
+	sh:in _:c14n588 ;
+	sh:order 7 ;
+	sh:path openlabel_v2:DrivableAreaSurfaceFeature .
+_:c14n720 rdf:first openlabel_v2:SpecialStructureTollPlaza ;
+	rdf:rest _:c14n721 .
+_:c14n721 rdf:first openlabel_v2:SpecialStructureTunnel ;
+	rdf:rest rdf:nil .
+_:c14n722 rdf:first openlabel_v2:SpecialStructureAutoAccess ;
+	rdf:rest _:c14n723 .
+_:c14n723 rdf:first openlabel_v2:SpecialStructureBridge ;
+	rdf:rest _:c14n724 .
+_:c14n724 rdf:first openlabel_v2:SpecialStructurePedestrianCrossing ;
+	rdf:rest _:c14n725 .
+_:c14n725 rdf:first openlabel_v2:SpecialStructureRailCrossing ;
+	rdf:rest _:c14n726 .
+_:c14n726 rdf:first openlabel_v2:SpecialStructureTollPlaza ;
+	rdf:rest _:c14n727 .
+_:c14n727 rdf:first openlabel_v2:SpecialStructureTunnel ;
+	rdf:rest rdf:nil .
+_:c14n728 rdf:first openlabel_v2:SpecialStructureAutoAccess ;
+	rdf:rest _:c14n729 .
+_:c14n729 rdf:first openlabel_v2:SpecialStructureBridge ;
+	rdf:rest _:c14n730 .
+_:c14n73 sh:datatype xsd:decimal ;
+	sh:description "Sun elevation (degrees). Refer to BSI PAS-1883 Section 5.3.3.a.1." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 3 ;
+	sh:path openlabel_v2:daySunElevationValue .
+_:c14n730 rdf:first openlabel_v2:SpecialStructurePedestrianCrossing ;
+	rdf:rest _:c14n731 .
+_:c14n731 rdf:first openlabel_v2:SpecialStructureRailCrossing ;
+	rdf:rest _:c14n732 .
+_:c14n732 rdf:first openlabel_v2:SpecialStructureTollPlaza ;
+	rdf:rest _:c14n733 .
+_:c14n733 rdf:first openlabel_v2:SpecialStructureTunnel ;
+	rdf:rest rdf:nil .
+_:c14n734 rdf:first openlabel_v2:RoadTypeSlip ;
+	rdf:rest rdf:nil .
+_:c14n735 rdf:first openlabel_v2:RoadTypeShared ;
+	rdf:rest _:c14n734 .
+_:c14n736 rdf:first openlabel_v2:RoadTypeRadial ;
+	rdf:rest _:c14n735 .
+_:c14n737 rdf:first openlabel_v2:RoadTypeParking ;
+	rdf:rest _:c14n736 .
+_:c14n738 rdf:first openlabel_v2:MotorwayUnmanaged ;
+	rdf:rest _:c14n737 .
+_:c14n739 rdf:first openlabel_v2:MotorwayManaged ;
+	rdf:rest _:c14n738 .
+_:c14n74 sh:description "Intersection type. Refer to BSI PAS-1883 Section 5.2.4." ;
+	sh:in _:c14n788 ;
+	sh:maxCount 1 ;
+	sh:order 19 ;
+	sh:path openlabel_v2:JunctionIntersection .
+_:c14n740 rdf:first openlabel_v2:RoadTypeMotorway ;
+	rdf:rest _:c14n739 .
+_:c14n741 rdf:first openlabel_v2:RoadTypeMinor ;
+	rdf:rest _:c14n740 .
+_:c14n742 rdf:first openlabel_v2:RoadTypeDistributor ;
+	rdf:rest _:c14n741 .
+_:c14n743 rdf:first openlabel_v2:RoadTypeSlip ;
+	rdf:rest rdf:nil .
+_:c14n744 rdf:first openlabel_v2:RoadTypeShared ;
+	rdf:rest _:c14n743 .
+_:c14n745 rdf:first openlabel_v2:RoadTypeRadial ;
+	rdf:rest _:c14n744 .
+_:c14n746 rdf:first openlabel_v2:RoadTypeParking ;
+	rdf:rest _:c14n745 .
+_:c14n747 rdf:first openlabel_v2:MotorwayUnmanaged ;
+	rdf:rest _:c14n746 .
+_:c14n748 rdf:first openlabel_v2:MotorwayManaged ;
+	rdf:rest _:c14n747 .
+_:c14n749 rdf:first openlabel_v2:RoadTypeMotorway ;
+	rdf:rest _:c14n748 .
+_:c14n75 sh:description "Intersection type. Refer to BSI PAS-1883 Section 5.2.4." ;
+	sh:in _:c14n773 ;
+	sh:order 19 ;
+	sh:path openlabel_v2:JunctionIntersection .
+_:c14n750 rdf:first openlabel_v2:RoadTypeMinor ;
+	rdf:rest _:c14n749 .
+_:c14n751 rdf:first openlabel_v2:RoadTypeDistributor ;
+	rdf:rest _:c14n750 .
+_:c14n752 rdf:first openlabel_v2:RoadTypeSlip ;
+	rdf:rest rdf:nil .
+_:c14n753 rdf:first openlabel_v2:RoadTypeShared ;
+	rdf:rest _:c14n752 .
+_:c14n754 rdf:first openlabel_v2:RoadTypeRadial ;
+	rdf:rest _:c14n753 .
+_:c14n755 rdf:first openlabel_v2:RoadTypeParking ;
+	rdf:rest _:c14n754 .
+_:c14n756 rdf:first openlabel_v2:MotorwayUnmanaged ;
+	rdf:rest _:c14n755 .
+_:c14n757 rdf:first openlabel_v2:MotorwayManaged ;
+	rdf:rest _:c14n756 .
+_:c14n758 rdf:first openlabel_v2:RoadTypeMotorway ;
+	rdf:rest _:c14n757 .
+_:c14n759 rdf:first openlabel_v2:RoadTypeMinor ;
+	rdf:rest _:c14n758 .
+_:c14n76 sh:description "Road surface feature. Refer to BSI PAS-1883 Section 5.2.3.7.b." ;
+	sh:in _:c14n584 ;
+	sh:maxCount 1 ;
+	sh:order 7 ;
+	sh:path openlabel_v2:DrivableAreaSurfaceFeature .
+_:c14n760 rdf:first openlabel_v2:RoadTypeDistributor ;
+	rdf:rest _:c14n759 .
+_:c14n761 rdf:first openlabel_v2:RoadTypeSlip ;
+	rdf:rest rdf:nil .
+_:c14n762 rdf:first openlabel_v2:RoadTypeShared ;
+	rdf:rest _:c14n761 .
+_:c14n763 rdf:first openlabel_v2:RoadTypeRadial ;
+	rdf:rest _:c14n762 .
+_:c14n764 rdf:first openlabel_v2:RoadTypeParking ;
+	rdf:rest _:c14n763 .
+_:c14n765 rdf:first openlabel_v2:MotorwayUnmanaged ;
+	rdf:rest _:c14n764 .
+_:c14n766 rdf:first openlabel_v2:MotorwayManaged ;
+	rdf:rest _:c14n765 .
+_:c14n767 rdf:first openlabel_v2:RoadTypeMotorway ;
+	rdf:rest _:c14n766 .
+_:c14n768 rdf:first openlabel_v2:RoadTypeMinor ;
+	rdf:rest _:c14n767 .
+_:c14n769 rdf:first openlabel_v2:RoadTypeDistributor ;
+	rdf:rest _:c14n768 .
+_:c14n77 sh:datatype xsd:decimal ;
+	sh:description "Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.ii." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 29 ;
+	sh:path openlabel_v2:longitudinalDownSlopeValue .
+_:c14n770 rdf:first openlabel_v2:IntersectionTJunction ;
+	rdf:rest _:c14n774 .
+_:c14n771 rdf:first openlabel_v2:IntersectionStaggered ;
+	rdf:rest _:c14n770 .
+_:c14n772 rdf:first openlabel_v2:IntersectionGradeSeperated ;
+	rdf:rest _:c14n771 .
+_:c14n773 rdf:first openlabel_v2:IntersectionCrossroad ;
+	rdf:rest _:c14n772 .
+_:c14n774 rdf:first openlabel_v2:IntersectionYJunction ;
+	rdf:rest rdf:nil .
+_:c14n775 rdf:first openlabel_v2:IntersectionTJunction ;
+	rdf:rest _:c14n779 .
+_:c14n776 rdf:first openlabel_v2:IntersectionStaggered ;
+	rdf:rest _:c14n775 .
+_:c14n777 rdf:first openlabel_v2:IntersectionGradeSeperated ;
+	rdf:rest _:c14n776 .
+_:c14n778 rdf:first openlabel_v2:IntersectionCrossroad ;
+	rdf:rest _:c14n777 .
+_:c14n779 rdf:first openlabel_v2:IntersectionYJunction ;
+	rdf:rest rdf:nil .
+_:c14n78 sh:description "Rainfall type. Refer to BSI PAS-1883 Section 5.3.1.2." ;
+	sh:in _:c14n846 ;
+	sh:maxCount 1 ;
+	sh:order 39 ;
+	sh:path openlabel_v2:RainType .
+_:c14n780 rdf:first openlabel_v2:IntersectionTJunction ;
+	rdf:rest _:c14n784 .
+_:c14n781 rdf:first openlabel_v2:IntersectionStaggered ;
+	rdf:rest _:c14n780 .
+_:c14n782 rdf:first openlabel_v2:IntersectionGradeSeperated ;
+	rdf:rest _:c14n781 .
+_:c14n783 rdf:first openlabel_v2:IntersectionCrossroad ;
+	rdf:rest _:c14n782 .
+_:c14n784 rdf:first openlabel_v2:IntersectionYJunction ;
+	rdf:rest rdf:nil .
+_:c14n785 rdf:first openlabel_v2:IntersectionTJunction ;
+	rdf:rest _:c14n789 .
+_:c14n786 rdf:first openlabel_v2:IntersectionStaggered ;
+	rdf:rest _:c14n785 .
+_:c14n787 rdf:first openlabel_v2:IntersectionGradeSeperated ;
+	rdf:rest _:c14n786 .
+_:c14n788 rdf:first openlabel_v2:IntersectionCrossroad ;
+	rdf:rest _:c14n787 .
+_:c14n789 rdf:first openlabel_v2:IntersectionYJunction ;
+	rdf:rest rdf:nil .
+_:c14n79 sh:datatype xsd:boolean ;
+	sh:description "Straight lines flag. Refer to BSI PAS-1883 Section 5.2.3.3." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 14 ;
+	sh:path openlabel_v2:HorizontalStraights .
+_:c14n790 rdf:first openlabel_v2:ZoneSchool ;
+	rdf:rest _:c14n794 .
+_:c14n791 rdf:first openlabel_v2:ZoneRegion ;
+	rdf:rest _:c14n790 .
+_:c14n792 rdf:first openlabel_v2:ZoneInterference ;
+	rdf:rest _:c14n791 .
+_:c14n793 rdf:first openlabel_v2:ZoneGeoFenced ;
+	rdf:rest _:c14n792 .
+_:c14n794 rdf:first openlabel_v2:ZoneTrafficManagement ;
+	rdf:rest rdf:nil .
+_:c14n795 rdf:first openlabel_v2:ZoneSchool ;
+	rdf:rest _:c14n799 .
+_:c14n796 rdf:first openlabel_v2:ZoneRegion ;
+	rdf:rest _:c14n795 .
+_:c14n797 rdf:first openlabel_v2:ZoneInterference ;
+	rdf:rest _:c14n796 .
+_:c14n798 rdf:first openlabel_v2:ZoneGeoFenced ;
+	rdf:rest _:c14n797 .
+_:c14n799 rdf:first openlabel_v2:ZoneTrafficManagement ;
+	rdf:rest rdf:nil .
+_:c14n8 sh:datatype xsd:boolean ;
+	sh:description "Level plane flag. Refer to BSI PAS-1883 Section 5.2.3.3.iii." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 30 ;
+	sh:path openlabel_v2:LongitudinalLevelPlane .
+_:c14n80 sh:datatype xsd:decimal ;
+	sh:description "Wind speed (m/s). Refer to BSI PAS-1883 Section 5.3.1.1." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 63 ;
+	sh:path openlabel_v2:weatherWindValue .
+_:c14n800 rdf:first openlabel_v2:ZoneSchool ;
+	rdf:rest _:c14n804 .
+_:c14n801 rdf:first openlabel_v2:ZoneRegion ;
+	rdf:rest _:c14n800 .
+_:c14n802 rdf:first openlabel_v2:ZoneInterference ;
+	rdf:rest _:c14n801 .
+_:c14n803 rdf:first openlabel_v2:ZoneGeoFenced ;
+	rdf:rest _:c14n802 .
+_:c14n804 rdf:first openlabel_v2:ZoneTrafficManagement ;
+	rdf:rest rdf:nil .
+_:c14n805 rdf:first openlabel_v2:ZoneSchool ;
+	rdf:rest _:c14n809 .
+_:c14n806 rdf:first openlabel_v2:ZoneRegion ;
+	rdf:rest _:c14n805 .
+_:c14n807 rdf:first openlabel_v2:ZoneInterference ;
+	rdf:rest _:c14n806 .
+_:c14n808 rdf:first openlabel_v2:ZoneGeoFenced ;
+	rdf:rest _:c14n807 .
+_:c14n809 rdf:first openlabel_v2:ZoneTrafficManagement ;
+	rdf:rest rdf:nil .
+_:c14n81 sh:datatype xsd:integer ;
+	sh:description "Volume (vehicle km). Refer to BSI PAS-1883 Section 5.4.a.2." ;
+	sh:minInclusive 0 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 57 ;
+	sh:path openlabel_v2:trafficVolumeValue .
+_:c14n810 rdf:first openlabel_v2:PositioningGlonass ;
+	rdf:rest _:c14n811 .
+_:c14n811 rdf:first openlabel_v2:PositioningGps ;
+	rdf:rest rdf:nil .
+_:c14n812 rdf:first openlabel_v2:PositioningGalileo ;
+	rdf:rest _:c14n810 .
+_:c14n813 rdf:first openlabel_v2:PositioningGlonass ;
+	rdf:rest _:c14n814 .
+_:c14n814 rdf:first openlabel_v2:PositioningGps ;
+	rdf:rest rdf:nil .
+_:c14n815 rdf:first openlabel_v2:PositioningGalileo ;
+	rdf:rest _:c14n813 .
+_:c14n816 rdf:first openlabel_v2:PositioningGlonass ;
+	rdf:rest _:c14n817 .
+_:c14n817 rdf:first openlabel_v2:PositioningGps ;
+	rdf:rest rdf:nil .
+_:c14n818 rdf:first openlabel_v2:PositioningGalileo ;
+	rdf:rest _:c14n816 .
+_:c14n819 rdf:first openlabel_v2:PositioningGlonass ;
+	rdf:rest _:c14n820 .
+_:c14n82 sh:datatype xsd:integer ;
+	sh:description "Density (vehicles/km). Refer to BSI PAS-1883 Section 5.4.a.1." ;
+	sh:minInclusive 0 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 50 ;
+	sh:path openlabel_v2:trafficAgentDensityValue .
+_:c14n820 rdf:first openlabel_v2:PositioningGps ;
+	rdf:rest rdf:nil .
+_:c14n821 rdf:first openlabel_v2:PositioningGalileo ;
+	rdf:rest _:c14n819 .
+_:c14n822 rdf:first openlabel_v2:RegulatorySignsVariableFullTime ;
+	rdf:rest _:c14n823 .
+_:c14n823 rdf:first openlabel_v2:RegulatorySignsVariableTemporary ;
+	rdf:rest rdf:nil .
+_:c14n824 rdf:first openlabel_v2:RegulatorySignsUniformTemporary ;
+	rdf:rest _:c14n822 .
+_:c14n825 rdf:first openlabel_v2:RegulatorySignsUniformFullTime ;
+	rdf:rest _:c14n824 .
+_:c14n826 rdf:first openlabel_v2:RegulatorySignsVariableFullTime ;
+	rdf:rest _:c14n827 .
+_:c14n827 rdf:first openlabel_v2:RegulatorySignsVariableTemporary ;
+	rdf:rest rdf:nil .
+_:c14n828 rdf:first openlabel_v2:RegulatorySignsUniformTemporary ;
+	rdf:rest _:c14n826 .
+_:c14n829 rdf:first openlabel_v2:RegulatorySignsUniformFullTime ;
+	rdf:rest _:c14n828 .
+_:c14n83 sh:description "Regulatory sign type. Refer to BSI PAS-1883 Section 5.2.3.5.b." ;
+	sh:in _:c14n837 ;
+	sh:order 45 ;
+	sh:path openlabel_v2:SignsRegulatory .
+_:c14n830 rdf:first openlabel_v2:RegulatorySignsVariableFullTime ;
+	rdf:rest _:c14n831 .
+_:c14n831 rdf:first openlabel_v2:RegulatorySignsVariableTemporary ;
+	rdf:rest rdf:nil .
+_:c14n832 rdf:first openlabel_v2:RegulatorySignsUniformTemporary ;
+	rdf:rest _:c14n830 .
+_:c14n833 rdf:first openlabel_v2:RegulatorySignsUniformFullTime ;
+	rdf:rest _:c14n832 .
+_:c14n834 rdf:first openlabel_v2:RegulatorySignsVariableFullTime ;
+	rdf:rest _:c14n835 .
+_:c14n835 rdf:first openlabel_v2:RegulatorySignsVariableTemporary ;
+	rdf:rest rdf:nil .
+_:c14n836 rdf:first openlabel_v2:RegulatorySignsUniformTemporary ;
+	rdf:rest _:c14n834 .
+_:c14n837 rdf:first openlabel_v2:RegulatorySignsUniformFullTime ;
+	rdf:rest _:c14n836 .
+_:c14n838 rdf:first openlabel_v2:RainTypeDynamic ;
+	rdf:rest _:c14n839 .
+_:c14n839 rdf:first openlabel_v2:RainTypeOrographic ;
+	rdf:rest rdf:nil .
+_:c14n84 sh:datatype xsd:boolean ;
+	sh:description "Traffic flow rate flag. Refer to BSI PAS-1883 Section 5.4.a.3." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 53 ;
+	sh:path openlabel_v2:TrafficFlowRate .
+_:c14n840 rdf:first openlabel_v2:RainTypeConvective ;
+	rdf:rest _:c14n838 .
+_:c14n841 rdf:first openlabel_v2:RainTypeDynamic ;
+	rdf:rest _:c14n842 .
+_:c14n842 rdf:first openlabel_v2:RainTypeOrographic ;
+	rdf:rest rdf:nil .
+_:c14n843 rdf:first openlabel_v2:RainTypeConvective ;
+	rdf:rest _:c14n841 .
+_:c14n844 rdf:first openlabel_v2:RainTypeDynamic ;
+	rdf:rest _:c14n845 .
+_:c14n845 rdf:first openlabel_v2:RainTypeOrographic ;
+	rdf:rest rdf:nil .
+_:c14n846 rdf:first openlabel_v2:RainTypeConvective ;
+	rdf:rest _:c14n844 .
+_:c14n847 rdf:first openlabel_v2:RainTypeDynamic ;
+	rdf:rest _:c14n848 .
+_:c14n848 rdf:first openlabel_v2:RainTypeOrographic ;
+	rdf:rest rdf:nil .
+_:c14n849 rdf:first openlabel_v2:RainTypeConvective ;
+	rdf:rest _:c14n847 .
+_:c14n85 sh:description "Lane width (m). Refer to BSI PAS-1883 Section 5.2.3.4.a." ;
+	sh:maxCount 1 ;
+	sh:or _:c14n556 ;
+	sh:order 22 ;
+	sh:path openlabel_v2:laneSpecificationDimensionsValue .
+_:c14n850 rdf:first _:c14n853 ;
+	rdf:rest _:c14n851 .
+_:c14n851 rdf:first _:c14n852 ;
+	rdf:rest rdf:nil .
+_:c14n852 sh:class sdo:QuantitativeValue .
+_:c14n853 sh:datatype xsd:integer ;
+	sh:nodeKind sh:Literal .
+_:c14n854 rdf:first _:c14n857 ;
+	rdf:rest _:c14n855 .
+_:c14n855 rdf:first _:c14n856 ;
+	rdf:rest rdf:nil .
+_:c14n856 sh:class sdo:QuantitativeValue .
+_:c14n857 sh:datatype xsd:integer ;
+	sh:nodeKind sh:Literal .
+_:c14n858 rdf:first _:c14n861 ;
+	rdf:rest _:c14n859 .
+_:c14n859 rdf:first _:c14n860 ;
+	rdf:rest rdf:nil .
+_:c14n86 sh:datatype xsd:boolean ;
+	sh:description "Volcanic ash flag. Refer to BSI PAS-1883 Section 5.3.2.e." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 36 ;
+	sh:path openlabel_v2:ParticulatesVolcanic .
+_:c14n860 sh:class sdo:QuantitativeValue .
+_:c14n861 sh:datatype xsd:integer ;
+	sh:nodeKind sh:Literal .
+_:c14n862 rdf:first _:c14n865 ;
+	rdf:rest _:c14n863 .
+_:c14n863 rdf:first _:c14n864 ;
+	rdf:rest rdf:nil .
+_:c14n864 sh:class sdo:QuantitativeValue .
+_:c14n865 sh:datatype xsd:integer ;
+	sh:nodeKind sh:Literal .
+_:c14n866 rdf:first _:c14n869 ;
+	rdf:rest _:c14n867 .
+_:c14n867 rdf:first _:c14n868 ;
+	rdf:rest rdf:nil .
+_:c14n868 sh:class sdo:QuantitativeValue .
+_:c14n869 sh:datatype xsd:integer ;
+	sh:nodeKind sh:Literal .
+_:c14n87 sh:datatype xsd:decimal ;
+	sh:description "Meteorological Optical Range (MOR) (m). Refer to BSI PAS-1883 Section 5.3.2.b." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 38 ;
+	sh:path openlabel_v2:particulatesWaterValue .
+_:c14n870 rdf:first _:c14n873 ;
+	rdf:rest _:c14n871 .
+_:c14n871 rdf:first _:c14n872 ;
+	rdf:rest rdf:nil .
+_:c14n872 sh:class sdo:QuantitativeValue .
+_:c14n873 sh:datatype xsd:integer ;
+	sh:nodeKind sh:Literal .
+_:c14n874 rdf:first _:c14n877 ;
+	rdf:rest _:c14n875 .
+_:c14n875 rdf:first _:c14n876 ;
+	rdf:rest rdf:nil .
+_:c14n876 sh:class sdo:QuantitativeValue .
+_:c14n877 sh:datatype xsd:integer ;
+	sh:nodeKind sh:Literal .
+_:c14n878 rdf:first _:c14n881 ;
+	rdf:rest _:c14n879 .
+_:c14n879 rdf:first _:c14n880 ;
+	rdf:rest rdf:nil .
+_:c14n88 sh:datatype xsd:integer ;
+	sh:description "Volume (vehicle km). Refer to BSI PAS-1883 Section 5.4.a.2." ;
+	sh:maxCount 1 ;
+	sh:minInclusive 0 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 57 ;
+	sh:path openlabel_v2:trafficVolumeValue .
+_:c14n880 sh:class sdo:QuantitativeValue .
+_:c14n881 sh:datatype xsd:integer ;
+	sh:nodeKind sh:Literal .
+_:c14n882 rdf:first openlabel_v2:TemporaryStructureConstructionDetour ;
+	rdf:rest _:c14n883 .
+_:c14n883 rdf:first openlabel_v2:TemporaryStructureRefuseCollection ;
+	rdf:rest _:c14n884 .
+_:c14n884 rdf:first openlabel_v2:TemporaryStructureRoadSignage ;
+	rdf:rest _:c14n885 .
+_:c14n885 rdf:first openlabel_v2:TemporaryStructureRoadWorks ;
+	rdf:rest rdf:nil .
+_:c14n886 rdf:first openlabel_v2:TemporaryStructureConstructionDetour ;
+	rdf:rest _:c14n887 .
+_:c14n887 rdf:first openlabel_v2:TemporaryStructureRefuseCollection ;
+	rdf:rest _:c14n888 .
+_:c14n888 rdf:first openlabel_v2:TemporaryStructureRoadSignage ;
+	rdf:rest _:c14n889 .
+_:c14n889 rdf:first openlabel_v2:TemporaryStructureRoadWorks ;
+	rdf:rest rdf:nil .
+_:c14n89 sh:datatype xsd:boolean ;
+	sh:description "Non-precipitating water droplets or ice crystals (mist/fog) flag. Refer to BSI PAS-1883 Section 5.3.2.b." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 37 ;
+	sh:path openlabel_v2:ParticulatesWater .
+_:c14n890 rdf:first openlabel_v2:TemporaryStructureConstructionDetour ;
+	rdf:rest _:c14n891 .
+_:c14n891 rdf:first openlabel_v2:TemporaryStructureRefuseCollection ;
+	rdf:rest _:c14n892 .
+_:c14n892 rdf:first openlabel_v2:TemporaryStructureRoadSignage ;
+	rdf:rest _:c14n893 .
+_:c14n893 rdf:first openlabel_v2:TemporaryStructureRoadWorks ;
+	rdf:rest rdf:nil .
+_:c14n894 rdf:first openlabel_v2:TemporaryStructureConstructionDetour ;
+	rdf:rest _:c14n895 .
+_:c14n895 rdf:first openlabel_v2:TemporaryStructureRefuseCollection ;
+	rdf:rest _:c14n896 .
+_:c14n896 rdf:first openlabel_v2:TemporaryStructureRoadSignage ;
+	rdf:rest _:c14n897 .
+_:c14n897 rdf:first openlabel_v2:TemporaryStructureRoadWorks ;
+	rdf:rest rdf:nil .
+_:c14n898 rdf:first openlabel_v2:FixedStructureStreetFurniture ;
+	rdf:rest _:c14n900 .
+_:c14n899 rdf:first openlabel_v2:FixedStructureBuilding ;
+	rdf:rest _:c14n898 .
+_:c14n9 sh:datatype xsd:boolean ;
+	sh:description "Number of lanes flag. Refer to BSI PAS-1883 Section 5.2.3.4.d." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 23 ;
+	sh:path openlabel_v2:LaneSpecificationLaneCount .
+_:c14n90 rdf:first openlabel_v2:CommunicationSignalEmergency ;
+	rdf:rest _:c14n26 .
+_:c14n900 rdf:first openlabel_v2:FixedStructureStreetlight ;
+	rdf:rest _:c14n901 .
+_:c14n901 rdf:first openlabel_v2:FixedStructureVegetation ;
+	rdf:rest rdf:nil .
+_:c14n902 rdf:first openlabel_v2:FixedStructureStreetFurniture ;
+	rdf:rest _:c14n904 .
+_:c14n903 rdf:first openlabel_v2:FixedStructureBuilding ;
+	rdf:rest _:c14n902 .
+_:c14n904 rdf:first openlabel_v2:FixedStructureStreetlight ;
+	rdf:rest _:c14n905 .
+_:c14n905 rdf:first openlabel_v2:FixedStructureVegetation ;
+	rdf:rest rdf:nil .
+_:c14n906 rdf:first openlabel_v2:FixedStructureStreetFurniture ;
+	rdf:rest _:c14n908 .
+_:c14n907 rdf:first openlabel_v2:FixedStructureBuilding ;
+	rdf:rest _:c14n906 .
+_:c14n908 rdf:first openlabel_v2:FixedStructureStreetlight ;
+	rdf:rest _:c14n909 .
+_:c14n909 rdf:first openlabel_v2:FixedStructureVegetation ;
+	rdf:rest rdf:nil .
+_:c14n91 sh:datatype xsd:decimal ;
+	sh:description "Lower bound inferred via RDFS from schema:minValue being a subPropertyOf cmns-q:hasLowerBound in schema.org OWL." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 2 ;
+	sh:path cmns-q:hasLowerBound .
+_:c14n910 rdf:first openlabel_v2:FixedStructureStreetFurniture ;
+	rdf:rest _:c14n912 .
+_:c14n911 rdf:first openlabel_v2:FixedStructureBuilding ;
+	rdf:rest _:c14n910 .
+_:c14n912 rdf:first openlabel_v2:FixedStructureStreetlight ;
+	rdf:rest _:c14n913 .
+_:c14n913 rdf:first openlabel_v2:FixedStructureVegetation ;
+	rdf:rest rdf:nil .
+_:c14n914 rdf:first openlabel_v2:TransverseBarriers ;
+	rdf:rest _:c14n915 .
+_:c14n915 rdf:first openlabel_v2:TransverseDivided ;
+	rdf:rest _:c14n916 .
+_:c14n916 rdf:first openlabel_v2:TransverseLanesTogether ;
+	rdf:rest _:c14n917 .
+_:c14n917 rdf:first openlabel_v2:TransversePavements ;
+	rdf:rest _:c14n918 .
+_:c14n918 rdf:first openlabel_v2:TransverseUndivided ;
+	rdf:rest rdf:nil .
+_:c14n919 rdf:first openlabel_v2:TransverseBarriers ;
+	rdf:rest _:c14n920 .
+_:c14n92 sh:description "Rainfall type. Refer to BSI PAS-1883 Section 5.3.1.2." ;
+	sh:in _:c14n840 ;
+	sh:order 39 ;
+	sh:path openlabel_v2:RainType .
+_:c14n920 rdf:first openlabel_v2:TransverseDivided ;
+	rdf:rest _:c14n921 .
+_:c14n921 rdf:first openlabel_v2:TransverseLanesTogether ;
+	rdf:rest _:c14n922 .
+_:c14n922 rdf:first openlabel_v2:TransversePavements ;
+	rdf:rest _:c14n923 .
+_:c14n923 rdf:first openlabel_v2:TransverseUndivided ;
+	rdf:rest rdf:nil .
+_:c14n924 rdf:first openlabel_v2:TransverseBarriers ;
+	rdf:rest _:c14n925 .
+_:c14n925 rdf:first openlabel_v2:TransverseDivided ;
+	rdf:rest _:c14n926 .
+_:c14n926 rdf:first openlabel_v2:TransverseLanesTogether ;
+	rdf:rest _:c14n927 .
+_:c14n927 rdf:first openlabel_v2:TransversePavements ;
+	rdf:rest _:c14n928 .
+_:c14n928 rdf:first openlabel_v2:TransverseUndivided ;
+	rdf:rest rdf:nil .
+_:c14n929 rdf:first openlabel_v2:TransverseBarriers ;
+	rdf:rest _:c14n930 .
+_:c14n93 sh:datatype xsd:boolean ;
+	sh:description "Traffic volume flag. Refer to BSI PAS-1883 Section 5.4.a.2." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 56 ;
+	sh:path openlabel_v2:TrafficVolume .
+_:c14n930 rdf:first openlabel_v2:TransverseDivided ;
+	rdf:rest _:c14n931 .
+_:c14n931 rdf:first openlabel_v2:TransverseLanesTogether ;
+	rdf:rest _:c14n932 .
+_:c14n932 rdf:first openlabel_v2:TransversePavements ;
+	rdf:rest _:c14n933 .
+_:c14n933 rdf:first openlabel_v2:TransverseUndivided ;
+	rdf:rest rdf:nil .
+_:c14n934 rdf:first openlabel_v2:ArtificialStreetLighting ;
+	rdf:rest _:c14n935 .
+_:c14n935 rdf:first openlabel_v2:ArtificialVehicleLighting ;
+	rdf:rest rdf:nil .
+_:c14n936 rdf:first openlabel_v2:ArtificialStreetLighting ;
+	rdf:rest _:c14n937 .
+_:c14n937 rdf:first openlabel_v2:ArtificialVehicleLighting ;
+	rdf:rest rdf:nil .
+_:c14n938 rdf:first openlabel_v2:ArtificialStreetLighting ;
+	rdf:rest _:c14n939 .
+_:c14n939 rdf:first openlabel_v2:ArtificialVehicleLighting ;
+	rdf:rest rdf:nil .
+_:c14n94 sh:datatype xsd:boolean ;
+	sh:description "Smoke and pollution flag. Refer to BSI PAS-1883 Section 5.3.2.d." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 35 ;
+	sh:path openlabel_v2:ParticulatesPollution .
+_:c14n940 rdf:first openlabel_v2:ArtificialStreetLighting ;
+	rdf:rest _:c14n941 .
+_:c14n941 rdf:first openlabel_v2:ArtificialVehicleLighting ;
+	rdf:rest rdf:nil .
+_:c14n942 rdf:first openlabel_v2:LowLightAmbient ;
+	rdf:rest _:c14n943 .
+_:c14n943 rdf:first openlabel_v2:LowLightNight ;
+	rdf:rest rdf:nil .
+_:c14n944 rdf:first openlabel_v2:LowLightAmbient ;
+	rdf:rest _:c14n945 .
+_:c14n945 rdf:first openlabel_v2:LowLightNight ;
+	rdf:rest rdf:nil .
+_:c14n946 rdf:first openlabel_v2:LowLightAmbient ;
+	rdf:rest _:c14n947 .
+_:c14n947 rdf:first openlabel_v2:LowLightNight ;
+	rdf:rest rdf:nil .
+_:c14n948 rdf:first openlabel_v2:LowLightAmbient ;
+	rdf:rest _:c14n949 .
+_:c14n949 rdf:first openlabel_v2:LowLightNight ;
+	rdf:rest rdf:nil .
+_:c14n95 sh:description "Position of the sun. Refer to BSI PAS-1883 Section 5.3.3.a.2." ;
+	sh:in _:c14n670 ;
+	sh:order 4 ;
+	sh:path openlabel_v2:DaySunPosition .
+_:c14n950 rdf:first openlabel_v2:TravelDirectionLeft ;
+	rdf:rest _:c14n951 .
+_:c14n951 rdf:first openlabel_v2:TravelDirectionRight ;
+	rdf:rest rdf:nil .
+_:c14n952 rdf:first openlabel_v2:TravelDirectionLeft ;
+	rdf:rest _:c14n953 .
+_:c14n953 rdf:first openlabel_v2:TravelDirectionRight ;
+	rdf:rest rdf:nil .
+_:c14n954 rdf:first openlabel_v2:TravelDirectionLeft ;
+	rdf:rest _:c14n955 .
+_:c14n955 rdf:first openlabel_v2:TravelDirectionRight ;
+	rdf:rest rdf:nil .
+_:c14n956 rdf:first openlabel_v2:TravelDirectionLeft ;
+	rdf:rest _:c14n957 .
+_:c14n957 rdf:first openlabel_v2:TravelDirectionRight ;
+	rdf:rest rdf:nil .
+_:c14n96 sh:datatype xsd:boolean ;
+	sh:description "Volcanic ash flag. Refer to BSI PAS-1883 Section 5.3.2.e." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 36 ;
+	sh:path openlabel_v2:ParticulatesVolcanic .
+_:c14n97 sh:description "Transverse geometry type. Refer to BSI PAS-1883 Section 5.2.3.3.b." ;
+	sh:in _:c14n924 ;
+	sh:maxCount 1 ;
+	sh:order 11 ;
+	sh:path openlabel_v2:GeometryTransverse .
+_:c14n98 sh:description "Warning sign type. Refer to BSI PAS-1883 Section 5.2.3.5.c." ;
+	sh:in _:c14n399 ;
+	sh:order 46 ;
+	sh:path openlabel_v2:SignsWarning .
+_:c14n99 sh:datatype xsd:decimal ;
+	sh:description "Wind speed (m/s). Refer to BSI PAS-1883 Section 5.3.1.1." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 63 ;
+	sh:path openlabel_v2:weatherWindValue .

--- a/artifacts/openlabel-v2/openlabel-v2.shacl.ttl
+++ b/artifacts/openlabel-v2/openlabel-v2.shacl.ttl
@@ -33,62 +33,62 @@
 sdo:QuantitativeValue a sh:NodeShape ;
 	rdfs:comment "A point value or interval for quantitative measurements. Requires minValue and maxValue." ;
 	sh:closed true ;
-	sh:ignoredProperties _:c14n102 ;
-	sh:property _:c14n113 , _:c14n138 , _:c14n193 , _:c14n91 ;
+	sh:ignoredProperties _:c14n103 ;
+	sh:property _:c14n114 , _:c14n139 , _:c14n194 , _:c14n92 ;
 	sh:targetClass sdo:QuantitativeValue .
 openlabel_v2:AdminTag a sh:NodeShape ;
 	rdfs:comment "The base tag to use when extending the Administration tags with new classes." ;
 	sh:closed true ;
-	sh:ignoredProperties _:c14n204 ;
-	sh:property _:c14n133 , _:c14n151 , _:c14n164 , _:c14n186 , _:c14n219 , _:c14n246 , _:c14n265 , _:c14n297 , _:c14n299 , _:c14n4 , _:c14n52 , _:c14n58 , _:c14n69 ;
+	sh:ignoredProperties _:c14n205 ;
+	sh:property _:c14n134 , _:c14n152 , _:c14n165 , _:c14n187 , _:c14n220 , _:c14n247 , _:c14n266 , _:c14n298 , _:c14n300 , _:c14n38 , _:c14n4 , _:c14n53 , _:c14n59 , _:c14n70 ;
 	sh:targetClass openlabel_v2:AdminTag .
 openlabel_v2:Behaviour a sh:NodeShape ;
 	rdfs:comment "An activity performed by a road user." ;
 	sh:closed true ;
-	sh:ignoredProperties _:c14n39 ;
-	sh:property _:c14n106 , _:c14n110 , _:c14n111 , _:c14n115 , _:c14n117 , _:c14n149 , _:c14n160 , _:c14n167 , _:c14n17 , _:c14n180 , _:c14n19 , _:c14n220 , _:c14n224 , _:c14n228 , _:c14n233 , _:c14n253 , _:c14n269 , _:c14n273 , _:c14n284 , _:c14n309 , _:c14n40 , _:c14n42 , _:c14n54 , _:c14n63 ;
+	sh:ignoredProperties _:c14n40 ;
+	sh:property _:c14n107 , _:c14n111 , _:c14n112 , _:c14n116 , _:c14n118 , _:c14n150 , _:c14n161 , _:c14n168 , _:c14n17 , _:c14n181 , _:c14n19 , _:c14n221 , _:c14n225 , _:c14n229 , _:c14n234 , _:c14n254 , _:c14n270 , _:c14n274 , _:c14n285 , _:c14n310 , _:c14n41 , _:c14n43 , _:c14n55 , _:c14n64 ;
 	sh:targetClass openlabel_v2:Behaviour .
 openlabel_v2:Odd a sh:NodeShape ;
 	rdfs:comment "Operational Design Domain. Refer to BSI PAS-1883 Section 5." ;
 	sh:closed true ;
-	sh:ignoredProperties _:c14n147 ;
-	sh:property _:c14n10 , _:c14n100 , _:c14n105 , _:c14n107 , _:c14n108 , _:c14n112 , _:c14n119 , _:c14n137 , _:c14n139 , _:c14n142 , _:c14n143 , _:c14n145 , _:c14n15 , _:c14n159 , _:c14n177 , _:c14n181 , _:c14n189 , _:c14n20 , _:c14n205 , _:c14n206 , _:c14n211 , _:c14n217 , _:c14n225 , _:c14n229 , _:c14n241 , _:c14n245 , _:c14n25 , _:c14n251 , _:c14n252 , _:c14n257 , _:c14n259 , _:c14n262 , _:c14n266 , _:c14n27 , _:c14n271 , _:c14n272 , _:c14n275 , _:c14n28 , _:c14n281 , _:c14n285 , _:c14n286 , _:c14n290 , _:c14n291 , _:c14n295 , _:c14n296 , _:c14n308 , _:c14n310 , _:c14n314 , _:c14n32 , _:c14n320 , _:c14n41 , _:c14n51 , _:c14n53 , _:c14n55 , _:c14n56 , _:c14n71 , _:c14n74 , _:c14n76 , _:c14n77 , _:c14n88 , _:c14n9 , _:c14n94 , _:c14n97 , _:c14n99 ;
+	sh:ignoredProperties _:c14n148 ;
+	sh:property _:c14n10 , _:c14n100 , _:c14n101 , _:c14n106 , _:c14n108 , _:c14n109 , _:c14n113 , _:c14n120 , _:c14n138 , _:c14n140 , _:c14n143 , _:c14n144 , _:c14n146 , _:c14n15 , _:c14n160 , _:c14n178 , _:c14n182 , _:c14n190 , _:c14n20 , _:c14n206 , _:c14n207 , _:c14n212 , _:c14n218 , _:c14n226 , _:c14n230 , _:c14n242 , _:c14n246 , _:c14n25 , _:c14n252 , _:c14n253 , _:c14n258 , _:c14n260 , _:c14n263 , _:c14n267 , _:c14n27 , _:c14n272 , _:c14n273 , _:c14n276 , _:c14n28 , _:c14n282 , _:c14n286 , _:c14n287 , _:c14n291 , _:c14n292 , _:c14n296 , _:c14n297 , _:c14n309 , _:c14n311 , _:c14n315 , _:c14n32 , _:c14n321 , _:c14n42 , _:c14n52 , _:c14n54 , _:c14n56 , _:c14n57 , _:c14n72 , _:c14n75 , _:c14n77 , _:c14n78 , _:c14n89 , _:c14n9 , _:c14n95 , _:c14n98 ;
 	sh:targetClass openlabel_v2:Odd .
 openlabel_v2:OddDynamicElements a sh:NodeShape ;
 	rdfs:comment "Dynamic elements subset of the Operational Design Domain. Covers traffic agents, flow rates, volume, and subject vehicle speed. Refer to BSI PAS-1883 Section 5.4." ;
 	sh:closed true ;
-	sh:ignoredProperties _:c14n209 ;
-	sh:property _:c14n0 , _:c14n1 , _:c14n104 , _:c14n118 , _:c14n120 , _:c14n122 , _:c14n125 , _:c14n127 , _:c14n130 , _:c14n132 , _:c14n135 , _:c14n14 , _:c14n146 , _:c14n148 , _:c14n152 , _:c14n155 , _:c14n162 , _:c14n163 , _:c14n166 , _:c14n168 , _:c14n169 , _:c14n170 , _:c14n171 , _:c14n172 , _:c14n174 , _:c14n18 , _:c14n185 , _:c14n188 , _:c14n195 , _:c14n196 , _:c14n201 , _:c14n207 , _:c14n21 , _:c14n210 , _:c14n22 , _:c14n23 , _:c14n24 , _:c14n249 , _:c14n277 , _:c14n287 , _:c14n293 , _:c14n30 , _:c14n301 , _:c14n307 , _:c14n312 , _:c14n316 , _:c14n321 , _:c14n37 , _:c14n47 , _:c14n48 , _:c14n50 , _:c14n57 , _:c14n61 , _:c14n64 , _:c14n67 , _:c14n68 , _:c14n7 , _:c14n73 , _:c14n75 , _:c14n8 , _:c14n83 , _:c14n84 , _:c14n89 , _:c14n92 ;
+	sh:ignoredProperties _:c14n210 ;
+	sh:property _:c14n0 , _:c14n1 , _:c14n105 , _:c14n119 , _:c14n121 , _:c14n123 , _:c14n126 , _:c14n128 , _:c14n131 , _:c14n133 , _:c14n136 , _:c14n14 , _:c14n147 , _:c14n149 , _:c14n153 , _:c14n156 , _:c14n163 , _:c14n164 , _:c14n167 , _:c14n169 , _:c14n170 , _:c14n171 , _:c14n172 , _:c14n173 , _:c14n175 , _:c14n18 , _:c14n186 , _:c14n189 , _:c14n196 , _:c14n197 , _:c14n202 , _:c14n208 , _:c14n21 , _:c14n211 , _:c14n22 , _:c14n23 , _:c14n24 , _:c14n250 , _:c14n278 , _:c14n288 , _:c14n294 , _:c14n30 , _:c14n302 , _:c14n308 , _:c14n313 , _:c14n317 , _:c14n322 , _:c14n37 , _:c14n48 , _:c14n49 , _:c14n51 , _:c14n58 , _:c14n62 , _:c14n65 , _:c14n68 , _:c14n69 , _:c14n7 , _:c14n74 , _:c14n76 , _:c14n8 , _:c14n84 , _:c14n85 , _:c14n90 , _:c14n93 ;
 	sh:targetClass openlabel_v2:OddDynamicElements .
 openlabel_v2:OddEnvironment a sh:NodeShape ;
 	rdfs:comment "Environment-related subset of the Operational Design Domain. Covers weather, illumination, connectivity, and particulates. Refer to BSI PAS-1883 Section 5.3." ;
 	sh:closed true ;
-	sh:ignoredProperties _:c14n232 ;
-	sh:property _:c14n101 , _:c14n109 , _:c14n114 , _:c14n12 , _:c14n123 , _:c14n124 , _:c14n13 , _:c14n140 , _:c14n141 , _:c14n150 , _:c14n153 , _:c14n161 , _:c14n173 , _:c14n187 , _:c14n194 , _:c14n199 , _:c14n213 , _:c14n218 , _:c14n221 , _:c14n223 , _:c14n235 , _:c14n243 , _:c14n244 , _:c14n247 , _:c14n248 , _:c14n254 , _:c14n255 , _:c14n260 , _:c14n268 , _:c14n270 , _:c14n274 , _:c14n276 , _:c14n279 , _:c14n288 , _:c14n289 , _:c14n29 , _:c14n292 , _:c14n294 , _:c14n298 , _:c14n302 , _:c14n303 , _:c14n306 , _:c14n313 , _:c14n319 , _:c14n322 , _:c14n34 , _:c14n35 , _:c14n36 , _:c14n43 , _:c14n46 , _:c14n49 , _:c14n59 , _:c14n6 , _:c14n60 , _:c14n65 , _:c14n66 , _:c14n72 , _:c14n78 , _:c14n79 , _:c14n80 , _:c14n82 , _:c14n87 , _:c14n96 , _:c14n98 ;
+	sh:ignoredProperties _:c14n233 ;
+	sh:property _:c14n102 , _:c14n110 , _:c14n115 , _:c14n12 , _:c14n124 , _:c14n125 , _:c14n13 , _:c14n141 , _:c14n142 , _:c14n151 , _:c14n154 , _:c14n162 , _:c14n174 , _:c14n188 , _:c14n195 , _:c14n200 , _:c14n214 , _:c14n219 , _:c14n222 , _:c14n224 , _:c14n236 , _:c14n244 , _:c14n245 , _:c14n248 , _:c14n249 , _:c14n255 , _:c14n256 , _:c14n261 , _:c14n269 , _:c14n271 , _:c14n275 , _:c14n277 , _:c14n280 , _:c14n289 , _:c14n29 , _:c14n290 , _:c14n293 , _:c14n295 , _:c14n299 , _:c14n303 , _:c14n304 , _:c14n307 , _:c14n314 , _:c14n320 , _:c14n323 , _:c14n34 , _:c14n35 , _:c14n36 , _:c14n44 , _:c14n47 , _:c14n50 , _:c14n6 , _:c14n60 , _:c14n61 , _:c14n66 , _:c14n67 , _:c14n73 , _:c14n79 , _:c14n80 , _:c14n81 , _:c14n83 , _:c14n88 , _:c14n97 , _:c14n99 ;
 	sh:targetClass openlabel_v2:OddEnvironment .
 openlabel_v2:OddScenery a sh:NodeShape ;
 	rdfs:comment "Scenery-related subset of the Operational Design Domain. Covers drivable area, geometry, lane specifications, junctions, signs, and structures. Refer to BSI PAS-1883 Section 5.2." ;
 	sh:closed true ;
-	sh:ignoredProperties _:c14n126 ;
-	sh:property _:c14n103 , _:c14n11 , _:c14n116 , _:c14n121 , _:c14n128 , _:c14n129 , _:c14n131 , _:c14n134 , _:c14n144 , _:c14n156 , _:c14n158 , _:c14n16 , _:c14n165 , _:c14n176 , _:c14n178 , _:c14n179 , _:c14n184 , _:c14n190 , _:c14n192 , _:c14n197 , _:c14n198 , _:c14n200 , _:c14n202 , _:c14n203 , _:c14n208 , _:c14n212 , _:c14n214 , _:c14n215 , _:c14n216 , _:c14n226 , _:c14n227 , _:c14n230 , _:c14n234 , _:c14n236 , _:c14n237 , _:c14n238 , _:c14n239 , _:c14n240 , _:c14n242 , _:c14n261 , _:c14n263 , _:c14n264 , _:c14n267 , _:c14n280 , _:c14n282 , _:c14n3 , _:c14n304 , _:c14n305 , _:c14n31 , _:c14n311 , _:c14n315 , _:c14n317 , _:c14n318 , _:c14n323 , _:c14n33 , _:c14n38 , _:c14n44 , _:c14n45 , _:c14n5 , _:c14n81 , _:c14n85 , _:c14n86 , _:c14n93 , _:c14n95 ;
+	sh:ignoredProperties _:c14n127 ;
+	sh:property _:c14n104 , _:c14n11 , _:c14n117 , _:c14n122 , _:c14n129 , _:c14n130 , _:c14n132 , _:c14n135 , _:c14n145 , _:c14n157 , _:c14n159 , _:c14n16 , _:c14n166 , _:c14n177 , _:c14n179 , _:c14n180 , _:c14n185 , _:c14n191 , _:c14n193 , _:c14n198 , _:c14n199 , _:c14n201 , _:c14n203 , _:c14n204 , _:c14n209 , _:c14n213 , _:c14n215 , _:c14n216 , _:c14n217 , _:c14n227 , _:c14n228 , _:c14n231 , _:c14n235 , _:c14n237 , _:c14n238 , _:c14n239 , _:c14n240 , _:c14n241 , _:c14n243 , _:c14n262 , _:c14n264 , _:c14n265 , _:c14n268 , _:c14n281 , _:c14n283 , _:c14n3 , _:c14n305 , _:c14n306 , _:c14n31 , _:c14n312 , _:c14n316 , _:c14n318 , _:c14n319 , _:c14n324 , _:c14n33 , _:c14n39 , _:c14n45 , _:c14n46 , _:c14n5 , _:c14n82 , _:c14n86 , _:c14n87 , _:c14n94 , _:c14n96 ;
 	sh:targetClass openlabel_v2:OddScenery .
 openlabel_v2:RoadUser a sh:NodeShape ;
 	rdfs:comment "Something which uses a road to travel." ;
 	sh:closed true ;
-	sh:ignoredProperties _:c14n278 ;
-	sh:property _:c14n175 , _:c14n222 , _:c14n300 , _:c14n70 ;
+	sh:ignoredProperties _:c14n279 ;
+	sh:property _:c14n176 , _:c14n223 , _:c14n301 , _:c14n71 ;
 	sh:targetClass openlabel_v2:RoadUser .
 openlabel_v2:Scenario a sh:NodeShape ;
 	rdfs:comment "A scenario that can be tagged with OpenLABEL tags." ;
 	sh:closed true ;
-	sh:ignoredProperties _:c14n154 ;
-	sh:property _:c14n191 ;
+	sh:ignoredProperties _:c14n155 ;
+	sh:property _:c14n192 ;
 	sh:targetClass openlabel_v2:Scenario .
 openlabel_v2:Tag a sh:NodeShape ;
 	rdfs:comment "The base tag." ;
 	sh:closed true ;
-	sh:ignoredProperties _:c14n250 ;
-	sh:property _:c14n136 , _:c14n157 , _:c14n183 , _:c14n258 ;
+	sh:ignoredProperties _:c14n251 ;
+	sh:property _:c14n137 , _:c14n158 , _:c14n184 , _:c14n259 ;
 	sh:targetClass openlabel_v2:Tag .
 _:c14n0 sh:datatype xsd:boolean ;
 	sh:description "Up-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.i." ;
@@ -96,123 +96,123 @@ _:c14n0 sh:datatype xsd:boolean ;
 	sh:order 31 ;
 	sh:path openlabel_v2:LongitudinalUpSlope .
 _:c14n1 sh:description "Direction of travel. Refer to BSI PAS-1883 Section 5.2.3.4.e." ;
-	sh:in _:c14n952 ;
+	sh:in _:c14n953 ;
 	sh:order 26 ;
 	sh:path openlabel_v2:LaneSpecificationTravelDirection .
 _:c14n10 sh:description "Temporary road structure. Refer to BSI PAS-1883 Section 5.2.1.f." ;
-	sh:in _:c14n894 ;
+	sh:in _:c14n895 ;
 	sh:maxCount 1 ;
 	sh:order 42 ;
 	sh:path openlabel_v2:SceneryTemporaryStructure .
-_:c14n100 sh:description "Agent type. Refer to BSI PAS-1883 Section 5.4.a.4." ;
-	sh:or _:c14n468 ;
+_:c14n100 sh:datatype xsd:decimal ;
+	sh:description "Wind speed (m/s). Refer to BSI PAS-1883 Section 5.3.1.1." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 63 ;
+	sh:path openlabel_v2:weatherWindValue .
+_:c14n101 sh:description "Agent type. Refer to BSI PAS-1883 Section 5.4.a.4." ;
+	sh:or _:c14n436 ;
 	sh:order 52 ;
 	sh:path openlabel_v2:trafficAgentTypeValue .
-_:c14n101 sh:datatype xsd:boolean ;
+_:c14n102 sh:datatype xsd:boolean ;
 	sh:description "Up-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.i." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 31 ;
 	sh:path openlabel_v2:LongitudinalUpSlope .
-_:c14n102 rdf:first rdf:type ;
+_:c14n103 rdf:first rdf:type ;
 	rdf:rest rdf:nil .
-_:c14n103 sh:description "Agent type. Refer to BSI PAS-1883 Section 5.4.a.4." ;
-	sh:or _:c14n490 ;
-	sh:order 52 ;
-	sh:path openlabel_v2:trafficAgentTypeValue .
 _:c14n104 sh:description "Agent type. Refer to BSI PAS-1883 Section 5.4.a.4." ;
-	sh:or _:c14n435 ;
+	sh:or _:c14n491 ;
 	sh:order 52 ;
 	sh:path openlabel_v2:trafficAgentTypeValue .
-_:c14n105 sh:datatype xsd:boolean ;
+_:c14n105 sh:description "Agent type. Refer to BSI PAS-1883 Section 5.4.a.4." ;
+	sh:or _:c14n458 ;
+	sh:order 52 ;
+	sh:path openlabel_v2:trafficAgentTypeValue .
+_:c14n106 sh:datatype xsd:boolean ;
 	sh:description "Subject vehicle speed flag. Refer to BSI PAS-1883 Section 5.4.b." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 47 ;
 	sh:path openlabel_v2:SubjectVehicleSpeed .
-_:c14n106 sh:datatype xsd:boolean ;
+_:c14n107 sh:datatype xsd:boolean ;
 	sh:description "An activity where the road user is closer to the object by the end." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 18 ;
 	sh:path openlabel_v2:MotionTowards .
-_:c14n107 sh:datatype xsd:decimal ;
+_:c14n108 sh:datatype xsd:decimal ;
 	sh:description "Visibility (km). Refer to BSI PAS-1883 Section 5.3.1.3." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 61 ;
 	sh:path openlabel_v2:weatherSnowValue .
-_:c14n108 sh:datatype xsd:boolean ;
+_:c14n109 sh:datatype xsd:boolean ;
 	sh:description "Level plane flag. Refer to BSI PAS-1883 Section 5.2.3.3.iii." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 30 ;
 	sh:path openlabel_v2:LongitudinalLevelPlane .
-_:c14n109 sh:description "Lane type. Refer to BSI PAS-1883 Section 5.2.3.4.c." ;
-	sh:in _:c14n336 ;
-	sh:order 27 ;
-	sh:path openlabel_v2:LaneSpecificationType .
 _:c14n11 sh:datatype xsd:boolean ;
 	sh:description "Level plane flag. Refer to BSI PAS-1883 Section 5.2.3.3.iii." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 30 ;
 	sh:path openlabel_v2:LongitudinalLevelPlane .
-_:c14n110 sh:datatype xsd:boolean ;
+_:c14n110 sh:description "Lane type. Refer to BSI PAS-1883 Section 5.2.3.4.c." ;
+	sh:in _:c14n325 ;
+	sh:order 27 ;
+	sh:path openlabel_v2:LaneSpecificationType .
+_:c14n111 sh:datatype xsd:boolean ;
 	sh:description "An activity where a pedestrian is slipping/sliding on the road." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 16 ;
 	sh:path openlabel_v2:MotionSlide .
-_:c14n111 sh:datatype xsd:boolean ;
+_:c14n112 sh:datatype xsd:boolean ;
 	sh:description "Subject exits the intersection on a road to the left of the original." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 20 ;
 	sh:path openlabel_v2:MotionTurnLeft .
-_:c14n112 sh:description "Communication connectivity type. Refer to BSI PAS-1883 Section 5.3.4.a." ;
-	sh:in _:c14n506 ;
+_:c14n113 sh:description "Communication connectivity type. Refer to BSI PAS-1883 Section 5.3.4.a." ;
+	sh:in _:c14n507 ;
 	sh:maxCount 1 ;
 	sh:order 0 ;
 	sh:path openlabel_v2:ConnectivityCommunication .
-_:c14n113 sh:datatype xsd:decimal ;
+_:c14n114 sh:datatype xsd:decimal ;
 	sh:description "Upper bound inferred via RDFS from schema:maxValue being a subPropertyOf cmns-q:hasUpperBound in schema.org OWL." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 3 ;
 	sh:path cmns-q:hasUpperBound .
-_:c14n114 sh:datatype xsd:decimal ;
+_:c14n115 sh:datatype xsd:decimal ;
 	sh:description "Rainfall intensity (mm/h). Refer to BSI PAS-1883 Section 5.3.1.2." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 59 ;
 	sh:path openlabel_v2:weatherRainValue .
-_:c14n115 sh:description "Speed (km/h)." ;
+_:c14n116 sh:description "Speed (km/h)." ;
 	sh:maxCount 1 ;
-	sh:or _:c14n560 ;
+	sh:or _:c14n577 ;
 	sh:order 10 ;
 	sh:path openlabel_v2:motionDriveValue .
-_:c14n116 sh:datatype xsd:decimal ;
+_:c14n117 sh:datatype xsd:decimal ;
 	sh:description "Visibility (km). Refer to BSI PAS-1883 Section 5.3.1.3." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 61 ;
 	sh:path openlabel_v2:weatherSnowValue .
-_:c14n117 sh:datatype xsd:boolean ;
+_:c14n118 sh:datatype xsd:boolean ;
 	sh:description "An activity where the trajectory of the road user crosses the trajectory of the object." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 4 ;
 	sh:path openlabel_v2:MotionCross .
-_:c14n118 sh:datatype xsd:boolean ;
+_:c14n119 sh:datatype xsd:boolean ;
 	sh:description "Lane dimensions flag. Refer to BSI PAS-1883 Section 5.2.3.4.a." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 21 ;
 	sh:path openlabel_v2:LaneSpecificationDimensions .
-_:c14n119 sh:datatype xsd:boolean ;
-	sh:description "Straight lines flag. Refer to BSI PAS-1883 Section 5.2.3.3." ;
-	sh:maxCount 1 ;
-	sh:nodeKind sh:Literal ;
-	sh:order 14 ;
-	sh:path openlabel_v2:HorizontalStraights .
 _:c14n12 sh:datatype xsd:boolean ;
 	sh:description "Non-precipitating water droplets or ice crystals (mist/fog) flag. Refer to BSI PAS-1883 Section 5.3.2.b." ;
 	sh:maxCount 1 ;
@@ -220,440 +220,441 @@ _:c14n12 sh:datatype xsd:boolean ;
 	sh:order 37 ;
 	sh:path openlabel_v2:ParticulatesWater .
 _:c14n120 sh:datatype xsd:boolean ;
+	sh:description "Straight lines flag. Refer to BSI PAS-1883 Section 5.2.3.3." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 14 ;
+	sh:path openlabel_v2:HorizontalStraights .
+_:c14n121 sh:datatype xsd:boolean ;
 	sh:description "Elevation of the sun above the horizon flag. Refer to BSI PAS-1883 Section 5.3.3.a.1." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 2 ;
 	sh:path openlabel_v2:DaySunElevation .
-_:c14n121 sh:description "Road surface condition. Refer to BSI PAS-1883 Section 5.2.3.7.c." ;
-	sh:in _:c14n705 ;
+_:c14n122 sh:description "Road surface condition. Refer to BSI PAS-1883 Section 5.2.3.7.c." ;
+	sh:in _:c14n699 ;
 	sh:maxCount 1 ;
 	sh:order 6 ;
 	sh:path openlabel_v2:DrivableAreaSurfaceCondition .
-_:c14n122 sh:datatype xsd:integer ;
+_:c14n123 sh:datatype xsd:integer ;
 	sh:description "Volume (vehicle km). Refer to BSI PAS-1883 Section 5.4.a.2." ;
 	sh:maxCount 1 ;
 	sh:minInclusive 0 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 57 ;
 	sh:path openlabel_v2:trafficVolumeValue .
-_:c14n123 sh:datatype xsd:boolean ;
+_:c14n124 sh:datatype xsd:boolean ;
 	sh:description "Elevation of the sun above the horizon flag. Refer to BSI PAS-1883 Section 5.3.3.a.1." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 2 ;
 	sh:path openlabel_v2:DaySunElevation .
-_:c14n124 sh:description "Positioning system type. Refer to BSI PAS-1883 Section 5.3.4.b." ;
-	sh:in _:c14n821 ;
+_:c14n125 sh:description "Positioning system type. Refer to BSI PAS-1883 Section 5.3.4.b." ;
+	sh:in _:c14n819 ;
 	sh:maxCount 1 ;
 	sh:order 1 ;
 	sh:path openlabel_v2:ConnectivityPositioning .
-_:c14n125 sh:description "Low light condition. Refer to BSI PAS-1883 Section 5.3.3.b." ;
-	sh:in _:c14n946 ;
+_:c14n126 sh:description "Low light condition. Refer to BSI PAS-1883 Section 5.3.3.b." ;
+	sh:in _:c14n947 ;
 	sh:order 18 ;
 	sh:path openlabel_v2:IlluminationLowLight .
-_:c14n126 rdf:first rdf:type ;
+_:c14n127 rdf:first rdf:type ;
 	rdf:rest rdf:nil .
-_:c14n127 sh:description "Position of the sun. Refer to BSI PAS-1883 Section 5.3.3.a.2." ;
-	sh:in _:c14n666 ;
+_:c14n128 sh:description "Position of the sun. Refer to BSI PAS-1883 Section 5.3.3.a.2." ;
+	sh:in _:c14n675 ;
 	sh:order 4 ;
 	sh:path openlabel_v2:DaySunPosition .
-_:c14n128 sh:datatype xsd:decimal ;
+_:c14n129 sh:datatype xsd:decimal ;
 	sh:description "Rainfall intensity (mm/h). Refer to BSI PAS-1883 Section 5.3.1.2." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 59 ;
 	sh:path openlabel_v2:weatherRainValue .
-_:c14n129 sh:description "Information sign type. Refer to BSI PAS-1883 Section 5.2.3.5.a." ;
-	sh:in _:c14n542 ;
+_:c14n13 sh:description "Information sign type. Refer to BSI PAS-1883 Section 5.2.3.5.a." ;
+	sh:in _:c14n535 ;
+	sh:order 44 ;
+	sh:path openlabel_v2:SignsInformation .
+_:c14n130 sh:description "Information sign type. Refer to BSI PAS-1883 Section 5.2.3.5.a." ;
+	sh:in _:c14n547 ;
 	sh:maxCount 1 ;
 	sh:order 44 ;
 	sh:path openlabel_v2:SignsInformation .
-_:c14n13 sh:description "Information sign type. Refer to BSI PAS-1883 Section 5.2.3.5.a." ;
-	sh:in _:c14n534 ;
-	sh:order 44 ;
-	sh:path openlabel_v2:SignsInformation .
-_:c14n130 sh:description "Positioning system type. Refer to BSI PAS-1883 Section 5.3.4.b." ;
-	sh:in _:c14n818 ;
+_:c14n131 sh:description "Positioning system type. Refer to BSI PAS-1883 Section 5.3.4.b." ;
+	sh:in _:c14n813 ;
 	sh:order 1 ;
 	sh:path openlabel_v2:ConnectivityPositioning .
-_:c14n131 sh:datatype xsd:decimal ;
+_:c14n132 sh:datatype xsd:decimal ;
 	sh:description "Meteorological Optical Range (MOR) (m). Refer to BSI PAS-1883 Section 5.3.2.b." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 38 ;
 	sh:path openlabel_v2:particulatesWaterValue .
-_:c14n132 sh:description "Lane type. Refer to BSI PAS-1883 Section 5.2.3.4.c." ;
-	sh:in _:c14n324 ;
+_:c14n133 sh:description "Lane type. Refer to BSI PAS-1883 Section 5.2.3.4.c." ;
+	sh:in _:c14n331 ;
 	sh:order 27 ;
 	sh:path openlabel_v2:LaneSpecificationType .
-_:c14n133 sh:datatype xsd:string ;
+_:c14n134 sh:datatype xsd:string ;
 	sh:description "The name of the scenario." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 8 ;
 	sh:path openlabel_v2:scenarioName .
-_:c14n134 sh:datatype xsd:boolean ;
+_:c14n135 sh:datatype xsd:boolean ;
 	sh:description "Non-precipitating water droplets or ice crystals (mist/fog) flag. Refer to BSI PAS-1883 Section 5.3.2.b." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 37 ;
 	sh:path openlabel_v2:ParticulatesWater .
-_:c14n135 sh:datatype xsd:decimal ;
+_:c14n136 sh:datatype xsd:decimal ;
 	sh:description "Rainfall intensity (mm/h). Refer to BSI PAS-1883 Section 5.3.1.2." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 59 ;
 	sh:path openlabel_v2:weatherRainValue .
-_:c14n136 sh:class openlabel_v2:Behaviour ;
+_:c14n137 sh:class openlabel_v2:Behaviour ;
 	sh:description "Behaviour tag." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:BlankNodeOrIRI ;
 	sh:order 1 ;
 	sh:path openlabel_v2:Behaviour .
-_:c14n137 sh:datatype xsd:boolean ;
+_:c14n138 sh:datatype xsd:boolean ;
 	sh:description "Elevation of the sun above the horizon flag. Refer to BSI PAS-1883 Section 5.3.3.a.1." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 2 ;
 	sh:path openlabel_v2:DaySunElevation .
-_:c14n138 sh:datatype xsd:decimal ;
+_:c14n139 sh:datatype xsd:decimal ;
 	sh:description "Maximum value of the range." ;
 	sh:maxCount 1 ;
 	sh:minCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 1 ;
 	sh:path sdo:maxValue .
-_:c14n139 sh:datatype xsd:boolean ;
+_:c14n14 sh:description "Special road structure. Refer to BSI PAS-1883 Section 5.2.1.d." ;
+	sh:in _:c14n723 ;
+	sh:order 41 ;
+	sh:path openlabel_v2:ScenerySpecialStructure .
+_:c14n140 sh:datatype xsd:boolean ;
 	sh:description "Traffic flow rate flag. Refer to BSI PAS-1883 Section 5.4.a.3." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 53 ;
 	sh:path openlabel_v2:TrafficFlowRate .
-_:c14n14 sh:description "Special road structure. Refer to BSI PAS-1883 Section 5.2.1.d." ;
-	sh:in _:c14n716 ;
+_:c14n141 sh:description "Special road structure. Refer to BSI PAS-1883 Section 5.2.1.d." ;
+	sh:in _:c14n711 ;
 	sh:order 41 ;
 	sh:path openlabel_v2:ScenerySpecialStructure .
-_:c14n140 sh:description "Special road structure. Refer to BSI PAS-1883 Section 5.2.1.d." ;
-	sh:in _:c14n722 ;
-	sh:order 41 ;
-	sh:path openlabel_v2:ScenerySpecialStructure .
-_:c14n141 sh:datatype xsd:boolean ;
+_:c14n142 sh:datatype xsd:boolean ;
 	sh:description "Curves flag. Refer to BSI PAS-1883 Section 5.2.3.3." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 12 ;
 	sh:path openlabel_v2:HorizontalCurves .
-_:c14n142 sh:description "Fixed road structure. Refer to BSI PAS-1883 Section 5.2.1.e." ;
-	sh:in _:c14n907 ;
+_:c14n143 sh:description "Fixed road structure. Refer to BSI PAS-1883 Section 5.2.1.e." ;
+	sh:in _:c14n904 ;
 	sh:maxCount 1 ;
 	sh:order 40 ;
 	sh:path openlabel_v2:SceneryFixedStructure .
-_:c14n143 sh:description "Special road structure. Refer to BSI PAS-1883 Section 5.2.1.d." ;
-	sh:in _:c14n728 ;
+_:c14n144 sh:description "Special road structure. Refer to BSI PAS-1883 Section 5.2.1.d." ;
+	sh:in _:c14n717 ;
 	sh:maxCount 1 ;
 	sh:order 41 ;
 	sh:path openlabel_v2:ScenerySpecialStructure .
-_:c14n144 sh:datatype xsd:decimal ;
+_:c14n145 sh:datatype xsd:decimal ;
 	sh:description "Cloud cover (okta). Refer to BSI PAS-1883 Section 5.3.3.c." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 17 ;
 	sh:path openlabel_v2:illuminationCloudinessValue .
-_:c14n145 sh:description "Direction of travel. Refer to BSI PAS-1883 Section 5.2.3.4.e." ;
-	sh:in _:c14n954 ;
+_:c14n146 sh:description "Direction of travel. Refer to BSI PAS-1883 Section 5.2.3.4.e." ;
+	sh:in _:c14n957 ;
 	sh:maxCount 1 ;
 	sh:order 26 ;
 	sh:path openlabel_v2:LaneSpecificationTravelDirection .
-_:c14n146 sh:datatype xsd:boolean ;
+_:c14n147 sh:datatype xsd:boolean ;
 	sh:description "Straight lines flag. Refer to BSI PAS-1883 Section 5.2.3.3." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 14 ;
 	sh:path openlabel_v2:HorizontalStraights .
-_:c14n147 rdf:first rdf:type ;
+_:c14n148 rdf:first rdf:type ;
 	rdf:rest rdf:nil .
-_:c14n148 sh:datatype xsd:boolean ;
+_:c14n149 sh:datatype xsd:boolean ;
 	sh:description "Volcanic ash flag. Refer to BSI PAS-1883 Section 5.3.2.e." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 36 ;
 	sh:path openlabel_v2:ParticulatesVolcanic .
-_:c14n149 sh:datatype xsd:boolean ;
+_:c14n15 sh:description "Number of lanes (unit). Refer to BSI PAS-1883 Section 5.2.3.4.d." ;
+	sh:maxCount 1 ;
+	sh:or _:c14n859 ;
+	sh:order 24 ;
+	sh:path openlabel_v2:laneSpecificationLaneCountValue .
+_:c14n150 sh:datatype xsd:boolean ;
 	sh:description "An activity where the subject vehicle is in a lane right of the original." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 12 ;
 	sh:path openlabel_v2:MotionLaneChangeRight .
-_:c14n15 sh:description "Number of lanes (unit). Refer to BSI PAS-1883 Section 5.2.3.4.d." ;
-	sh:maxCount 1 ;
-	sh:or _:c14n858 ;
-	sh:order 24 ;
-	sh:path openlabel_v2:laneSpecificationLaneCountValue .
-_:c14n150 sh:datatype xsd:boolean ;
+_:c14n151 sh:datatype xsd:boolean ;
 	sh:description "Number of lanes flag. Refer to BSI PAS-1883 Section 5.2.3.4.d." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 23 ;
 	sh:path openlabel_v2:LaneSpecificationLaneCount .
-_:c14n151 sh:datatype xsd:string ;
+_:c14n152 sh:datatype xsd:string ;
 	sh:description "The version number of the scenario." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 11 ;
 	sh:path openlabel_v2:scenarioVersion .
-_:c14n152 sh:description "Particulate type. Refer to BSI PAS-1883 Section 5.3.2." ;
-	sh:in _:c14n364 ;
+_:c14n153 sh:description "Particulate type. Refer to BSI PAS-1883 Section 5.3.2." ;
+	sh:in _:c14n365 ;
 	sh:order 10 ;
 	sh:path openlabel_v2:EnvironmentParticulates .
-_:c14n153 sh:datatype xsd:boolean ;
+_:c14n154 sh:datatype xsd:boolean ;
 	sh:description "Level plane flag. Refer to BSI PAS-1883 Section 5.2.3.3.iii." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 30 ;
 	sh:path openlabel_v2:LongitudinalLevelPlane .
-_:c14n154 rdf:first rdf:type ;
+_:c14n155 rdf:first rdf:type ;
 	rdf:rest rdf:nil .
-_:c14n155 sh:datatype xsd:boolean ;
+_:c14n156 sh:datatype xsd:boolean ;
 	sh:description "Cloudiness flag. Refer to BSI PAS-1883 Section 5.3.3.c." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 16 ;
 	sh:path openlabel_v2:IlluminationCloudiness .
-_:c14n156 sh:datatype xsd:boolean ;
+_:c14n157 sh:datatype xsd:boolean ;
 	sh:description "Straight lines flag. Refer to BSI PAS-1883 Section 5.2.3.3." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 14 ;
 	sh:path openlabel_v2:HorizontalStraights .
-_:c14n157 sh:class openlabel_v2:RoadUser ;
+_:c14n158 sh:class openlabel_v2:RoadUser ;
 	sh:description "Road user tag." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:BlankNodeOrIRI ;
 	sh:order 3 ;
 	sh:path openlabel_v2:RoadUser .
-_:c14n158 sh:description "Fixed road structure. Refer to BSI PAS-1883 Section 5.2.1.e." ;
-	sh:in _:c14n911 ;
+_:c14n159 sh:description "Fixed road structure. Refer to BSI PAS-1883 Section 5.2.1.e." ;
+	sh:in _:c14n912 ;
 	sh:maxCount 1 ;
 	sh:order 40 ;
 	sh:path openlabel_v2:SceneryFixedStructure .
-_:c14n159 sh:datatype xsd:boolean ;
+_:c14n16 sh:description "Road surface feature. Refer to BSI PAS-1883 Section 5.2.3.7.b." ;
+	sh:in _:c14n593 ;
+	sh:maxCount 1 ;
+	sh:order 7 ;
+	sh:path openlabel_v2:DrivableAreaSurfaceFeature .
+_:c14n160 sh:datatype xsd:boolean ;
 	sh:description "Sand and dust flag. Refer to BSI PAS-1883 Section 5.3.2.c." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 33 ;
 	sh:path openlabel_v2:ParticulatesDust .
-_:c14n16 sh:description "Road surface feature. Refer to BSI PAS-1883 Section 5.2.3.7.b." ;
-	sh:in _:c14n592 ;
-	sh:maxCount 1 ;
-	sh:order 7 ;
-	sh:path openlabel_v2:DrivableAreaSurfaceFeature .
-_:c14n160 sh:datatype xsd:boolean ;
+_:c14n161 sh:datatype xsd:boolean ;
 	sh:description "An activity where the road user increases their velocity." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 1 ;
 	sh:path openlabel_v2:MotionAccelerate .
-_:c14n161 sh:description "Roundabout type. Refer to BSI PAS-1883 Section 5.2.4." ;
-	sh:in _:c14n638 ;
+_:c14n162 sh:description "Roundabout type. Refer to BSI PAS-1883 Section 5.2.4." ;
+	sh:in _:c14n629 ;
 	sh:order 20 ;
 	sh:path openlabel_v2:JunctionRoundabout .
-_:c14n162 sh:datatype xsd:boolean ;
+_:c14n163 sh:datatype xsd:boolean ;
 	sh:description "Wind flag. Refer to BSI PAS-1883 Section 5.3.1.1." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 62 ;
 	sh:path openlabel_v2:WeatherWind .
-_:c14n163 sh:description "Road type. Refer to BSI PAS-1883 Section 5.2.3.2." ;
-	sh:in _:c14n751 ;
+_:c14n164 sh:description "Road type. Refer to BSI PAS-1883 Section 5.2.3.2." ;
+	sh:in _:c14n770 ;
 	sh:order 9 ;
 	sh:path openlabel_v2:DrivableAreaType .
-_:c14n164 sh:datatype xsd:string ;
+_:c14n165 sh:datatype xsd:string ;
 	sh:description "The name of the legal entity who owns the rights to the scenario." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 2 ;
 	sh:path openlabel_v2:ownerName .
-_:c14n165 sh:datatype xsd:boolean ;
+_:c14n166 sh:datatype xsd:boolean ;
 	sh:description "Lane marking flag. Refer to BSI PAS-1883 Section 5.2.3.4.b." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 25 ;
 	sh:path openlabel_v2:LaneSpecificationMarking .
-_:c14n166 sh:datatype xsd:boolean ;
+_:c14n167 sh:datatype xsd:boolean ;
 	sh:description "Sand and dust flag. Refer to BSI PAS-1883 Section 5.3.2.c." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 33 ;
 	sh:path openlabel_v2:ParticulatesDust .
-_:c14n167 sh:datatype xsd:boolean ;
+_:c14n168 sh:datatype xsd:boolean ;
 	sh:description "Subject performs a turn resulting in heading in the opposite direction." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 22 ;
 	sh:path openlabel_v2:MotionUTurn .
-_:c14n168 sh:description "Information sign type. Refer to BSI PAS-1883 Section 5.2.3.5.a." ;
-	sh:in _:c14n546 ;
+_:c14n169 sh:description "Information sign type. Refer to BSI PAS-1883 Section 5.2.3.5.a." ;
+	sh:in _:c14n539 ;
 	sh:order 44 ;
 	sh:path openlabel_v2:SignsInformation .
-_:c14n169 sh:datatype xsd:decimal ;
-	sh:description "Wind speed (m/s). Refer to BSI PAS-1883 Section 5.3.1.1." ;
-	sh:nodeKind sh:Literal ;
-	sh:order 63 ;
-	sh:path openlabel_v2:weatherWindValue .
 _:c14n17 sh:datatype xsd:boolean ;
 	sh:description "Locomotion mode where at least one foot is always on the ground." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 23 ;
 	sh:path openlabel_v2:MotionWalk .
-_:c14n170 sh:datatype xsd:boolean ;
+_:c14n170 sh:datatype xsd:decimal ;
+	sh:description "Wind speed (m/s). Refer to BSI PAS-1883 Section 5.3.1.1." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 63 ;
+	sh:path openlabel_v2:weatherWindValue .
+_:c14n171 sh:datatype xsd:boolean ;
 	sh:description "Subject vehicle speed flag. Refer to BSI PAS-1883 Section 5.4.b." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 47 ;
 	sh:path openlabel_v2:SubjectVehicleSpeed .
-_:c14n171 sh:description "Communication connectivity type. Refer to BSI PAS-1883 Section 5.3.4.a." ;
-	sh:in _:c14n522 ;
+_:c14n172 sh:description "Communication connectivity type. Refer to BSI PAS-1883 Section 5.3.4.a." ;
+	sh:in _:c14n515 ;
 	sh:order 0 ;
 	sh:path openlabel_v2:ConnectivityCommunication .
-_:c14n172 sh:datatype xsd:boolean ;
+_:c14n173 sh:datatype xsd:boolean ;
 	sh:description "Rainfall flag. Refer to BSI PAS-1883 Section 5.3.1.2." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 58 ;
 	sh:path openlabel_v2:WeatherRain .
-_:c14n173 sh:datatype xsd:boolean ;
+_:c14n174 sh:datatype xsd:boolean ;
 	sh:description "Wind flag. Refer to BSI PAS-1883 Section 5.3.1.1." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 62 ;
 	sh:path openlabel_v2:WeatherWind .
-_:c14n174 sh:description "Transverse geometry type. Refer to BSI PAS-1883 Section 5.2.3.3.b." ;
-	sh:in _:c14n919 ;
+_:c14n175 sh:description "Transverse geometry type. Refer to BSI PAS-1883 Section 5.2.3.3.b." ;
+	sh:in _:c14n915 ;
 	sh:order 11 ;
 	sh:path openlabel_v2:GeometryTransverse .
-_:c14n175 sh:description "Vehicle type." ;
-	sh:in _:c14n454 ;
+_:c14n176 sh:description "Vehicle type." ;
+	sh:in _:c14n477 ;
 	sh:maxCount 1 ;
 	sh:order 2 ;
 	sh:path openlabel_v2:RoadUserVehicle .
-_:c14n176 sh:description "Lane type. Refer to BSI PAS-1883 Section 5.2.3.4.c." ;
-	sh:in _:c14n342 ;
+_:c14n177 sh:description "Lane type. Refer to BSI PAS-1883 Section 5.2.3.4.c." ;
+	sh:in _:c14n337 ;
 	sh:order 27 ;
 	sh:path openlabel_v2:LaneSpecificationType .
-_:c14n177 sh:description "Position of the sun. Refer to BSI PAS-1883 Section 5.3.3.a.2." ;
-	sh:in _:c14n678 ;
+_:c14n178 sh:description "Position of the sun. Refer to BSI PAS-1883 Section 5.3.3.a.2." ;
+	sh:in _:c14n671 ;
 	sh:maxCount 1 ;
 	sh:order 4 ;
 	sh:path openlabel_v2:DaySunPosition .
-_:c14n178 sh:description "Low light condition. Refer to BSI PAS-1883 Section 5.3.3.b." ;
-	sh:in _:c14n948 ;
+_:c14n179 sh:description "Low light condition. Refer to BSI PAS-1883 Section 5.3.3.b." ;
+	sh:in _:c14n949 ;
 	sh:order 18 ;
 	sh:path openlabel_v2:IlluminationLowLight .
-_:c14n179 sh:description "Positioning system type. Refer to BSI PAS-1883 Section 5.3.4.b." ;
-	sh:in _:c14n812 ;
-	sh:order 1 ;
-	sh:path openlabel_v2:ConnectivityPositioning .
 _:c14n18 sh:datatype xsd:boolean ;
 	sh:description "Lane marking flag. Refer to BSI PAS-1883 Section 5.2.3.4.b." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 25 ;
 	sh:path openlabel_v2:LaneSpecificationMarking .
-_:c14n180 sh:datatype xsd:boolean ;
+_:c14n180 sh:description "Positioning system type. Refer to BSI PAS-1883 Section 5.3.4.b." ;
+	sh:in _:c14n822 ;
+	sh:order 1 ;
+	sh:path openlabel_v2:ConnectivityPositioning .
+_:c14n181 sh:datatype xsd:boolean ;
 	sh:description "An activity where the road user is further away from the object by the end." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 3 ;
 	sh:path openlabel_v2:MotionAway .
-_:c14n181 sh:datatype xsd:boolean ;
+_:c14n182 sh:datatype xsd:boolean ;
 	sh:description "Presence of special vehicles flag. Refer to BSI PAS-1883 Section 5.4.a.5." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 55 ;
 	sh:path openlabel_v2:TrafficSpecialVehicle .
-_:c14n182 rdf:first openlabel_v2:CommunicationWave ;
+_:c14n183 rdf:first openlabel_v2:CommunicationWave ;
 	rdf:rest rdf:nil .
-_:c14n183 sh:class openlabel_v2:AdminTag ;
+_:c14n184 sh:class openlabel_v2:AdminTag ;
 	sh:description "Administration tag." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:BlankNodeOrIRI ;
 	sh:order 0 ;
 	sh:path openlabel_v2:AdminTag .
-_:c14n184 sh:description "Roundabout type. Refer to BSI PAS-1883 Section 5.2.4." ;
-	sh:in _:c14n628 ;
+_:c14n185 sh:description "Roundabout type. Refer to BSI PAS-1883 Section 5.2.4." ;
+	sh:in _:c14n639 ;
 	sh:maxCount 1 ;
 	sh:order 20 ;
 	sh:path openlabel_v2:JunctionRoundabout .
-_:c14n185 sh:datatype xsd:decimal ;
+_:c14n186 sh:datatype xsd:decimal ;
 	sh:description "Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.ii." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 29 ;
 	sh:path openlabel_v2:longitudinalDownSlopeValue .
-_:c14n186 sh:datatype xsd:string ;
+_:c14n187 sh:datatype xsd:string ;
 	sh:description "A description of the scenario." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 7 ;
 	sh:path openlabel_v2:scenarioDescription .
-_:c14n187 sh:description "Intersection type. Refer to BSI PAS-1883 Section 5.2.4." ;
-	sh:in _:c14n778 ;
+_:c14n188 sh:description "Intersection type. Refer to BSI PAS-1883 Section 5.2.4." ;
+	sh:in _:c14n789 ;
 	sh:order 19 ;
 	sh:path openlabel_v2:JunctionIntersection .
-_:c14n188 sh:description "Number of lanes (unit). Refer to BSI PAS-1883 Section 5.2.3.4.d." ;
-	sh:or _:c14n878 ;
+_:c14n189 sh:description "Number of lanes (unit). Refer to BSI PAS-1883 Section 5.2.3.4.d." ;
+	sh:or _:c14n879 ;
 	sh:order 24 ;
 	sh:path openlabel_v2:laneSpecificationLaneCountValue .
-_:c14n189 sh:datatype xsd:boolean ;
-	sh:description "Traffic volume flag. Refer to BSI PAS-1883 Section 5.4.a.2." ;
-	sh:maxCount 1 ;
-	sh:nodeKind sh:Literal ;
-	sh:order 56 ;
-	sh:path openlabel_v2:TrafficVolume .
 _:c14n19 sh:datatype xsd:boolean ;
 	sh:description "An activity where the object vehicle suddenly moves out of the lane." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 6 ;
 	sh:path openlabel_v2:MotionCutOut .
-_:c14n190 sh:description "Speed (km/h). Refer to BSI PAS-1883 Section 5.4.b." ;
-	sh:or _:c14n854 ;
+_:c14n190 sh:datatype xsd:boolean ;
+	sh:description "Traffic volume flag. Refer to BSI PAS-1883 Section 5.4.a.2." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 56 ;
+	sh:path openlabel_v2:TrafficVolume .
+_:c14n191 sh:description "Speed (km/h). Refer to BSI PAS-1883 Section 5.4.b." ;
+	sh:or _:c14n867 ;
 	sh:order 48 ;
 	sh:path openlabel_v2:subjectVehicleSpeedValue .
-_:c14n191 sh:class openlabel_v2:Tag ;
+_:c14n192 sh:class openlabel_v2:Tag ;
 	sh:description "A tag associated with a scenario." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:BlankNodeOrIRI ;
 	sh:order 0 ;
 	sh:path openlabel_v2:hasTag .
-_:c14n192 sh:description "Communication connectivity type. Refer to BSI PAS-1883 Section 5.3.4.a." ;
-	sh:in _:c14n514 ;
+_:c14n193 sh:description "Communication connectivity type. Refer to BSI PAS-1883 Section 5.3.4.a." ;
+	sh:in _:c14n523 ;
 	sh:order 0 ;
 	sh:path openlabel_v2:ConnectivityCommunication .
-_:c14n193 sh:datatype xsd:decimal ;
+_:c14n194 sh:datatype xsd:decimal ;
 	sh:description "Minimum value of the range." ;
 	sh:maxCount 1 ;
 	sh:minCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 0 ;
 	sh:path sdo:minValue .
-_:c14n194 sh:datatype xsd:decimal ;
+_:c14n195 sh:datatype xsd:decimal ;
 	sh:description "Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.ii." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 29 ;
 	sh:path openlabel_v2:longitudinalDownSlopeValue .
-_:c14n195 sh:datatype xsd:decimal ;
+_:c14n196 sh:datatype xsd:decimal ;
 	sh:description "Visibility (km). Refer to BSI PAS-1883 Section 5.3.1.3." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 61 ;
 	sh:path openlabel_v2:weatherSnowValue .
-_:c14n196 sh:description "Artificial illumination type. Refer to BSI PAS-1883 Section 5.3.3.d." ;
-	sh:in _:c14n936 ;
+_:c14n197 sh:description "Artificial illumination type. Refer to BSI PAS-1883 Section 5.3.3.d." ;
+	sh:in _:c14n937 ;
 	sh:order 15 ;
 	sh:path openlabel_v2:IlluminationArtificial .
-_:c14n197 sh:datatype xsd:boolean ;
+_:c14n198 sh:datatype xsd:boolean ;
 	sh:description "Elevation of the sun above the horizon flag. Refer to BSI PAS-1883 Section 5.3.3.a.1." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 2 ;
 	sh:path openlabel_v2:DaySunElevation .
-_:c14n198 sh:datatype xsd:boolean ;
+_:c14n199 sh:datatype xsd:boolean ;
 	sh:description "Up-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.i." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 31 ;
 	sh:path openlabel_v2:LongitudinalUpSlope .
-_:c14n199 sh:datatype xsd:boolean ;
-	sh:description "Subject vehicle speed flag. Refer to BSI PAS-1883 Section 5.4.b." ;
-	sh:nodeKind sh:Literal ;
-	sh:order 47 ;
-	sh:path openlabel_v2:SubjectVehicleSpeed .
 _:c14n2 rdf:first openlabel_v2:CommunicationSignalSlowing ;
-	rdf:rest _:c14n182 .
+	rdf:rest _:c14n183 .
 _:c14n20 sh:datatype xsd:boolean ;
 	sh:description "Lane marking flag. Refer to BSI PAS-1883 Section 5.2.3.4.b." ;
 	sh:maxCount 1 ;
@@ -661,552 +662,551 @@ _:c14n20 sh:datatype xsd:boolean ;
 	sh:order 25 ;
 	sh:path openlabel_v2:LaneSpecificationMarking .
 _:c14n200 sh:datatype xsd:boolean ;
+	sh:description "Subject vehicle speed flag. Refer to BSI PAS-1883 Section 5.4.b." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 47 ;
+	sh:path openlabel_v2:SubjectVehicleSpeed .
+_:c14n201 sh:datatype xsd:boolean ;
 	sh:description "Curves flag. Refer to BSI PAS-1883 Section 5.2.3.3." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 12 ;
 	sh:path openlabel_v2:HorizontalCurves .
-_:c14n201 sh:description "Road surface type. Refer to BSI PAS-1883 Section 5.2.3.7.a." ;
-	sh:in _:c14n359 ;
+_:c14n202 sh:description "Road surface type. Refer to BSI PAS-1883 Section 5.2.3.7.a." ;
+	sh:in _:c14n357 ;
 	sh:order 8 ;
 	sh:path openlabel_v2:DrivableAreaSurfaceType .
-_:c14n202 sh:description "Warning sign type. Refer to BSI PAS-1883 Section 5.2.3.5.c." ;
-	sh:in _:c14n389 ;
+_:c14n203 sh:description "Warning sign type. Refer to BSI PAS-1883 Section 5.2.3.5.c." ;
+	sh:in _:c14n385 ;
 	sh:maxCount 1 ;
 	sh:order 46 ;
 	sh:path openlabel_v2:SignsWarning .
-_:c14n203 sh:description "Particulate type. Refer to BSI PAS-1883 Section 5.3.2." ;
-	sh:in _:c14n379 ;
+_:c14n204 sh:description "Particulate type. Refer to BSI PAS-1883 Section 5.3.2." ;
+	sh:in _:c14n380 ;
 	sh:order 10 ;
 	sh:path openlabel_v2:EnvironmentParticulates .
-_:c14n204 rdf:first rdf:type ;
+_:c14n205 rdf:first rdf:type ;
 	rdf:rest rdf:nil .
-_:c14n205 sh:description "Positioning system type. Refer to BSI PAS-1883 Section 5.3.4.b." ;
-	sh:in _:c14n815 ;
+_:c14n206 sh:description "Positioning system type. Refer to BSI PAS-1883 Section 5.3.4.b." ;
+	sh:in _:c14n816 ;
 	sh:maxCount 1 ;
 	sh:order 1 ;
 	sh:path openlabel_v2:ConnectivityPositioning .
-_:c14n206 sh:datatype xsd:boolean ;
+_:c14n207 sh:datatype xsd:boolean ;
 	sh:description "Traffic agent type classification flag. Refer to BSI PAS-1883 Section 5.4.a.4." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 51 ;
 	sh:path openlabel_v2:TrafficAgentType .
-_:c14n207 sh:description "Road surface feature. Refer to BSI PAS-1883 Section 5.2.3.7.b." ;
-	sh:in _:c14n580 ;
+_:c14n208 sh:description "Road surface feature. Refer to BSI PAS-1883 Section 5.2.3.7.b." ;
+	sh:in _:c14n585 ;
 	sh:order 7 ;
 	sh:path openlabel_v2:DrivableAreaSurfaceFeature .
-_:c14n208 sh:datatype xsd:decimal ;
+_:c14n209 sh:datatype xsd:decimal ;
 	sh:description "Sun elevation (degrees). Refer to BSI PAS-1883 Section 5.3.3.a.1." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 3 ;
 	sh:path openlabel_v2:daySunElevationValue .
-_:c14n209 rdf:first rdf:type ;
-	rdf:rest rdf:nil .
 _:c14n21 sh:datatype xsd:boolean ;
 	sh:description "Traffic volume flag. Refer to BSI PAS-1883 Section 5.4.a.2." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 56 ;
 	sh:path openlabel_v2:TrafficVolume .
-_:c14n210 sh:datatype xsd:decimal ;
+_:c14n210 rdf:first rdf:type ;
+	rdf:rest rdf:nil .
+_:c14n211 sh:datatype xsd:decimal ;
 	sh:description "Meteorological Optical Range (MOR) (m). Refer to BSI PAS-1883 Section 5.3.2.b." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 38 ;
 	sh:path openlabel_v2:particulatesWaterValue .
-_:c14n211 sh:datatype xsd:integer ;
+_:c14n212 sh:datatype xsd:integer ;
 	sh:description "Rate (vehicles/h). Refer to BSI PAS-1883 Section 5.4.a.3." ;
 	sh:maxCount 1 ;
 	sh:minInclusive 0 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 54 ;
 	sh:path openlabel_v2:trafficFlowRateValue .
-_:c14n212 sh:description "Artificial illumination type. Refer to BSI PAS-1883 Section 5.3.3.d." ;
-	sh:in _:c14n940 ;
+_:c14n213 sh:description "Artificial illumination type. Refer to BSI PAS-1883 Section 5.3.3.d." ;
+	sh:in _:c14n935 ;
 	sh:order 15 ;
 	sh:path openlabel_v2:IlluminationArtificial .
-_:c14n213 sh:datatype xsd:boolean ;
+_:c14n214 sh:datatype xsd:boolean ;
 	sh:description "Traffic flow rate flag. Refer to BSI PAS-1883 Section 5.4.a.3." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 53 ;
 	sh:path openlabel_v2:TrafficFlowRate .
-_:c14n214 sh:datatype xsd:boolean ;
+_:c14n215 sh:datatype xsd:boolean ;
 	sh:description "Number of lanes flag. Refer to BSI PAS-1883 Section 5.2.3.4.d." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 23 ;
 	sh:path openlabel_v2:LaneSpecificationLaneCount .
-_:c14n215 sh:description "Number of lanes (unit). Refer to BSI PAS-1883 Section 5.2.3.4.d." ;
+_:c14n216 sh:description "Number of lanes (unit). Refer to BSI PAS-1883 Section 5.2.3.4.d." ;
 	sh:maxCount 1 ;
-	sh:or _:c14n874 ;
+	sh:or _:c14n851 ;
 	sh:order 24 ;
 	sh:path openlabel_v2:laneSpecificationLaneCountValue .
-_:c14n216 sh:description "Special road structure. Refer to BSI PAS-1883 Section 5.2.1.d." ;
-	sh:in _:c14n710 ;
+_:c14n217 sh:description "Special road structure. Refer to BSI PAS-1883 Section 5.2.1.d." ;
+	sh:in _:c14n729 ;
 	sh:maxCount 1 ;
 	sh:order 41 ;
 	sh:path openlabel_v2:ScenerySpecialStructure .
-_:c14n217 sh:datatype xsd:boolean ;
+_:c14n218 sh:datatype xsd:boolean ;
 	sh:description "Curves flag. Refer to BSI PAS-1883 Section 5.2.3.3." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 12 ;
 	sh:path openlabel_v2:HorizontalCurves .
-_:c14n218 sh:datatype xsd:decimal ;
+_:c14n219 sh:datatype xsd:decimal ;
 	sh:description "Cloud cover (okta). Refer to BSI PAS-1883 Section 5.3.3.c." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 17 ;
 	sh:path openlabel_v2:illuminationCloudinessValue .
-_:c14n219 sh:datatype xsd:string ;
-	sh:description "The email address of the legal entity who owns the rights to the scenario." ;
-	sh:maxCount 1 ;
-	sh:nodeKind sh:Literal ;
-	sh:order 1 ;
-	sh:path openlabel_v2:ownerEmail .
 _:c14n22 sh:datatype xsd:boolean ;
 	sh:description "Marine (coastal areas only) flag. Refer to BSI PAS-1883 Section 5.3.2.a." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 34 ;
 	sh:path openlabel_v2:ParticulatesMarine .
-_:c14n220 sh:datatype xsd:boolean ;
+_:c14n220 sh:datatype xsd:string ;
+	sh:description "The email address of the legal entity who owns the rights to the scenario." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 1 ;
+	sh:path openlabel_v2:ownerEmail .
+_:c14n221 sh:datatype xsd:boolean ;
 	sh:description "An activity where the subject vehicle is in a lane left of the original." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 11 ;
 	sh:path openlabel_v2:MotionLaneChangeLeft .
-_:c14n221 sh:datatype xsd:boolean ;
+_:c14n222 sh:datatype xsd:boolean ;
 	sh:description "Traffic volume flag. Refer to BSI PAS-1883 Section 5.4.a.2." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 56 ;
 	sh:path openlabel_v2:TrafficVolume .
-_:c14n222 sh:datatype xsd:boolean ;
+_:c14n223 sh:datatype xsd:boolean ;
 	sh:description "Animal road user flag." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 0 ;
 	sh:path openlabel_v2:RoadUserAnimal .
-_:c14n223 sh:datatype xsd:decimal ;
+_:c14n224 sh:datatype xsd:decimal ;
 	sh:description "Curve radius (m). Refer to BSI PAS-1883 Section 5.2.3.3." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 13 ;
 	sh:path openlabel_v2:horizontalCurvesValue .
-_:c14n224 sh:datatype xsd:boolean ;
+_:c14n225 sh:datatype xsd:boolean ;
 	sh:description "An activity where the subject vehicle ends up directly in front of the object vehicle." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 5 ;
 	sh:path openlabel_v2:MotionCutIn .
-_:c14n225 sh:description "Zone type. Refer to BSI PAS-1883 Section 5.2.1.a." ;
-	sh:in _:c14n798 ;
+_:c14n226 sh:description "Zone type. Refer to BSI PAS-1883 Section 5.2.1.a." ;
+	sh:in _:c14n799 ;
 	sh:maxCount 1 ;
 	sh:order 43 ;
 	sh:path openlabel_v2:SceneryZone .
-_:c14n226 sh:description "Rainfall type. Refer to BSI PAS-1883 Section 5.3.1.2." ;
-	sh:in _:c14n849 ;
+_:c14n227 sh:description "Rainfall type. Refer to BSI PAS-1883 Section 5.3.1.2." ;
+	sh:in _:c14n850 ;
 	sh:order 39 ;
 	sh:path openlabel_v2:RainType .
-_:c14n227 sh:datatype xsd:boolean ;
+_:c14n228 sh:datatype xsd:boolean ;
 	sh:description "Subject vehicle speed flag. Refer to BSI PAS-1883 Section 5.4.b." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 47 ;
 	sh:path openlabel_v2:SubjectVehicleSpeed .
-_:c14n228 sh:datatype xsd:boolean ;
+_:c14n229 sh:datatype xsd:boolean ;
 	sh:description "An activity where the subject vehicle is moving in the opposite direction to which it is facing." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 14 ;
 	sh:path openlabel_v2:MotionReverse .
-_:c14n229 sh:description "Low light condition. Refer to BSI PAS-1883 Section 5.3.3.b." ;
-	sh:in _:c14n942 ;
+_:c14n23 sh:description "Temporary road structure. Refer to BSI PAS-1883 Section 5.2.1.f." ;
+	sh:in _:c14n883 ;
+	sh:order 42 ;
+	sh:path openlabel_v2:SceneryTemporaryStructure .
+_:c14n230 sh:description "Low light condition. Refer to BSI PAS-1883 Section 5.3.3.b." ;
+	sh:in _:c14n945 ;
 	sh:maxCount 1 ;
 	sh:order 18 ;
 	sh:path openlabel_v2:IlluminationLowLight .
-_:c14n23 sh:description "Temporary road structure. Refer to BSI PAS-1883 Section 5.2.1.f." ;
-	sh:in _:c14n886 ;
-	sh:order 42 ;
-	sh:path openlabel_v2:SceneryTemporaryStructure .
-_:c14n230 sh:datatype xsd:boolean ;
+_:c14n231 sh:datatype xsd:boolean ;
 	sh:description "Traffic agent type classification flag. Refer to BSI PAS-1883 Section 5.4.a.4." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 51 ;
 	sh:path openlabel_v2:TrafficAgentType .
-_:c14n231 rdf:first openlabel_v2:CommunicationSignalLeft ;
-	rdf:rest _:c14n283 .
-_:c14n232 rdf:first rdf:type ;
+_:c14n232 rdf:first openlabel_v2:CommunicationSignalLeft ;
+	rdf:rest _:c14n284 .
+_:c14n233 rdf:first rdf:type ;
 	rdf:rest rdf:nil .
-_:c14n233 sh:datatype xsd:boolean ;
+_:c14n234 sh:datatype xsd:boolean ;
 	sh:description "Locomotion mode where at a specific point no foot touches the ground." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 15 ;
 	sh:path openlabel_v2:MotionRun .
-_:c14n234 sh:datatype xsd:decimal ;
+_:c14n235 sh:datatype xsd:decimal ;
 	sh:description "Curve radius (m). Refer to BSI PAS-1883 Section 5.2.3.3." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 13 ;
 	sh:path openlabel_v2:horizontalCurvesValue .
-_:c14n235 sh:datatype xsd:boolean ;
+_:c14n236 sh:datatype xsd:boolean ;
 	sh:description "Marine (coastal areas only) flag. Refer to BSI PAS-1883 Section 5.3.2.a." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 34 ;
 	sh:path openlabel_v2:ParticulatesMarine .
-_:c14n236 sh:datatype xsd:boolean ;
+_:c14n237 sh:datatype xsd:boolean ;
 	sh:description "Smoke and pollution flag. Refer to BSI PAS-1883 Section 5.3.2.d." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 35 ;
 	sh:path openlabel_v2:ParticulatesPollution .
-_:c14n237 sh:description "Temporary road structure. Refer to BSI PAS-1883 Section 5.2.1.f." ;
-	sh:in _:c14n890 ;
+_:c14n238 sh:description "Temporary road structure. Refer to BSI PAS-1883 Section 5.2.1.f." ;
+	sh:in _:c14n891 ;
 	sh:maxCount 1 ;
 	sh:order 42 ;
 	sh:path openlabel_v2:SceneryTemporaryStructure .
-_:c14n238 sh:description "Regulatory sign type. Refer to BSI PAS-1883 Section 5.2.3.5.b." ;
-	sh:in _:c14n833 ;
+_:c14n239 sh:description "Regulatory sign type. Refer to BSI PAS-1883 Section 5.2.3.5.b." ;
+	sh:in _:c14n834 ;
 	sh:maxCount 1 ;
 	sh:order 45 ;
 	sh:path openlabel_v2:SignsRegulatory .
-_:c14n239 sh:description "Transverse geometry type. Refer to BSI PAS-1883 Section 5.2.3.3.b." ;
-	sh:in _:c14n929 ;
-	sh:maxCount 1 ;
-	sh:order 11 ;
-	sh:path openlabel_v2:GeometryTransverse .
 _:c14n24 sh:datatype xsd:boolean ;
 	sh:description "Traffic agent density flag. Refer to BSI PAS-1883 Section 5.4.a.1." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 49 ;
 	sh:path openlabel_v2:TrafficAgentDensity .
-_:c14n240 sh:description "Road type. Refer to BSI PAS-1883 Section 5.2.3.2." ;
-	sh:in _:c14n760 ;
+_:c14n240 sh:description "Transverse geometry type. Refer to BSI PAS-1883 Section 5.2.3.3.b." ;
+	sh:in _:c14n920 ;
+	sh:maxCount 1 ;
+	sh:order 11 ;
+	sh:path openlabel_v2:GeometryTransverse .
+_:c14n241 sh:description "Road type. Refer to BSI PAS-1883 Section 5.2.3.2." ;
+	sh:in _:c14n743 ;
 	sh:maxCount 1 ;
 	sh:order 9 ;
 	sh:path openlabel_v2:DrivableAreaType .
-_:c14n241 sh:description "Lane width (m). Refer to BSI PAS-1883 Section 5.2.3.4.a." ;
+_:c14n242 sh:description "Lane width (m). Refer to BSI PAS-1883 Section 5.2.3.4.a." ;
 	sh:maxCount 1 ;
-	sh:or _:c14n564 ;
+	sh:or _:c14n573 ;
 	sh:order 22 ;
 	sh:path openlabel_v2:laneSpecificationDimensionsValue .
-_:c14n242 sh:datatype xsd:boolean ;
+_:c14n243 sh:datatype xsd:boolean ;
 	sh:description "Traffic flow rate flag. Refer to BSI PAS-1883 Section 5.4.a.3." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 53 ;
 	sh:path openlabel_v2:TrafficFlowRate .
-_:c14n243 sh:description "Road surface condition. Refer to BSI PAS-1883 Section 5.2.3.7.c." ;
-	sh:in _:c14n684 ;
+_:c14n244 sh:description "Road surface condition. Refer to BSI PAS-1883 Section 5.2.3.7.c." ;
+	sh:in _:c14n706 ;
 	sh:order 6 ;
 	sh:path openlabel_v2:DrivableAreaSurfaceCondition .
-_:c14n244 sh:datatype xsd:boolean ;
+_:c14n245 sh:datatype xsd:boolean ;
 	sh:description "Traffic agent type classification flag. Refer to BSI PAS-1883 Section 5.4.a.4." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 51 ;
 	sh:path openlabel_v2:TrafficAgentType .
-_:c14n245 sh:description "Road surface type. Refer to BSI PAS-1883 Section 5.2.3.7.a." ;
-	sh:in _:c14n350 ;
+_:c14n246 sh:description "Road surface type. Refer to BSI PAS-1883 Section 5.2.3.7.a." ;
+	sh:in _:c14n354 ;
 	sh:maxCount 1 ;
 	sh:order 8 ;
 	sh:path openlabel_v2:DrivableAreaSurfaceType .
-_:c14n246 sh:datatype xsd:string ;
+_:c14n247 sh:datatype xsd:string ;
 	sh:description "SDL definition of the scenario." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 5 ;
 	sh:path openlabel_v2:scenarioDefinition .
-_:c14n247 sh:description "Drivable area edge type. Refer to BSI PAS-1883 Section 5.2.3.1.e." ;
-	sh:in _:c14n606 ;
+_:c14n248 sh:description "Drivable area edge type. Refer to BSI PAS-1883 Section 5.2.3.1.e." ;
+	sh:in _:c14n613 ;
 	sh:order 5 ;
 	sh:path openlabel_v2:DrivableAreaEdge .
-_:c14n248 sh:description "Artificial illumination type. Refer to BSI PAS-1883 Section 5.3.3.d." ;
-	sh:in _:c14n934 ;
+_:c14n249 sh:description "Artificial illumination type. Refer to BSI PAS-1883 Section 5.3.3.d." ;
+	sh:in _:c14n939 ;
 	sh:maxCount 1 ;
 	sh:order 15 ;
 	sh:path openlabel_v2:IlluminationArtificial .
-_:c14n249 sh:datatype xsd:decimal ;
-	sh:description "Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.i." ;
-	sh:nodeKind sh:Literal ;
-	sh:order 32 ;
-	sh:path openlabel_v2:longitudinalUpSlopeValue .
 _:c14n25 sh:datatype xsd:boolean ;
 	sh:description "Lane dimensions flag. Refer to BSI PAS-1883 Section 5.2.3.4.a." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 21 ;
 	sh:path openlabel_v2:LaneSpecificationDimensions .
-_:c14n250 rdf:first rdf:type ;
+_:c14n250 sh:datatype xsd:decimal ;
+	sh:description "Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.i." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 32 ;
+	sh:path openlabel_v2:longitudinalUpSlopeValue .
+_:c14n251 rdf:first rdf:type ;
 	rdf:rest rdf:nil .
-_:c14n251 sh:datatype xsd:boolean ;
+_:c14n252 sh:datatype xsd:boolean ;
 	sh:description "Snowfall flag. Refer to BSI PAS-1883 Section 5.3.1.3." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 60 ;
 	sh:path openlabel_v2:WeatherSnow .
-_:c14n252 sh:datatype xsd:boolean ;
+_:c14n253 sh:datatype xsd:boolean ;
 	sh:description "Traffic agent density flag. Refer to BSI PAS-1883 Section 5.4.a.1." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 49 ;
 	sh:path openlabel_v2:TrafficAgentDensity .
-_:c14n253 sh:datatype xsd:boolean ;
+_:c14n254 sh:datatype xsd:boolean ;
 	sh:description "An activity where the subject vehicle is moving in the direction it is facing." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 9 ;
 	sh:path openlabel_v2:MotionDrive .
-_:c14n254 sh:datatype xsd:boolean ;
+_:c14n255 sh:datatype xsd:boolean ;
 	sh:description "Sand and dust flag. Refer to BSI PAS-1883 Section 5.3.2.c." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 33 ;
 	sh:path openlabel_v2:ParticulatesDust .
-_:c14n255 sh:description "Fixed road structure. Refer to BSI PAS-1883 Section 5.2.1.e." ;
-	sh:in _:c14n903 ;
+_:c14n256 sh:description "Fixed road structure. Refer to BSI PAS-1883 Section 5.2.1.e." ;
+	sh:in _:c14n908 ;
 	sh:order 40 ;
 	sh:path openlabel_v2:SceneryFixedStructure .
-_:c14n256 rdf:first openlabel_v2:CommunicationHeadlightFlash ;
-	rdf:rest _:c14n62 .
-_:c14n257 sh:description "Rainfall type. Refer to BSI PAS-1883 Section 5.3.1.2." ;
-	sh:in _:c14n843 ;
+_:c14n257 rdf:first openlabel_v2:CommunicationHeadlightFlash ;
+	rdf:rest _:c14n63 .
+_:c14n258 sh:description "Rainfall type. Refer to BSI PAS-1883 Section 5.3.1.2." ;
+	sh:in _:c14n847 ;
 	sh:maxCount 1 ;
 	sh:order 39 ;
 	sh:path openlabel_v2:RainType .
-_:c14n258 sh:class openlabel_v2:Odd ;
+_:c14n259 sh:class openlabel_v2:Odd ;
 	sh:description "Operational Design Domain tag." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:BlankNodeOrIRI ;
 	sh:order 2 ;
 	sh:path openlabel_v2:Odd .
-_:c14n259 sh:datatype xsd:decimal ;
+_:c14n26 rdf:first openlabel_v2:CommunicationSignalHazard ;
+	rdf:rest _:c14n232 .
+_:c14n260 sh:datatype xsd:decimal ;
 	sh:description "Cloud cover (okta). Refer to BSI PAS-1883 Section 5.3.3.c." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 17 ;
 	sh:path openlabel_v2:illuminationCloudinessValue .
-_:c14n26 rdf:first openlabel_v2:CommunicationSignalHazard ;
-	rdf:rest _:c14n231 .
-_:c14n260 sh:description "Road surface type. Refer to BSI PAS-1883 Section 5.2.3.7.a." ;
-	sh:in _:c14n356 ;
+_:c14n261 sh:description "Road surface type. Refer to BSI PAS-1883 Section 5.2.3.7.a." ;
+	sh:in _:c14n351 ;
 	sh:order 8 ;
 	sh:path openlabel_v2:DrivableAreaSurfaceType .
-_:c14n261 sh:datatype xsd:boolean ;
+_:c14n262 sh:datatype xsd:boolean ;
 	sh:description "Snowfall flag. Refer to BSI PAS-1883 Section 5.3.1.3." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 60 ;
 	sh:path openlabel_v2:WeatherSnow .
-_:c14n262 sh:datatype xsd:decimal ;
+_:c14n263 sh:datatype xsd:decimal ;
 	sh:description "Curve radius (m). Refer to BSI PAS-1883 Section 5.2.3.3." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 13 ;
 	sh:path openlabel_v2:horizontalCurvesValue .
-_:c14n263 sh:datatype xsd:integer ;
+_:c14n264 sh:datatype xsd:integer ;
 	sh:description "Rate (vehicles/h). Refer to BSI PAS-1883 Section 5.4.a.3." ;
 	sh:minInclusive 0 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 54 ;
 	sh:path openlabel_v2:trafficFlowRateValue .
-_:c14n264 sh:datatype xsd:decimal ;
+_:c14n265 sh:datatype xsd:decimal ;
 	sh:description "Wind speed (m/s). Refer to BSI PAS-1883 Section 5.3.1.1." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 63 ;
 	sh:path openlabel_v2:weatherWindValue .
-_:c14n265 sh:datatype xsd:string ;
+_:c14n266 sh:datatype xsd:string ;
 	sh:description "Relative or absolute URL of a static image or animation of the scenario to allow users to easily see what the scenario represents." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 12 ;
 	sh:path openlabel_v2:scenarioVisualisationURL .
-_:c14n266 sh:datatype xsd:boolean ;
+_:c14n267 sh:datatype xsd:boolean ;
 	sh:description "Down-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.ii." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 28 ;
 	sh:path openlabel_v2:LongitudinalDownSlope .
-_:c14n267 sh:datatype xsd:boolean ;
+_:c14n268 sh:datatype xsd:boolean ;
 	sh:description "Lane dimensions flag. Refer to BSI PAS-1883 Section 5.2.3.4.a." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 21 ;
 	sh:path openlabel_v2:LaneSpecificationDimensions .
-_:c14n268 sh:datatype xsd:boolean ;
+_:c14n269 sh:datatype xsd:boolean ;
 	sh:description "Rainfall flag. Refer to BSI PAS-1883 Section 5.3.1.2." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 58 ;
 	sh:path openlabel_v2:WeatherRain .
-_:c14n269 sh:datatype xsd:boolean ;
+_:c14n27 sh:description "Drivable area edge type. Refer to BSI PAS-1883 Section 5.2.3.1.e." ;
+	sh:in _:c14n607 ;
+	sh:order 5 ;
+	sh:path openlabel_v2:DrivableAreaEdge .
+_:c14n270 sh:datatype xsd:boolean ;
 	sh:description "Subject exits the intersection on a road to the right of the original." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 21 ;
 	sh:path openlabel_v2:MotionTurnRight .
-_:c14n27 sh:description "Drivable area edge type. Refer to BSI PAS-1883 Section 5.2.3.1.e." ;
-	sh:in _:c14n600 ;
-	sh:order 5 ;
-	sh:path openlabel_v2:DrivableAreaEdge .
-_:c14n270 sh:datatype xsd:decimal ;
+_:c14n271 sh:datatype xsd:decimal ;
 	sh:description "Sun elevation (degrees). Refer to BSI PAS-1883 Section 5.3.3.a.1." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 3 ;
 	sh:path openlabel_v2:daySunElevationValue .
-_:c14n271 sh:datatype xsd:boolean ;
+_:c14n272 sh:datatype xsd:boolean ;
 	sh:description "Marine (coastal areas only) flag. Refer to BSI PAS-1883 Section 5.3.2.a." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 34 ;
 	sh:path openlabel_v2:ParticulatesMarine .
-_:c14n272 sh:datatype xsd:decimal ;
+_:c14n273 sh:datatype xsd:decimal ;
 	sh:description "Meteorological Optical Range (MOR) (m). Refer to BSI PAS-1883 Section 5.3.2.b." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 38 ;
 	sh:path openlabel_v2:particulatesWaterValue .
-_:c14n273 sh:datatype xsd:boolean ;
+_:c14n274 sh:datatype xsd:boolean ;
 	sh:description "An activity where the road user changes their heading." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 19 ;
 	sh:path openlabel_v2:MotionTurn .
-_:c14n274 sh:datatype xsd:integer ;
+_:c14n275 sh:datatype xsd:integer ;
 	sh:description "Rate (vehicles/h). Refer to BSI PAS-1883 Section 5.4.a.3." ;
 	sh:minInclusive 0 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 54 ;
 	sh:path openlabel_v2:trafficFlowRateValue .
-_:c14n275 sh:datatype xsd:boolean ;
+_:c14n276 sh:datatype xsd:boolean ;
 	sh:description "Rainfall flag. Refer to BSI PAS-1883 Section 5.3.1.2." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 58 ;
 	sh:path openlabel_v2:WeatherRain .
-_:c14n276 sh:datatype xsd:boolean ;
+_:c14n277 sh:datatype xsd:boolean ;
 	sh:description "Cloudiness flag. Refer to BSI PAS-1883 Section 5.3.3.c." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 16 ;
 	sh:path openlabel_v2:IlluminationCloudiness .
-_:c14n277 sh:description "Lane width (m). Refer to BSI PAS-1883 Section 5.2.3.4.a." ;
-	sh:or _:c14n572 ;
+_:c14n278 sh:description "Lane width (m). Refer to BSI PAS-1883 Section 5.2.3.4.a." ;
+	sh:or _:c14n565 ;
 	sh:order 22 ;
 	sh:path openlabel_v2:laneSpecificationDimensionsValue .
-_:c14n278 rdf:first rdf:type ;
+_:c14n279 rdf:first rdf:type ;
 	rdf:rest rdf:nil .
-_:c14n279 sh:description "Particulate type. Refer to BSI PAS-1883 Section 5.3.2." ;
-	sh:in _:c14n374 ;
-	sh:maxCount 1 ;
-	sh:order 10 ;
-	sh:path openlabel_v2:EnvironmentParticulates .
 _:c14n28 sh:description "Regulatory sign type. Refer to BSI PAS-1883 Section 5.2.3.5.b." ;
-	sh:in _:c14n825 ;
+	sh:in _:c14n826 ;
 	sh:maxCount 1 ;
 	sh:order 45 ;
 	sh:path openlabel_v2:SignsRegulatory .
-_:c14n280 sh:datatype xsd:boolean ;
+_:c14n280 sh:description "Particulate type. Refer to BSI PAS-1883 Section 5.3.2." ;
+	sh:in _:c14n375 ;
+	sh:maxCount 1 ;
+	sh:order 10 ;
+	sh:path openlabel_v2:EnvironmentParticulates .
+_:c14n281 sh:datatype xsd:boolean ;
 	sh:description "Traffic agent density flag. Refer to BSI PAS-1883 Section 5.4.a.1." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 49 ;
 	sh:path openlabel_v2:TrafficAgentDensity .
-_:c14n281 sh:description "Particulate type. Refer to BSI PAS-1883 Section 5.3.2." ;
-	sh:in _:c14n369 ;
+_:c14n282 sh:description "Particulate type. Refer to BSI PAS-1883 Section 5.3.2." ;
+	sh:in _:c14n370 ;
 	sh:maxCount 1 ;
 	sh:order 10 ;
 	sh:path openlabel_v2:EnvironmentParticulates .
-_:c14n282 sh:description "Drivable area edge type. Refer to BSI PAS-1883 Section 5.2.3.1.e." ;
-	sh:in _:c14n612 ;
+_:c14n283 sh:description "Drivable area edge type. Refer to BSI PAS-1883 Section 5.2.3.1.e." ;
+	sh:in _:c14n601 ;
 	sh:order 5 ;
 	sh:path openlabel_v2:DrivableAreaEdge .
-_:c14n283 rdf:first openlabel_v2:CommunicationSignalRight ;
+_:c14n284 rdf:first openlabel_v2:CommunicationSignalRight ;
 	rdf:rest _:c14n2 .
-_:c14n284 sh:description "Communication type of road user behaviour." ;
-	sh:in _:c14n256 ;
+_:c14n285 sh:description "Communication type of road user behaviour." ;
+	sh:in _:c14n257 ;
 	sh:order 0 ;
 	sh:path openlabel_v2:BehaviourCommunication .
-_:c14n285 sh:description "Lane type. Refer to BSI PAS-1883 Section 5.2.3.4.c." ;
-	sh:in _:c14n330 ;
+_:c14n286 sh:description "Lane type. Refer to BSI PAS-1883 Section 5.2.3.4.c." ;
+	sh:in _:c14n343 ;
 	sh:order 27 ;
 	sh:path openlabel_v2:LaneSpecificationType .
-_:c14n286 sh:datatype xsd:boolean ;
+_:c14n287 sh:datatype xsd:boolean ;
 	sh:description "Non-precipitating water droplets or ice crystals (mist/fog) flag. Refer to BSI PAS-1883 Section 5.3.2.b." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 37 ;
 	sh:path openlabel_v2:ParticulatesWater .
-_:c14n287 sh:description "Roundabout type. Refer to BSI PAS-1883 Section 5.2.4." ;
-	sh:in _:c14n648 ;
+_:c14n288 sh:description "Roundabout type. Refer to BSI PAS-1883 Section 5.2.4." ;
+	sh:in _:c14n659 ;
 	sh:order 20 ;
 	sh:path openlabel_v2:JunctionRoundabout .
-_:c14n288 sh:datatype xsd:boolean ;
+_:c14n289 sh:datatype xsd:boolean ;
 	sh:description "Smoke and pollution flag. Refer to BSI PAS-1883 Section 5.3.2.d." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 35 ;
 	sh:path openlabel_v2:ParticulatesPollution .
-_:c14n289 sh:datatype xsd:decimal ;
+_:c14n29 sh:description "Agent type. Refer to BSI PAS-1883 Section 5.4.a.4." ;
+	sh:or _:c14n414 ;
+	sh:order 52 ;
+	sh:path openlabel_v2:trafficAgentTypeValue .
+_:c14n290 sh:datatype xsd:decimal ;
 	sh:description "Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.i." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 32 ;
 	sh:path openlabel_v2:longitudinalUpSlopeValue .
-_:c14n29 sh:description "Agent type. Refer to BSI PAS-1883 Section 5.4.a.4." ;
-	sh:or _:c14n413 ;
-	sh:order 52 ;
-	sh:path openlabel_v2:trafficAgentTypeValue .
-_:c14n290 sh:datatype xsd:decimal ;
+_:c14n291 sh:datatype xsd:decimal ;
 	sh:description "Rainfall intensity (mm/h). Refer to BSI PAS-1883 Section 5.3.1.2." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 59 ;
 	sh:path openlabel_v2:weatherRainValue .
-_:c14n291 sh:description "Information sign type. Refer to BSI PAS-1883 Section 5.2.3.5.a." ;
-	sh:in _:c14n538 ;
+_:c14n292 sh:description "Information sign type. Refer to BSI PAS-1883 Section 5.2.3.5.a." ;
+	sh:in _:c14n543 ;
 	sh:maxCount 1 ;
 	sh:order 44 ;
 	sh:path openlabel_v2:SignsInformation .
-_:c14n292 sh:datatype xsd:boolean ;
+_:c14n293 sh:datatype xsd:boolean ;
 	sh:description "Lane dimensions flag. Refer to BSI PAS-1883 Section 5.2.3.4.a." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 21 ;
 	sh:path openlabel_v2:LaneSpecificationDimensions .
-_:c14n293 sh:datatype xsd:boolean ;
+_:c14n294 sh:datatype xsd:boolean ;
 	sh:description "Snowfall flag. Refer to BSI PAS-1883 Section 5.3.1.3." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 60 ;
 	sh:path openlabel_v2:WeatherSnow .
-_:c14n294 sh:description "Lane width (m). Refer to BSI PAS-1883 Section 5.2.3.4.a." ;
-	sh:or _:c14n568 ;
+_:c14n295 sh:description "Lane width (m). Refer to BSI PAS-1883 Section 5.2.3.4.a." ;
+	sh:or _:c14n569 ;
 	sh:order 22 ;
 	sh:path openlabel_v2:laneSpecificationDimensionsValue .
-_:c14n295 sh:datatype xsd:boolean ;
+_:c14n296 sh:datatype xsd:boolean ;
 	sh:description "Cloudiness flag. Refer to BSI PAS-1883 Section 5.3.3.c." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 16 ;
 	sh:path openlabel_v2:IlluminationCloudiness .
-_:c14n296 sh:datatype xsd:decimal ;
+_:c14n297 sh:datatype xsd:decimal ;
 	sh:description "Sun elevation (degrees). Refer to BSI PAS-1883 Section 5.3.3.a.1." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 3 ;
 	sh:path openlabel_v2:daySunElevationValue .
-_:c14n297 sh:datatype xsd:string ;
+_:c14n298 sh:datatype xsd:string ;
 	sh:description "The URL of the legal entity who owns the rights to the scenario." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 3 ;
 	sh:path openlabel_v2:ownerURL .
-_:c14n298 sh:datatype xsd:boolean ;
+_:c14n299 sh:datatype xsd:boolean ;
 	sh:description "Snowfall flag. Refer to BSI PAS-1883 Section 5.3.1.3." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 60 ;
 	sh:path openlabel_v2:WeatherSnow .
-_:c14n299 sh:datatype xsd:string ;
-	sh:description "URI of SDL language used for the definition of the scenario." ;
-	sh:maxCount 1 ;
-	sh:nodeKind sh:Literal ;
-	sh:order 6 ;
-	sh:path openlabel_v2:scenarioDefinitionLanguageURI .
 _:c14n3 sh:datatype xsd:integer ;
 	sh:description "Density (vehicles/km). Refer to BSI PAS-1883 Section 5.4.a.1." ;
 	sh:minInclusive 0 ;
@@ -1218,110 +1218,111 @@ _:c14n30 sh:datatype xsd:boolean ;
 	sh:nodeKind sh:Literal ;
 	sh:order 28 ;
 	sh:path openlabel_v2:LongitudinalDownSlope .
-_:c14n300 sh:description "Speed (km/h)." ;
+_:c14n300 sh:datatype xsd:string ;
+	sh:description "URI of SDL language used for the definition of the scenario." ;
 	sh:maxCount 1 ;
-	sh:or _:c14n552 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 6 ;
+	sh:path openlabel_v2:scenarioDefinitionLanguageURI .
+_:c14n301 sh:description "Speed (km/h)." ;
+	sh:maxCount 1 ;
+	sh:or _:c14n553 ;
 	sh:order 3 ;
 	sh:path openlabel_v2:motionDriveValue .
-_:c14n301 sh:description "Zone type. Refer to BSI PAS-1883 Section 5.2.1.a." ;
-	sh:in _:c14n808 ;
+_:c14n302 sh:description "Zone type. Refer to BSI PAS-1883 Section 5.2.1.a." ;
+	sh:in _:c14n804 ;
 	sh:order 43 ;
 	sh:path openlabel_v2:SceneryZone .
-_:c14n302 sh:datatype xsd:integer ;
+_:c14n303 sh:datatype xsd:integer ;
 	sh:description "Volume (vehicle km). Refer to BSI PAS-1883 Section 5.4.a.2." ;
 	sh:minInclusive 0 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 57 ;
 	sh:path openlabel_v2:trafficVolumeValue .
-_:c14n303 sh:datatype xsd:boolean ;
+_:c14n304 sh:datatype xsd:boolean ;
 	sh:description "Traffic agent density flag. Refer to BSI PAS-1883 Section 5.4.a.1." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 49 ;
 	sh:path openlabel_v2:TrafficAgentDensity .
-_:c14n304 sh:description "Road surface type. Refer to BSI PAS-1883 Section 5.2.3.7.a." ;
-	sh:in _:c14n353 ;
+_:c14n305 sh:description "Road surface type. Refer to BSI PAS-1883 Section 5.2.3.7.a." ;
+	sh:in _:c14n360 ;
 	sh:maxCount 1 ;
 	sh:order 8 ;
 	sh:path openlabel_v2:DrivableAreaSurfaceType .
-_:c14n305 sh:datatype xsd:boolean ;
+_:c14n306 sh:datatype xsd:boolean ;
 	sh:description "Wind flag. Refer to BSI PAS-1883 Section 5.3.1.1." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 62 ;
 	sh:path openlabel_v2:WeatherWind .
-_:c14n306 sh:description "Zone type. Refer to BSI PAS-1883 Section 5.2.1.a." ;
-	sh:in _:c14n803 ;
+_:c14n307 sh:description "Zone type. Refer to BSI PAS-1883 Section 5.2.1.a." ;
+	sh:in _:c14n794 ;
 	sh:order 43 ;
 	sh:path openlabel_v2:SceneryZone .
-_:c14n307 sh:description "Drivable area edge type. Refer to BSI PAS-1883 Section 5.2.3.1.e." ;
-	sh:in _:c14n618 ;
+_:c14n308 sh:description "Drivable area edge type. Refer to BSI PAS-1883 Section 5.2.3.1.e." ;
+	sh:in _:c14n619 ;
 	sh:order 5 ;
 	sh:path openlabel_v2:DrivableAreaEdge .
-_:c14n308 sh:datatype xsd:boolean ;
+_:c14n309 sh:datatype xsd:boolean ;
 	sh:description "Volcanic ash flag. Refer to BSI PAS-1883 Section 5.3.2.e." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 36 ;
 	sh:path openlabel_v2:ParticulatesVolcanic .
-_:c14n309 sh:datatype xsd:boolean ;
-	sh:description "An activity where the road user is stationary." ;
-	sh:maxCount 1 ;
-	sh:nodeKind sh:Literal ;
-	sh:order 17 ;
-	sh:path openlabel_v2:MotionStop .
 _:c14n31 sh:datatype xsd:decimal ;
 	sh:description "Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.ii." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 29 ;
 	sh:path openlabel_v2:longitudinalDownSlopeValue .
-_:c14n310 sh:description "Roundabout type. Refer to BSI PAS-1883 Section 5.2.4." ;
-	sh:in _:c14n658 ;
+_:c14n310 sh:datatype xsd:boolean ;
+	sh:description "An activity where the road user is stationary." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 17 ;
+	sh:path openlabel_v2:MotionStop .
+_:c14n311 sh:description "Roundabout type. Refer to BSI PAS-1883 Section 5.2.4." ;
+	sh:in _:c14n649 ;
 	sh:maxCount 1 ;
 	sh:order 20 ;
 	sh:path openlabel_v2:JunctionRoundabout .
-_:c14n311 sh:datatype xsd:boolean ;
+_:c14n312 sh:datatype xsd:boolean ;
 	sh:description "Rainfall flag. Refer to BSI PAS-1883 Section 5.3.1.2." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 58 ;
 	sh:path openlabel_v2:WeatherRain .
-_:c14n312 sh:datatype xsd:boolean ;
+_:c14n313 sh:datatype xsd:boolean ;
 	sh:description "Presence of special vehicles flag. Refer to BSI PAS-1883 Section 5.4.a.5." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 55 ;
 	sh:path openlabel_v2:TrafficSpecialVehicle .
-_:c14n313 sh:description "Number of lanes (unit). Refer to BSI PAS-1883 Section 5.2.3.4.d." ;
-	sh:or _:c14n866 ;
+_:c14n314 sh:description "Number of lanes (unit). Refer to BSI PAS-1883 Section 5.2.3.4.d." ;
+	sh:or _:c14n871 ;
 	sh:order 24 ;
 	sh:path openlabel_v2:laneSpecificationLaneCountValue .
-_:c14n314 sh:description "Road surface condition. Refer to BSI PAS-1883 Section 5.2.3.7.c." ;
-	sh:in _:c14n698 ;
+_:c14n315 sh:description "Road surface condition. Refer to BSI PAS-1883 Section 5.2.3.7.c." ;
+	sh:in _:c14n692 ;
 	sh:maxCount 1 ;
 	sh:order 6 ;
 	sh:path openlabel_v2:DrivableAreaSurfaceCondition .
-_:c14n315 sh:datatype xsd:boolean ;
+_:c14n316 sh:datatype xsd:boolean ;
 	sh:description "Sand and dust flag. Refer to BSI PAS-1883 Section 5.3.2.c." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 33 ;
 	sh:path openlabel_v2:ParticulatesDust .
-_:c14n316 sh:datatype xsd:integer ;
+_:c14n317 sh:datatype xsd:integer ;
 	sh:description "Rate (vehicles/h). Refer to BSI PAS-1883 Section 5.4.a.3." ;
 	sh:maxCount 1 ;
 	sh:minInclusive 0 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 54 ;
 	sh:path openlabel_v2:trafficFlowRateValue .
-_:c14n317 sh:datatype xsd:decimal ;
+_:c14n318 sh:datatype xsd:decimal ;
 	sh:description "Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.i." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 32 ;
 	sh:path openlabel_v2:longitudinalUpSlopeValue .
-_:c14n318 sh:datatype xsd:boolean ;
-	sh:description "Presence of special vehicles flag. Refer to BSI PAS-1883 Section 5.4.a.5." ;
-	sh:nodeKind sh:Literal ;
-	sh:order 55 ;
-	sh:path openlabel_v2:TrafficSpecialVehicle .
 _:c14n319 sh:datatype xsd:boolean ;
 	sh:description "Presence of special vehicles flag. Refer to BSI PAS-1883 Section 5.4.a.5." ;
 	sh:nodeKind sh:Literal ;
@@ -1329,213 +1330,220 @@ _:c14n319 sh:datatype xsd:boolean ;
 	sh:path openlabel_v2:TrafficSpecialVehicle .
 _:c14n32 sh:description "Speed (km/h). Refer to BSI PAS-1883 Section 5.4.b." ;
 	sh:maxCount 1 ;
-	sh:or _:c14n870 ;
+	sh:or _:c14n875 ;
 	sh:order 48 ;
 	sh:path openlabel_v2:subjectVehicleSpeedValue .
-_:c14n320 sh:datatype xsd:decimal ;
+_:c14n320 sh:datatype xsd:boolean ;
+	sh:description "Presence of special vehicles flag. Refer to BSI PAS-1883 Section 5.4.a.5." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 55 ;
+	sh:path openlabel_v2:TrafficSpecialVehicle .
+_:c14n321 sh:datatype xsd:decimal ;
 	sh:description "Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.i." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 32 ;
 	sh:path openlabel_v2:longitudinalUpSlopeValue .
-_:c14n321 sh:description "Speed (km/h). Refer to BSI PAS-1883 Section 5.4.b." ;
+_:c14n322 sh:description "Speed (km/h). Refer to BSI PAS-1883 Section 5.4.b." ;
 	sh:maxCount 1 ;
-	sh:or _:c14n862 ;
+	sh:or _:c14n863 ;
 	sh:order 48 ;
 	sh:path openlabel_v2:subjectVehicleSpeedValue .
-_:c14n322 sh:datatype xsd:boolean ;
+_:c14n323 sh:datatype xsd:boolean ;
 	sh:description "Down-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.ii." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 28 ;
 	sh:path openlabel_v2:LongitudinalDownSlope .
-_:c14n323 sh:description "Intersection type. Refer to BSI PAS-1883 Section 5.2.4." ;
-	sh:in _:c14n783 ;
+_:c14n324 sh:description "Intersection type. Refer to BSI PAS-1883 Section 5.2.4." ;
+	sh:in _:c14n784 ;
 	sh:maxCount 1 ;
 	sh:order 19 ;
 	sh:path openlabel_v2:JunctionIntersection .
-_:c14n324 rdf:first openlabel_v2:LaneTypeBus ;
-	rdf:rest _:c14n325 .
-_:c14n325 rdf:first openlabel_v2:LaneTypeCycle ;
+_:c14n325 rdf:first openlabel_v2:LaneTypeBus ;
 	rdf:rest _:c14n326 .
-_:c14n326 rdf:first openlabel_v2:LaneTypeEmergency ;
+_:c14n326 rdf:first openlabel_v2:LaneTypeCycle ;
 	rdf:rest _:c14n327 .
-_:c14n327 rdf:first openlabel_v2:LaneTypeSpecial ;
+_:c14n327 rdf:first openlabel_v2:LaneTypeEmergency ;
 	rdf:rest _:c14n328 .
-_:c14n328 rdf:first openlabel_v2:LaneTypeTraffic ;
+_:c14n328 rdf:first openlabel_v2:LaneTypeSpecial ;
 	rdf:rest _:c14n329 .
-_:c14n329 rdf:first openlabel_v2:LaneTypeTram ;
-	rdf:rest rdf:nil .
+_:c14n329 rdf:first openlabel_v2:LaneTypeTraffic ;
+	rdf:rest _:c14n330 .
 _:c14n33 sh:description "Direction of travel. Refer to BSI PAS-1883 Section 5.2.3.4.e." ;
-	sh:in _:c14n950 ;
+	sh:in _:c14n951 ;
 	sh:maxCount 1 ;
 	sh:order 26 ;
 	sh:path openlabel_v2:LaneSpecificationTravelDirection .
-_:c14n330 rdf:first openlabel_v2:LaneTypeBus ;
-	rdf:rest _:c14n331 .
-_:c14n331 rdf:first openlabel_v2:LaneTypeCycle ;
-	rdf:rest _:c14n332 .
-_:c14n332 rdf:first openlabel_v2:LaneTypeEmergency ;
-	rdf:rest _:c14n333 .
-_:c14n333 rdf:first openlabel_v2:LaneTypeSpecial ;
-	rdf:rest _:c14n334 .
-_:c14n334 rdf:first openlabel_v2:LaneTypeTraffic ;
-	rdf:rest _:c14n335 .
-_:c14n335 rdf:first openlabel_v2:LaneTypeTram ;
+_:c14n330 rdf:first openlabel_v2:LaneTypeTram ;
 	rdf:rest rdf:nil .
-_:c14n336 rdf:first openlabel_v2:LaneTypeBus ;
-	rdf:rest _:c14n337 .
-_:c14n337 rdf:first openlabel_v2:LaneTypeCycle ;
+_:c14n331 rdf:first openlabel_v2:LaneTypeBus ;
+	rdf:rest _:c14n332 .
+_:c14n332 rdf:first openlabel_v2:LaneTypeCycle ;
+	rdf:rest _:c14n333 .
+_:c14n333 rdf:first openlabel_v2:LaneTypeEmergency ;
+	rdf:rest _:c14n334 .
+_:c14n334 rdf:first openlabel_v2:LaneTypeSpecial ;
+	rdf:rest _:c14n335 .
+_:c14n335 rdf:first openlabel_v2:LaneTypeTraffic ;
+	rdf:rest _:c14n336 .
+_:c14n336 rdf:first openlabel_v2:LaneTypeTram ;
+	rdf:rest rdf:nil .
+_:c14n337 rdf:first openlabel_v2:LaneTypeBus ;
 	rdf:rest _:c14n338 .
-_:c14n338 rdf:first openlabel_v2:LaneTypeEmergency ;
+_:c14n338 rdf:first openlabel_v2:LaneTypeCycle ;
 	rdf:rest _:c14n339 .
-_:c14n339 rdf:first openlabel_v2:LaneTypeSpecial ;
+_:c14n339 rdf:first openlabel_v2:LaneTypeEmergency ;
 	rdf:rest _:c14n340 .
 _:c14n34 sh:datatype xsd:boolean ;
 	sh:description "Lane marking flag. Refer to BSI PAS-1883 Section 5.2.3.4.b." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 25 ;
 	sh:path openlabel_v2:LaneSpecificationMarking .
-_:c14n340 rdf:first openlabel_v2:LaneTypeTraffic ;
+_:c14n340 rdf:first openlabel_v2:LaneTypeSpecial ;
 	rdf:rest _:c14n341 .
-_:c14n341 rdf:first openlabel_v2:LaneTypeTram ;
+_:c14n341 rdf:first openlabel_v2:LaneTypeTraffic ;
+	rdf:rest _:c14n342 .
+_:c14n342 rdf:first openlabel_v2:LaneTypeTram ;
 	rdf:rest rdf:nil .
-_:c14n342 rdf:first openlabel_v2:LaneTypeBus ;
-	rdf:rest _:c14n343 .
-_:c14n343 rdf:first openlabel_v2:LaneTypeCycle ;
+_:c14n343 rdf:first openlabel_v2:LaneTypeBus ;
 	rdf:rest _:c14n344 .
-_:c14n344 rdf:first openlabel_v2:LaneTypeEmergency ;
+_:c14n344 rdf:first openlabel_v2:LaneTypeCycle ;
 	rdf:rest _:c14n345 .
-_:c14n345 rdf:first openlabel_v2:LaneTypeSpecial ;
+_:c14n345 rdf:first openlabel_v2:LaneTypeEmergency ;
 	rdf:rest _:c14n346 .
-_:c14n346 rdf:first openlabel_v2:LaneTypeTraffic ;
+_:c14n346 rdf:first openlabel_v2:LaneTypeSpecial ;
 	rdf:rest _:c14n347 .
-_:c14n347 rdf:first openlabel_v2:LaneTypeTram ;
-	rdf:rest rdf:nil .
-_:c14n348 rdf:first openlabel_v2:SurfaceTypeUniform ;
-	rdf:rest rdf:nil .
-_:c14n349 rdf:first openlabel_v2:SurfaceTypeSegmented ;
+_:c14n347 rdf:first openlabel_v2:LaneTypeTraffic ;
 	rdf:rest _:c14n348 .
+_:c14n348 rdf:first openlabel_v2:LaneTypeTram ;
+	rdf:rest rdf:nil .
+_:c14n349 rdf:first openlabel_v2:SurfaceTypeUniform ;
+	rdf:rest rdf:nil .
 _:c14n35 sh:description "Speed (km/h). Refer to BSI PAS-1883 Section 5.4.b." ;
-	sh:or _:c14n850 ;
+	sh:or _:c14n855 ;
 	sh:order 48 ;
 	sh:path openlabel_v2:subjectVehicleSpeedValue .
-_:c14n350 rdf:first openlabel_v2:SurfaceTypeLoose ;
+_:c14n350 rdf:first openlabel_v2:SurfaceTypeSegmented ;
 	rdf:rest _:c14n349 .
-_:c14n351 rdf:first openlabel_v2:SurfaceTypeUniform ;
+_:c14n351 rdf:first openlabel_v2:SurfaceTypeLoose ;
+	rdf:rest _:c14n350 .
+_:c14n352 rdf:first openlabel_v2:SurfaceTypeUniform ;
 	rdf:rest rdf:nil .
-_:c14n352 rdf:first openlabel_v2:SurfaceTypeSegmented ;
-	rdf:rest _:c14n351 .
-_:c14n353 rdf:first openlabel_v2:SurfaceTypeLoose ;
+_:c14n353 rdf:first openlabel_v2:SurfaceTypeSegmented ;
 	rdf:rest _:c14n352 .
-_:c14n354 rdf:first openlabel_v2:SurfaceTypeUniform ;
+_:c14n354 rdf:first openlabel_v2:SurfaceTypeLoose ;
+	rdf:rest _:c14n353 .
+_:c14n355 rdf:first openlabel_v2:SurfaceTypeUniform ;
 	rdf:rest rdf:nil .
-_:c14n355 rdf:first openlabel_v2:SurfaceTypeSegmented ;
-	rdf:rest _:c14n354 .
-_:c14n356 rdf:first openlabel_v2:SurfaceTypeLoose ;
+_:c14n356 rdf:first openlabel_v2:SurfaceTypeSegmented ;
 	rdf:rest _:c14n355 .
-_:c14n357 rdf:first openlabel_v2:SurfaceTypeUniform ;
+_:c14n357 rdf:first openlabel_v2:SurfaceTypeLoose ;
+	rdf:rest _:c14n356 .
+_:c14n358 rdf:first openlabel_v2:SurfaceTypeUniform ;
 	rdf:rest rdf:nil .
-_:c14n358 rdf:first openlabel_v2:SurfaceTypeSegmented ;
-	rdf:rest _:c14n357 .
-_:c14n359 rdf:first openlabel_v2:SurfaceTypeLoose ;
+_:c14n359 rdf:first openlabel_v2:SurfaceTypeSegmented ;
 	rdf:rest _:c14n358 .
 _:c14n36 sh:description "Position of the sun. Refer to BSI PAS-1883 Section 5.3.3.a.2." ;
-	sh:in _:c14n674 ;
+	sh:in _:c14n679 ;
 	sh:maxCount 1 ;
 	sh:order 4 ;
 	sh:path openlabel_v2:DaySunPosition .
-_:c14n360 rdf:first openlabel_v2:ParticulatesPollution ;
-	rdf:rest _:c14n361 .
-_:c14n361 rdf:first openlabel_v2:ParticulatesVolcanic ;
+_:c14n360 rdf:first openlabel_v2:SurfaceTypeLoose ;
+	rdf:rest _:c14n359 .
+_:c14n361 rdf:first openlabel_v2:ParticulatesPollution ;
 	rdf:rest _:c14n362 .
-_:c14n362 rdf:first openlabel_v2:ParticulatesWater ;
-	rdf:rest rdf:nil .
-_:c14n363 rdf:first openlabel_v2:ParticulatesMarine ;
-	rdf:rest _:c14n360 .
-_:c14n364 rdf:first openlabel_v2:ParticulatesDust ;
+_:c14n362 rdf:first openlabel_v2:ParticulatesVolcanic ;
 	rdf:rest _:c14n363 .
-_:c14n365 rdf:first openlabel_v2:ParticulatesPollution ;
-	rdf:rest _:c14n366 .
-_:c14n366 rdf:first openlabel_v2:ParticulatesVolcanic ;
-	rdf:rest _:c14n367 .
-_:c14n367 rdf:first openlabel_v2:ParticulatesWater ;
+_:c14n363 rdf:first openlabel_v2:ParticulatesWater ;
 	rdf:rest rdf:nil .
-_:c14n368 rdf:first openlabel_v2:ParticulatesMarine ;
-	rdf:rest _:c14n365 .
-_:c14n369 rdf:first openlabel_v2:ParticulatesDust ;
+_:c14n364 rdf:first openlabel_v2:ParticulatesMarine ;
+	rdf:rest _:c14n361 .
+_:c14n365 rdf:first openlabel_v2:ParticulatesDust ;
+	rdf:rest _:c14n364 .
+_:c14n366 rdf:first openlabel_v2:ParticulatesPollution ;
+	rdf:rest _:c14n367 .
+_:c14n367 rdf:first openlabel_v2:ParticulatesVolcanic ;
 	rdf:rest _:c14n368 .
+_:c14n368 rdf:first openlabel_v2:ParticulatesWater ;
+	rdf:rest rdf:nil .
+_:c14n369 rdf:first openlabel_v2:ParticulatesMarine ;
+	rdf:rest _:c14n366 .
 _:c14n37 sh:datatype xsd:boolean ;
 	sh:description "Smoke and pollution flag. Refer to BSI PAS-1883 Section 5.3.2.d." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 35 ;
 	sh:path openlabel_v2:ParticulatesPollution .
-_:c14n370 rdf:first openlabel_v2:ParticulatesPollution ;
-	rdf:rest _:c14n371 .
-_:c14n371 rdf:first openlabel_v2:ParticulatesVolcanic ;
+_:c14n370 rdf:first openlabel_v2:ParticulatesDust ;
+	rdf:rest _:c14n369 .
+_:c14n371 rdf:first openlabel_v2:ParticulatesPollution ;
 	rdf:rest _:c14n372 .
-_:c14n372 rdf:first openlabel_v2:ParticulatesWater ;
-	rdf:rest rdf:nil .
-_:c14n373 rdf:first openlabel_v2:ParticulatesMarine ;
-	rdf:rest _:c14n370 .
-_:c14n374 rdf:first openlabel_v2:ParticulatesDust ;
+_:c14n372 rdf:first openlabel_v2:ParticulatesVolcanic ;
 	rdf:rest _:c14n373 .
-_:c14n375 rdf:first openlabel_v2:ParticulatesPollution ;
-	rdf:rest _:c14n376 .
-_:c14n376 rdf:first openlabel_v2:ParticulatesVolcanic ;
-	rdf:rest _:c14n377 .
-_:c14n377 rdf:first openlabel_v2:ParticulatesWater ;
+_:c14n373 rdf:first openlabel_v2:ParticulatesWater ;
 	rdf:rest rdf:nil .
-_:c14n378 rdf:first openlabel_v2:ParticulatesMarine ;
-	rdf:rest _:c14n375 .
-_:c14n379 rdf:first openlabel_v2:ParticulatesDust ;
+_:c14n374 rdf:first openlabel_v2:ParticulatesMarine ;
+	rdf:rest _:c14n371 .
+_:c14n375 rdf:first openlabel_v2:ParticulatesDust ;
+	rdf:rest _:c14n374 .
+_:c14n376 rdf:first openlabel_v2:ParticulatesPollution ;
+	rdf:rest _:c14n377 .
+_:c14n377 rdf:first openlabel_v2:ParticulatesVolcanic ;
 	rdf:rest _:c14n378 .
-_:c14n38 sh:datatype xsd:boolean ;
+_:c14n378 rdf:first openlabel_v2:ParticulatesWater ;
+	rdf:rest rdf:nil .
+_:c14n379 rdf:first openlabel_v2:ParticulatesMarine ;
+	rdf:rest _:c14n376 .
+_:c14n38 sh:datatype xsd:string ;
+	sh:description "An optional free-text comment for the scenario." ;
+	sh:maxCount 1 ;
+	sh:nodeKind sh:Literal ;
+	sh:order 13 ;
+	sh:path openlabel_v2:scenarioComment .
+_:c14n380 rdf:first openlabel_v2:ParticulatesDust ;
+	rdf:rest _:c14n379 .
+_:c14n381 rdf:first openlabel_v2:WarningSignsVariableFullTime ;
+	rdf:rest _:c14n382 .
+_:c14n382 rdf:first openlabel_v2:WarningSignsVariableTemporary ;
+	rdf:rest rdf:nil .
+_:c14n383 rdf:first openlabel_v2:WarningSignsUniformTemporary ;
+	rdf:rest _:c14n381 .
+_:c14n384 rdf:first openlabel_v2:WarningSignsUniformFullTime ;
+	rdf:rest _:c14n383 .
+_:c14n385 rdf:first openlabel_v2:WarningSignsUniform ;
+	rdf:rest _:c14n384 .
+_:c14n386 rdf:first openlabel_v2:WarningSignsVariableFullTime ;
+	rdf:rest _:c14n387 .
+_:c14n387 rdf:first openlabel_v2:WarningSignsVariableTemporary ;
+	rdf:rest rdf:nil .
+_:c14n388 rdf:first openlabel_v2:WarningSignsUniformTemporary ;
+	rdf:rest _:c14n386 .
+_:c14n389 rdf:first openlabel_v2:WarningSignsUniformFullTime ;
+	rdf:rest _:c14n388 .
+_:c14n39 sh:datatype xsd:boolean ;
 	sh:description "Down-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.ii." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 28 ;
 	sh:path openlabel_v2:LongitudinalDownSlope .
-_:c14n380 rdf:first openlabel_v2:WarningSignsVariableFullTime ;
-	rdf:rest _:c14n381 .
-_:c14n381 rdf:first openlabel_v2:WarningSignsVariableTemporary ;
-	rdf:rest rdf:nil .
-_:c14n382 rdf:first openlabel_v2:WarningSignsUniformTemporary ;
-	rdf:rest _:c14n380 .
-_:c14n383 rdf:first openlabel_v2:WarningSignsUniformFullTime ;
-	rdf:rest _:c14n382 .
-_:c14n384 rdf:first openlabel_v2:WarningSignsUniform ;
-	rdf:rest _:c14n383 .
-_:c14n385 rdf:first openlabel_v2:WarningSignsVariableFullTime ;
-	rdf:rest _:c14n386 .
-_:c14n386 rdf:first openlabel_v2:WarningSignsVariableTemporary ;
-	rdf:rest rdf:nil .
-_:c14n387 rdf:first openlabel_v2:WarningSignsUniformTemporary ;
-	rdf:rest _:c14n385 .
-_:c14n388 rdf:first openlabel_v2:WarningSignsUniformFullTime ;
-	rdf:rest _:c14n387 .
-_:c14n389 rdf:first openlabel_v2:WarningSignsUniform ;
-	rdf:rest _:c14n388 .
-_:c14n39 rdf:first rdf:type ;
-	rdf:rest rdf:nil .
-_:c14n390 rdf:first openlabel_v2:WarningSignsVariableFullTime ;
-	rdf:rest _:c14n391 .
-_:c14n391 rdf:first openlabel_v2:WarningSignsVariableTemporary ;
-	rdf:rest rdf:nil .
-_:c14n392 rdf:first openlabel_v2:WarningSignsUniformTemporary ;
-	rdf:rest _:c14n390 .
-_:c14n393 rdf:first openlabel_v2:WarningSignsUniformFullTime ;
+_:c14n390 rdf:first openlabel_v2:WarningSignsUniform ;
+	rdf:rest _:c14n389 .
+_:c14n391 rdf:first openlabel_v2:WarningSignsVariableFullTime ;
 	rdf:rest _:c14n392 .
-_:c14n394 rdf:first openlabel_v2:WarningSignsUniform ;
-	rdf:rest _:c14n393 .
-_:c14n395 rdf:first openlabel_v2:WarningSignsVariableFullTime ;
-	rdf:rest _:c14n396 .
-_:c14n396 rdf:first openlabel_v2:WarningSignsVariableTemporary ;
+_:c14n392 rdf:first openlabel_v2:WarningSignsVariableTemporary ;
 	rdf:rest rdf:nil .
-_:c14n397 rdf:first openlabel_v2:WarningSignsUniformTemporary ;
-	rdf:rest _:c14n395 .
-_:c14n398 rdf:first openlabel_v2:WarningSignsUniformFullTime ;
+_:c14n393 rdf:first openlabel_v2:WarningSignsUniformTemporary ;
+	rdf:rest _:c14n391 .
+_:c14n394 rdf:first openlabel_v2:WarningSignsUniformFullTime ;
+	rdf:rest _:c14n393 .
+_:c14n395 rdf:first openlabel_v2:WarningSignsUniform ;
+	rdf:rest _:c14n394 .
+_:c14n396 rdf:first openlabel_v2:WarningSignsVariableFullTime ;
 	rdf:rest _:c14n397 .
-_:c14n399 rdf:first openlabel_v2:WarningSignsUniform ;
+_:c14n397 rdf:first openlabel_v2:WarningSignsVariableTemporary ;
+	rdf:rest rdf:nil .
+_:c14n398 rdf:first openlabel_v2:WarningSignsUniformTemporary ;
+	rdf:rest _:c14n396 .
+_:c14n399 rdf:first openlabel_v2:WarningSignsUniformFullTime ;
 	rdf:rest _:c14n398 .
 _:c14n4 sh:datatype xsd:string ;
 	sh:description "The type of license which governs usage of the scenario." ;
@@ -1543,1426 +1551,1424 @@ _:c14n4 sh:datatype xsd:string ;
 	sh:nodeKind sh:Literal ;
 	sh:order 0 ;
 	sh:path openlabel_v2:licenseURI .
-_:c14n40 sh:datatype xsd:boolean ;
+_:c14n40 rdf:first rdf:type ;
+	rdf:rest rdf:nil .
+_:c14n400 rdf:first openlabel_v2:WarningSignsUniform ;
+	rdf:rest _:c14n399 .
+_:c14n401 rdf:first openlabel_v2:VehicleCycle ;
+	rdf:rest _:c14n402 .
+_:c14n402 rdf:first openlabel_v2:VehicleEmergency ;
+	rdf:rest _:c14n403 .
+_:c14n403 rdf:first openlabel_v2:VehicleMotorcycle ;
+	rdf:rest _:c14n404 .
+_:c14n404 rdf:first openlabel_v2:VehicleTrailer ;
+	rdf:rest _:c14n405 .
+_:c14n405 rdf:first openlabel_v2:VehicleTruck ;
+	rdf:rest _:c14n406 .
+_:c14n406 rdf:first openlabel_v2:VehicleVan ;
+	rdf:rest _:c14n407 .
+_:c14n407 rdf:first openlabel_v2:VehicleWheelchair ;
+	rdf:rest rdf:nil .
+_:c14n408 rdf:first openlabel_v2:VehicleConstruction ;
+	rdf:rest _:c14n401 .
+_:c14n409 rdf:first openlabel_v2:VehicleCar ;
+	rdf:rest _:c14n408 .
+_:c14n41 sh:datatype xsd:boolean ;
 	sh:description "An activity where the road user decreases their velocity." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 7 ;
 	sh:path openlabel_v2:MotionDecelerate .
-_:c14n400 rdf:first openlabel_v2:VehicleCycle ;
-	rdf:rest _:c14n401 .
-_:c14n401 rdf:first openlabel_v2:VehicleEmergency ;
-	rdf:rest _:c14n402 .
-_:c14n402 rdf:first openlabel_v2:VehicleMotorcycle ;
-	rdf:rest _:c14n403 .
-_:c14n403 rdf:first openlabel_v2:VehicleTrailer ;
-	rdf:rest _:c14n404 .
-_:c14n404 rdf:first openlabel_v2:VehicleTruck ;
-	rdf:rest _:c14n405 .
-_:c14n405 rdf:first openlabel_v2:VehicleVan ;
-	rdf:rest _:c14n406 .
-_:c14n406 rdf:first openlabel_v2:VehicleWheelchair ;
+_:c14n410 rdf:first openlabel_v2:VehicleBus ;
+	rdf:rest _:c14n409 .
+_:c14n411 rdf:first openlabel_v2:VehicleAgricultural ;
+	rdf:rest _:c14n410 .
+_:c14n412 sh:in _:c14n411 .
+_:c14n413 rdf:first _:c14n412 ;
 	rdf:rest rdf:nil .
-_:c14n407 rdf:first openlabel_v2:VehicleConstruction ;
-	rdf:rest _:c14n400 .
-_:c14n408 rdf:first openlabel_v2:VehicleCar ;
-	rdf:rest _:c14n407 .
-_:c14n409 rdf:first openlabel_v2:VehicleBus ;
-	rdf:rest _:c14n408 .
-_:c14n41 sh:description "Warning sign type. Refer to BSI PAS-1883 Section 5.2.3.5.c." ;
-	sh:in _:c14n384 ;
+_:c14n414 rdf:first _:c14n415 ;
+	rdf:rest _:c14n413 .
+_:c14n415 sh:in _:c14n416 .
+_:c14n416 rdf:first openlabel_v2:HumanAnimalRider ;
+	rdf:rest _:c14n417 .
+_:c14n417 rdf:first openlabel_v2:HumanCyclist ;
+	rdf:rest _:c14n418 .
+_:c14n418 rdf:first openlabel_v2:HumanDriver ;
+	rdf:rest _:c14n419 .
+_:c14n419 rdf:first openlabel_v2:HumanMotorcyclist ;
+	rdf:rest _:c14n420 .
+_:c14n42 sh:description "Warning sign type. Refer to BSI PAS-1883 Section 5.2.3.5.c." ;
+	sh:in _:c14n390 ;
 	sh:maxCount 1 ;
 	sh:order 46 ;
 	sh:path openlabel_v2:SignsWarning .
-_:c14n410 rdf:first openlabel_v2:VehicleAgricultural ;
-	rdf:rest _:c14n409 .
-_:c14n411 sh:in _:c14n410 .
-_:c14n412 rdf:first _:c14n411 ;
+_:c14n420 rdf:first openlabel_v2:HumanPassenger ;
+	rdf:rest _:c14n421 .
+_:c14n421 rdf:first openlabel_v2:HumanPedestrian ;
+	rdf:rest _:c14n422 .
+_:c14n422 rdf:first openlabel_v2:HumanWheelchairUser ;
 	rdf:rest rdf:nil .
-_:c14n413 rdf:first _:c14n414 ;
-	rdf:rest _:c14n412 .
-_:c14n414 sh:in _:c14n415 .
-_:c14n415 rdf:first openlabel_v2:HumanAnimalRider ;
-	rdf:rest _:c14n416 .
-_:c14n416 rdf:first openlabel_v2:HumanCyclist ;
-	rdf:rest _:c14n417 .
-_:c14n417 rdf:first openlabel_v2:HumanDriver ;
-	rdf:rest _:c14n418 .
-_:c14n418 rdf:first openlabel_v2:HumanMotorcyclist ;
-	rdf:rest _:c14n419 .
-_:c14n419 rdf:first openlabel_v2:HumanPassenger ;
-	rdf:rest _:c14n420 .
-_:c14n42 sh:description "Rate of deceleration (ms-2)." ;
+_:c14n423 rdf:first openlabel_v2:VehicleCycle ;
+	rdf:rest _:c14n424 .
+_:c14n424 rdf:first openlabel_v2:VehicleEmergency ;
+	rdf:rest _:c14n425 .
+_:c14n425 rdf:first openlabel_v2:VehicleMotorcycle ;
+	rdf:rest _:c14n426 .
+_:c14n426 rdf:first openlabel_v2:VehicleTrailer ;
+	rdf:rest _:c14n427 .
+_:c14n427 rdf:first openlabel_v2:VehicleTruck ;
+	rdf:rest _:c14n428 .
+_:c14n428 rdf:first openlabel_v2:VehicleVan ;
+	rdf:rest _:c14n429 .
+_:c14n429 rdf:first openlabel_v2:VehicleWheelchair ;
+	rdf:rest rdf:nil .
+_:c14n43 sh:description "Rate of deceleration (ms-2)." ;
 	sh:maxCount 1 ;
-	sh:or _:c14n548 ;
+	sh:or _:c14n557 ;
 	sh:order 8 ;
 	sh:path openlabel_v2:motionDecelerateValue .
-_:c14n420 rdf:first openlabel_v2:HumanPedestrian ;
-	rdf:rest _:c14n421 .
-_:c14n421 rdf:first openlabel_v2:HumanWheelchairUser ;
-	rdf:rest rdf:nil .
-_:c14n422 rdf:first openlabel_v2:VehicleCycle ;
+_:c14n430 rdf:first openlabel_v2:VehicleConstruction ;
 	rdf:rest _:c14n423 .
-_:c14n423 rdf:first openlabel_v2:VehicleEmergency ;
-	rdf:rest _:c14n424 .
-_:c14n424 rdf:first openlabel_v2:VehicleMotorcycle ;
-	rdf:rest _:c14n425 .
-_:c14n425 rdf:first openlabel_v2:VehicleTrailer ;
-	rdf:rest _:c14n426 .
-_:c14n426 rdf:first openlabel_v2:VehicleTruck ;
-	rdf:rest _:c14n427 .
-_:c14n427 rdf:first openlabel_v2:VehicleVan ;
-	rdf:rest _:c14n428 .
-_:c14n428 rdf:first openlabel_v2:VehicleWheelchair ;
+_:c14n431 rdf:first openlabel_v2:VehicleCar ;
+	rdf:rest _:c14n430 .
+_:c14n432 rdf:first openlabel_v2:VehicleBus ;
+	rdf:rest _:c14n431 .
+_:c14n433 rdf:first openlabel_v2:VehicleAgricultural ;
+	rdf:rest _:c14n432 .
+_:c14n434 sh:in _:c14n433 .
+_:c14n435 rdf:first _:c14n434 ;
 	rdf:rest rdf:nil .
-_:c14n429 rdf:first openlabel_v2:VehicleConstruction ;
-	rdf:rest _:c14n422 .
-_:c14n43 sh:datatype xsd:decimal ;
+_:c14n436 rdf:first _:c14n437 ;
+	rdf:rest _:c14n435 .
+_:c14n437 sh:in _:c14n438 .
+_:c14n438 rdf:first openlabel_v2:HumanAnimalRider ;
+	rdf:rest _:c14n439 .
+_:c14n439 rdf:first openlabel_v2:HumanCyclist ;
+	rdf:rest _:c14n440 .
+_:c14n44 sh:datatype xsd:decimal ;
 	sh:description "Visibility (km). Refer to BSI PAS-1883 Section 5.3.1.3." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 61 ;
 	sh:path openlabel_v2:weatherSnowValue .
-_:c14n430 rdf:first openlabel_v2:VehicleCar ;
-	rdf:rest _:c14n429 .
-_:c14n431 rdf:first openlabel_v2:VehicleBus ;
-	rdf:rest _:c14n430 .
-_:c14n432 rdf:first openlabel_v2:VehicleAgricultural ;
-	rdf:rest _:c14n431 .
-_:c14n433 sh:in _:c14n432 .
-_:c14n434 rdf:first _:c14n433 ;
+_:c14n440 rdf:first openlabel_v2:HumanDriver ;
+	rdf:rest _:c14n441 .
+_:c14n441 rdf:first openlabel_v2:HumanMotorcyclist ;
+	rdf:rest _:c14n442 .
+_:c14n442 rdf:first openlabel_v2:HumanPassenger ;
+	rdf:rest _:c14n443 .
+_:c14n443 rdf:first openlabel_v2:HumanPedestrian ;
+	rdf:rest _:c14n444 .
+_:c14n444 rdf:first openlabel_v2:HumanWheelchairUser ;
 	rdf:rest rdf:nil .
-_:c14n435 rdf:first _:c14n436 ;
-	rdf:rest _:c14n434 .
-_:c14n436 sh:in _:c14n437 .
-_:c14n437 rdf:first openlabel_v2:HumanAnimalRider ;
-	rdf:rest _:c14n438 .
-_:c14n438 rdf:first openlabel_v2:HumanCyclist ;
-	rdf:rest _:c14n439 .
-_:c14n439 rdf:first openlabel_v2:HumanDriver ;
-	rdf:rest _:c14n440 .
-_:c14n44 sh:description "Zone type. Refer to BSI PAS-1883 Section 5.2.1.a." ;
-	sh:in _:c14n793 ;
+_:c14n445 rdf:first openlabel_v2:VehicleCycle ;
+	rdf:rest _:c14n446 .
+_:c14n446 rdf:first openlabel_v2:VehicleEmergency ;
+	rdf:rest _:c14n447 .
+_:c14n447 rdf:first openlabel_v2:VehicleMotorcycle ;
+	rdf:rest _:c14n448 .
+_:c14n448 rdf:first openlabel_v2:VehicleTrailer ;
+	rdf:rest _:c14n449 .
+_:c14n449 rdf:first openlabel_v2:VehicleTruck ;
+	rdf:rest _:c14n450 .
+_:c14n45 sh:description "Zone type. Refer to BSI PAS-1883 Section 5.2.1.a." ;
+	sh:in _:c14n809 ;
 	sh:maxCount 1 ;
 	sh:order 43 ;
 	sh:path openlabel_v2:SceneryZone .
-_:c14n440 rdf:first openlabel_v2:HumanMotorcyclist ;
-	rdf:rest _:c14n441 .
-_:c14n441 rdf:first openlabel_v2:HumanPassenger ;
-	rdf:rest _:c14n442 .
-_:c14n442 rdf:first openlabel_v2:HumanPedestrian ;
-	rdf:rest _:c14n443 .
-_:c14n443 rdf:first openlabel_v2:HumanWheelchairUser ;
+_:c14n450 rdf:first openlabel_v2:VehicleVan ;
+	rdf:rest _:c14n451 .
+_:c14n451 rdf:first openlabel_v2:VehicleWheelchair ;
 	rdf:rest rdf:nil .
-_:c14n444 rdf:first openlabel_v2:VehicleCycle ;
+_:c14n452 rdf:first openlabel_v2:VehicleConstruction ;
 	rdf:rest _:c14n445 .
-_:c14n445 rdf:first openlabel_v2:VehicleEmergency ;
-	rdf:rest _:c14n446 .
-_:c14n446 rdf:first openlabel_v2:VehicleMotorcycle ;
-	rdf:rest _:c14n447 .
-_:c14n447 rdf:first openlabel_v2:VehicleTrailer ;
-	rdf:rest _:c14n448 .
-_:c14n448 rdf:first openlabel_v2:VehicleTruck ;
-	rdf:rest _:c14n449 .
-_:c14n449 rdf:first openlabel_v2:VehicleVan ;
-	rdf:rest _:c14n450 .
-_:c14n45 sh:datatype xsd:boolean ;
+_:c14n453 rdf:first openlabel_v2:VehicleCar ;
+	rdf:rest _:c14n452 .
+_:c14n454 rdf:first openlabel_v2:VehicleBus ;
+	rdf:rest _:c14n453 .
+_:c14n455 rdf:first openlabel_v2:VehicleAgricultural ;
+	rdf:rest _:c14n454 .
+_:c14n456 sh:in _:c14n455 .
+_:c14n457 rdf:first _:c14n456 ;
+	rdf:rest rdf:nil .
+_:c14n458 rdf:first _:c14n459 ;
+	rdf:rest _:c14n457 .
+_:c14n459 sh:in _:c14n460 .
+_:c14n46 sh:datatype xsd:boolean ;
 	sh:description "Cloudiness flag. Refer to BSI PAS-1883 Section 5.3.3.c." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 16 ;
 	sh:path openlabel_v2:IlluminationCloudiness .
-_:c14n450 rdf:first openlabel_v2:VehicleWheelchair ;
+_:c14n460 rdf:first openlabel_v2:HumanAnimalRider ;
+	rdf:rest _:c14n461 .
+_:c14n461 rdf:first openlabel_v2:HumanCyclist ;
+	rdf:rest _:c14n462 .
+_:c14n462 rdf:first openlabel_v2:HumanDriver ;
+	rdf:rest _:c14n463 .
+_:c14n463 rdf:first openlabel_v2:HumanMotorcyclist ;
+	rdf:rest _:c14n464 .
+_:c14n464 rdf:first openlabel_v2:HumanPassenger ;
+	rdf:rest _:c14n465 .
+_:c14n465 rdf:first openlabel_v2:HumanPedestrian ;
+	rdf:rest _:c14n466 .
+_:c14n466 rdf:first openlabel_v2:HumanWheelchairUser ;
 	rdf:rest rdf:nil .
-_:c14n451 rdf:first openlabel_v2:VehicleConstruction ;
-	rdf:rest _:c14n444 .
-_:c14n452 rdf:first openlabel_v2:VehicleCar ;
-	rdf:rest _:c14n451 .
-_:c14n453 rdf:first openlabel_v2:VehicleBus ;
-	rdf:rest _:c14n452 .
-_:c14n454 rdf:first openlabel_v2:VehicleAgricultural ;
-	rdf:rest _:c14n453 .
-_:c14n455 rdf:first openlabel_v2:VehicleCycle ;
-	rdf:rest _:c14n456 .
-_:c14n456 rdf:first openlabel_v2:VehicleEmergency ;
-	rdf:rest _:c14n457 .
-_:c14n457 rdf:first openlabel_v2:VehicleMotorcycle ;
-	rdf:rest _:c14n458 .
-_:c14n458 rdf:first openlabel_v2:VehicleTrailer ;
-	rdf:rest _:c14n459 .
-_:c14n459 rdf:first openlabel_v2:VehicleTruck ;
-	rdf:rest _:c14n460 .
-_:c14n46 sh:description "Temporary road structure. Refer to BSI PAS-1883 Section 5.2.1.f." ;
-	sh:in _:c14n882 ;
+_:c14n467 rdf:first openlabel_v2:VehicleCycle ;
+	rdf:rest _:c14n468 .
+_:c14n468 rdf:first openlabel_v2:VehicleEmergency ;
+	rdf:rest _:c14n469 .
+_:c14n469 rdf:first openlabel_v2:VehicleMotorcycle ;
+	rdf:rest _:c14n470 .
+_:c14n47 sh:description "Temporary road structure. Refer to BSI PAS-1883 Section 5.2.1.f." ;
+	sh:in _:c14n887 ;
 	sh:order 42 ;
 	sh:path openlabel_v2:SceneryTemporaryStructure .
-_:c14n460 rdf:first openlabel_v2:VehicleVan ;
-	rdf:rest _:c14n461 .
-_:c14n461 rdf:first openlabel_v2:VehicleWheelchair ;
+_:c14n470 rdf:first openlabel_v2:VehicleTrailer ;
+	rdf:rest _:c14n471 .
+_:c14n471 rdf:first openlabel_v2:VehicleTruck ;
+	rdf:rest _:c14n472 .
+_:c14n472 rdf:first openlabel_v2:VehicleVan ;
+	rdf:rest _:c14n473 .
+_:c14n473 rdf:first openlabel_v2:VehicleWheelchair ;
 	rdf:rest rdf:nil .
-_:c14n462 rdf:first openlabel_v2:VehicleConstruction ;
-	rdf:rest _:c14n455 .
-_:c14n463 rdf:first openlabel_v2:VehicleCar ;
-	rdf:rest _:c14n462 .
-_:c14n464 rdf:first openlabel_v2:VehicleBus ;
-	rdf:rest _:c14n463 .
-_:c14n465 rdf:first openlabel_v2:VehicleAgricultural ;
-	rdf:rest _:c14n464 .
-_:c14n466 sh:in _:c14n465 .
-_:c14n467 rdf:first _:c14n466 ;
-	rdf:rest rdf:nil .
-_:c14n468 rdf:first _:c14n469 ;
+_:c14n474 rdf:first openlabel_v2:VehicleConstruction ;
 	rdf:rest _:c14n467 .
-_:c14n469 sh:in _:c14n470 .
-_:c14n47 sh:datatype xsd:decimal ;
+_:c14n475 rdf:first openlabel_v2:VehicleCar ;
+	rdf:rest _:c14n474 .
+_:c14n476 rdf:first openlabel_v2:VehicleBus ;
+	rdf:rest _:c14n475 .
+_:c14n477 rdf:first openlabel_v2:VehicleAgricultural ;
+	rdf:rest _:c14n476 .
+_:c14n478 rdf:first openlabel_v2:VehicleCycle ;
+	rdf:rest _:c14n479 .
+_:c14n479 rdf:first openlabel_v2:VehicleEmergency ;
+	rdf:rest _:c14n480 .
+_:c14n48 sh:datatype xsd:decimal ;
 	sh:description "Curve radius (m). Refer to BSI PAS-1883 Section 5.2.3.3." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 13 ;
 	sh:path openlabel_v2:horizontalCurvesValue .
-_:c14n470 rdf:first openlabel_v2:HumanAnimalRider ;
-	rdf:rest _:c14n471 .
-_:c14n471 rdf:first openlabel_v2:HumanCyclist ;
-	rdf:rest _:c14n472 .
-_:c14n472 rdf:first openlabel_v2:HumanDriver ;
-	rdf:rest _:c14n473 .
-_:c14n473 rdf:first openlabel_v2:HumanMotorcyclist ;
-	rdf:rest _:c14n474 .
-_:c14n474 rdf:first openlabel_v2:HumanPassenger ;
-	rdf:rest _:c14n475 .
-_:c14n475 rdf:first openlabel_v2:HumanPedestrian ;
-	rdf:rest _:c14n476 .
-_:c14n476 rdf:first openlabel_v2:HumanWheelchairUser ;
+_:c14n480 rdf:first openlabel_v2:VehicleMotorcycle ;
+	rdf:rest _:c14n481 .
+_:c14n481 rdf:first openlabel_v2:VehicleTrailer ;
+	rdf:rest _:c14n482 .
+_:c14n482 rdf:first openlabel_v2:VehicleTruck ;
+	rdf:rest _:c14n483 .
+_:c14n483 rdf:first openlabel_v2:VehicleVan ;
+	rdf:rest _:c14n484 .
+_:c14n484 rdf:first openlabel_v2:VehicleWheelchair ;
 	rdf:rest rdf:nil .
-_:c14n477 rdf:first openlabel_v2:VehicleCycle ;
+_:c14n485 rdf:first openlabel_v2:VehicleConstruction ;
 	rdf:rest _:c14n478 .
-_:c14n478 rdf:first openlabel_v2:VehicleEmergency ;
-	rdf:rest _:c14n479 .
-_:c14n479 rdf:first openlabel_v2:VehicleMotorcycle ;
-	rdf:rest _:c14n480 .
-_:c14n48 sh:description "Warning sign type. Refer to BSI PAS-1883 Section 5.2.3.5.c." ;
-	sh:in _:c14n394 ;
+_:c14n486 rdf:first openlabel_v2:VehicleCar ;
+	rdf:rest _:c14n485 .
+_:c14n487 rdf:first openlabel_v2:VehicleBus ;
+	rdf:rest _:c14n486 .
+_:c14n488 rdf:first openlabel_v2:VehicleAgricultural ;
+	rdf:rest _:c14n487 .
+_:c14n489 sh:in _:c14n488 .
+_:c14n49 sh:description "Warning sign type. Refer to BSI PAS-1883 Section 5.2.3.5.c." ;
+	sh:in _:c14n395 ;
 	sh:order 46 ;
 	sh:path openlabel_v2:SignsWarning .
-_:c14n480 rdf:first openlabel_v2:VehicleTrailer ;
-	rdf:rest _:c14n481 .
-_:c14n481 rdf:first openlabel_v2:VehicleTruck ;
-	rdf:rest _:c14n482 .
-_:c14n482 rdf:first openlabel_v2:VehicleVan ;
-	rdf:rest _:c14n483 .
-_:c14n483 rdf:first openlabel_v2:VehicleWheelchair ;
+_:c14n490 rdf:first _:c14n489 ;
 	rdf:rest rdf:nil .
-_:c14n484 rdf:first openlabel_v2:VehicleConstruction ;
-	rdf:rest _:c14n477 .
-_:c14n485 rdf:first openlabel_v2:VehicleCar ;
-	rdf:rest _:c14n484 .
-_:c14n486 rdf:first openlabel_v2:VehicleBus ;
-	rdf:rest _:c14n485 .
-_:c14n487 rdf:first openlabel_v2:VehicleAgricultural ;
-	rdf:rest _:c14n486 .
-_:c14n488 sh:in _:c14n487 .
-_:c14n489 rdf:first _:c14n488 ;
-	rdf:rest rdf:nil .
-_:c14n49 sh:description "Road type. Refer to BSI PAS-1883 Section 5.2.3.2." ;
-	sh:in _:c14n769 ;
-	sh:order 9 ;
-	sh:path openlabel_v2:DrivableAreaType .
-_:c14n490 rdf:first _:c14n491 ;
-	rdf:rest _:c14n489 .
-_:c14n491 sh:in _:c14n492 .
-_:c14n492 rdf:first openlabel_v2:HumanAnimalRider ;
-	rdf:rest _:c14n493 .
-_:c14n493 rdf:first openlabel_v2:HumanCyclist ;
+_:c14n491 rdf:first _:c14n492 ;
+	rdf:rest _:c14n490 .
+_:c14n492 sh:in _:c14n493 .
+_:c14n493 rdf:first openlabel_v2:HumanAnimalRider ;
 	rdf:rest _:c14n494 .
-_:c14n494 rdf:first openlabel_v2:HumanDriver ;
+_:c14n494 rdf:first openlabel_v2:HumanCyclist ;
 	rdf:rest _:c14n495 .
-_:c14n495 rdf:first openlabel_v2:HumanMotorcyclist ;
+_:c14n495 rdf:first openlabel_v2:HumanDriver ;
 	rdf:rest _:c14n496 .
-_:c14n496 rdf:first openlabel_v2:HumanPassenger ;
+_:c14n496 rdf:first openlabel_v2:HumanMotorcyclist ;
 	rdf:rest _:c14n497 .
-_:c14n497 rdf:first openlabel_v2:HumanPedestrian ;
+_:c14n497 rdf:first openlabel_v2:HumanPassenger ;
 	rdf:rest _:c14n498 .
-_:c14n498 rdf:first openlabel_v2:HumanWheelchairUser ;
-	rdf:rest rdf:nil .
-_:c14n499 rdf:first openlabel_v2:V2vWifi ;
+_:c14n498 rdf:first openlabel_v2:HumanPedestrian ;
+	rdf:rest _:c14n499 .
+_:c14n499 rdf:first openlabel_v2:HumanWheelchairUser ;
 	rdf:rest rdf:nil .
 _:c14n5 sh:datatype xsd:boolean ;
 	sh:description "Marine (coastal areas only) flag. Refer to BSI PAS-1883 Section 5.3.2.a." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 34 ;
 	sh:path openlabel_v2:ParticulatesMarine .
-_:c14n50 sh:datatype xsd:decimal ;
+_:c14n50 sh:description "Road type. Refer to BSI PAS-1883 Section 5.2.3.2." ;
+	sh:in _:c14n752 ;
+	sh:order 9 ;
+	sh:path openlabel_v2:DrivableAreaType .
+_:c14n500 rdf:first openlabel_v2:V2vWifi ;
+	rdf:rest rdf:nil .
+_:c14n501 rdf:first openlabel_v2:V2vSatellite ;
+	rdf:rest _:c14n500 .
+_:c14n502 rdf:first openlabel_v2:V2vCellular ;
+	rdf:rest _:c14n501 .
+_:c14n503 rdf:first openlabel_v2:CommunicationV2v ;
+	rdf:rest _:c14n502 .
+_:c14n504 rdf:first openlabel_v2:V2iWifi ;
+	rdf:rest _:c14n503 .
+_:c14n505 rdf:first openlabel_v2:V2iSatellite ;
+	rdf:rest _:c14n504 .
+_:c14n506 rdf:first openlabel_v2:V2iCellular ;
+	rdf:rest _:c14n505 .
+_:c14n507 rdf:first openlabel_v2:CommunicationV2i ;
+	rdf:rest _:c14n506 .
+_:c14n508 rdf:first openlabel_v2:V2vWifi ;
+	rdf:rest rdf:nil .
+_:c14n509 rdf:first openlabel_v2:V2vSatellite ;
+	rdf:rest _:c14n508 .
+_:c14n51 sh:datatype xsd:decimal ;
 	sh:description "Cloud cover (okta). Refer to BSI PAS-1883 Section 5.3.3.c." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 17 ;
 	sh:path openlabel_v2:illuminationCloudinessValue .
-_:c14n500 rdf:first openlabel_v2:V2vSatellite ;
-	rdf:rest _:c14n499 .
-_:c14n501 rdf:first openlabel_v2:V2vCellular ;
-	rdf:rest _:c14n500 .
-_:c14n502 rdf:first openlabel_v2:CommunicationV2v ;
-	rdf:rest _:c14n501 .
-_:c14n503 rdf:first openlabel_v2:V2iWifi ;
-	rdf:rest _:c14n502 .
-_:c14n504 rdf:first openlabel_v2:V2iSatellite ;
-	rdf:rest _:c14n503 .
-_:c14n505 rdf:first openlabel_v2:V2iCellular ;
-	rdf:rest _:c14n504 .
-_:c14n506 rdf:first openlabel_v2:CommunicationV2i ;
-	rdf:rest _:c14n505 .
-_:c14n507 rdf:first openlabel_v2:V2vWifi ;
+_:c14n510 rdf:first openlabel_v2:V2vCellular ;
+	rdf:rest _:c14n509 .
+_:c14n511 rdf:first openlabel_v2:CommunicationV2v ;
+	rdf:rest _:c14n510 .
+_:c14n512 rdf:first openlabel_v2:V2iWifi ;
+	rdf:rest _:c14n511 .
+_:c14n513 rdf:first openlabel_v2:V2iSatellite ;
+	rdf:rest _:c14n512 .
+_:c14n514 rdf:first openlabel_v2:V2iCellular ;
+	rdf:rest _:c14n513 .
+_:c14n515 rdf:first openlabel_v2:CommunicationV2i ;
+	rdf:rest _:c14n514 .
+_:c14n516 rdf:first openlabel_v2:V2vWifi ;
 	rdf:rest rdf:nil .
-_:c14n508 rdf:first openlabel_v2:V2vSatellite ;
-	rdf:rest _:c14n507 .
-_:c14n509 rdf:first openlabel_v2:V2vCellular ;
-	rdf:rest _:c14n508 .
-_:c14n51 sh:description "Road type. Refer to BSI PAS-1883 Section 5.2.3.2." ;
-	sh:in _:c14n742 ;
+_:c14n517 rdf:first openlabel_v2:V2vSatellite ;
+	rdf:rest _:c14n516 .
+_:c14n518 rdf:first openlabel_v2:V2vCellular ;
+	rdf:rest _:c14n517 .
+_:c14n519 rdf:first openlabel_v2:CommunicationV2v ;
+	rdf:rest _:c14n518 .
+_:c14n52 sh:description "Road type. Refer to BSI PAS-1883 Section 5.2.3.2." ;
+	sh:in _:c14n761 ;
 	sh:maxCount 1 ;
 	sh:order 9 ;
 	sh:path openlabel_v2:DrivableAreaType .
-_:c14n510 rdf:first openlabel_v2:CommunicationV2v ;
-	rdf:rest _:c14n509 .
-_:c14n511 rdf:first openlabel_v2:V2iWifi ;
-	rdf:rest _:c14n510 .
-_:c14n512 rdf:first openlabel_v2:V2iSatellite ;
-	rdf:rest _:c14n511 .
-_:c14n513 rdf:first openlabel_v2:V2iCellular ;
-	rdf:rest _:c14n512 .
-_:c14n514 rdf:first openlabel_v2:CommunicationV2i ;
-	rdf:rest _:c14n513 .
-_:c14n515 rdf:first openlabel_v2:V2vWifi ;
+_:c14n520 rdf:first openlabel_v2:V2iWifi ;
+	rdf:rest _:c14n519 .
+_:c14n521 rdf:first openlabel_v2:V2iSatellite ;
+	rdf:rest _:c14n520 .
+_:c14n522 rdf:first openlabel_v2:V2iCellular ;
+	rdf:rest _:c14n521 .
+_:c14n523 rdf:first openlabel_v2:CommunicationV2i ;
+	rdf:rest _:c14n522 .
+_:c14n524 rdf:first openlabel_v2:V2vWifi ;
 	rdf:rest rdf:nil .
-_:c14n516 rdf:first openlabel_v2:V2vSatellite ;
-	rdf:rest _:c14n515 .
-_:c14n517 rdf:first openlabel_v2:V2vCellular ;
-	rdf:rest _:c14n516 .
-_:c14n518 rdf:first openlabel_v2:CommunicationV2v ;
-	rdf:rest _:c14n517 .
-_:c14n519 rdf:first openlabel_v2:V2iWifi ;
-	rdf:rest _:c14n518 .
-_:c14n52 sh:datatype xsd:dateTime ;
+_:c14n525 rdf:first openlabel_v2:V2vSatellite ;
+	rdf:rest _:c14n524 .
+_:c14n526 rdf:first openlabel_v2:V2vCellular ;
+	rdf:rest _:c14n525 .
+_:c14n527 rdf:first openlabel_v2:CommunicationV2v ;
+	rdf:rest _:c14n526 .
+_:c14n528 rdf:first openlabel_v2:V2iWifi ;
+	rdf:rest _:c14n527 .
+_:c14n529 rdf:first openlabel_v2:V2iSatellite ;
+	rdf:rest _:c14n528 .
+_:c14n53 sh:datatype xsd:dateTime ;
 	sh:description "The date that the scenario was created/published." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 4 ;
 	sh:path openlabel_v2:scenarioCreatedDate .
-_:c14n520 rdf:first openlabel_v2:V2iSatellite ;
-	rdf:rest _:c14n519 .
-_:c14n521 rdf:first openlabel_v2:V2iCellular ;
-	rdf:rest _:c14n520 .
-_:c14n522 rdf:first openlabel_v2:CommunicationV2i ;
-	rdf:rest _:c14n521 .
-_:c14n523 rdf:first openlabel_v2:V2vWifi ;
+_:c14n530 rdf:first openlabel_v2:V2iCellular ;
+	rdf:rest _:c14n529 .
+_:c14n531 rdf:first openlabel_v2:CommunicationV2i ;
+	rdf:rest _:c14n530 .
+_:c14n532 rdf:first openlabel_v2:InformationSignsUniformTemporary ;
+	rdf:rest _:c14n533 .
+_:c14n533 rdf:first openlabel_v2:InformationSignsVariableFullTime ;
+	rdf:rest _:c14n534 .
+_:c14n534 rdf:first openlabel_v2:InformationSignsVariableTemporary ;
 	rdf:rest rdf:nil .
-_:c14n524 rdf:first openlabel_v2:V2vSatellite ;
-	rdf:rest _:c14n523 .
-_:c14n525 rdf:first openlabel_v2:V2vCellular ;
-	rdf:rest _:c14n524 .
-_:c14n526 rdf:first openlabel_v2:CommunicationV2v ;
-	rdf:rest _:c14n525 .
-_:c14n527 rdf:first openlabel_v2:V2iWifi ;
-	rdf:rest _:c14n526 .
-_:c14n528 rdf:first openlabel_v2:V2iSatellite ;
-	rdf:rest _:c14n527 .
-_:c14n529 rdf:first openlabel_v2:V2iCellular ;
-	rdf:rest _:c14n528 .
-_:c14n53 sh:datatype xsd:integer ;
+_:c14n535 rdf:first openlabel_v2:InformationSignsUniformFullTime ;
+	rdf:rest _:c14n532 .
+_:c14n536 rdf:first openlabel_v2:InformationSignsUniformTemporary ;
+	rdf:rest _:c14n537 .
+_:c14n537 rdf:first openlabel_v2:InformationSignsVariableFullTime ;
+	rdf:rest _:c14n538 .
+_:c14n538 rdf:first openlabel_v2:InformationSignsVariableTemporary ;
+	rdf:rest rdf:nil .
+_:c14n539 rdf:first openlabel_v2:InformationSignsUniformFullTime ;
+	rdf:rest _:c14n536 .
+_:c14n54 sh:datatype xsd:integer ;
 	sh:description "Density (vehicles/km). Refer to BSI PAS-1883 Section 5.4.a.1." ;
 	sh:maxCount 1 ;
 	sh:minInclusive 0 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 50 ;
 	sh:path openlabel_v2:trafficAgentDensityValue .
-_:c14n530 rdf:first openlabel_v2:CommunicationV2i ;
-	rdf:rest _:c14n529 .
-_:c14n531 rdf:first openlabel_v2:InformationSignsUniformTemporary ;
-	rdf:rest _:c14n532 .
-_:c14n532 rdf:first openlabel_v2:InformationSignsVariableFullTime ;
-	rdf:rest _:c14n533 .
-_:c14n533 rdf:first openlabel_v2:InformationSignsVariableTemporary ;
+_:c14n540 rdf:first openlabel_v2:InformationSignsUniformTemporary ;
+	rdf:rest _:c14n541 .
+_:c14n541 rdf:first openlabel_v2:InformationSignsVariableFullTime ;
+	rdf:rest _:c14n542 .
+_:c14n542 rdf:first openlabel_v2:InformationSignsVariableTemporary ;
 	rdf:rest rdf:nil .
-_:c14n534 rdf:first openlabel_v2:InformationSignsUniformFullTime ;
-	rdf:rest _:c14n531 .
-_:c14n535 rdf:first openlabel_v2:InformationSignsUniformTemporary ;
-	rdf:rest _:c14n536 .
-_:c14n536 rdf:first openlabel_v2:InformationSignsVariableFullTime ;
-	rdf:rest _:c14n537 .
-_:c14n537 rdf:first openlabel_v2:InformationSignsVariableTemporary ;
-	rdf:rest rdf:nil .
-_:c14n538 rdf:first openlabel_v2:InformationSignsUniformFullTime ;
-	rdf:rest _:c14n535 .
-_:c14n539 rdf:first openlabel_v2:InformationSignsUniformTemporary ;
+_:c14n543 rdf:first openlabel_v2:InformationSignsUniformFullTime ;
 	rdf:rest _:c14n540 .
-_:c14n54 sh:description "Rate of acceleration (ms-2)." ;
+_:c14n544 rdf:first openlabel_v2:InformationSignsUniformTemporary ;
+	rdf:rest _:c14n545 .
+_:c14n545 rdf:first openlabel_v2:InformationSignsVariableFullTime ;
+	rdf:rest _:c14n546 .
+_:c14n546 rdf:first openlabel_v2:InformationSignsVariableTemporary ;
+	rdf:rest rdf:nil .
+_:c14n547 rdf:first openlabel_v2:InformationSignsUniformFullTime ;
+	rdf:rest _:c14n544 .
+_:c14n548 sh:datatype xsd:decimal ;
+	sh:nodeKind sh:Literal .
+_:c14n549 rdf:first _:c14n548 ;
+	rdf:rest _:c14n550 .
+_:c14n55 sh:description "Rate of acceleration (ms-2)." ;
 	sh:maxCount 1 ;
-	sh:or _:c14n576 ;
+	sh:or _:c14n561 ;
 	sh:order 2 ;
 	sh:path openlabel_v2:motionAccelerateValue .
-_:c14n540 rdf:first openlabel_v2:InformationSignsVariableFullTime ;
-	rdf:rest _:c14n541 .
-_:c14n541 rdf:first openlabel_v2:InformationSignsVariableTemporary ;
+_:c14n550 rdf:first _:c14n551 ;
 	rdf:rest rdf:nil .
-_:c14n542 rdf:first openlabel_v2:InformationSignsUniformFullTime ;
-	rdf:rest _:c14n539 .
-_:c14n543 rdf:first openlabel_v2:InformationSignsUniformTemporary ;
-	rdf:rest _:c14n544 .
-_:c14n544 rdf:first openlabel_v2:InformationSignsVariableFullTime ;
-	rdf:rest _:c14n545 .
-_:c14n545 rdf:first openlabel_v2:InformationSignsVariableTemporary ;
-	rdf:rest rdf:nil .
-_:c14n546 rdf:first openlabel_v2:InformationSignsUniformFullTime ;
-	rdf:rest _:c14n543 .
-_:c14n547 sh:datatype xsd:decimal ;
+_:c14n551 sh:class sdo:QuantitativeValue .
+_:c14n552 sh:datatype xsd:decimal ;
 	sh:nodeKind sh:Literal .
-_:c14n548 rdf:first _:c14n547 ;
-	rdf:rest _:c14n549 .
-_:c14n549 rdf:first _:c14n550 ;
+_:c14n553 rdf:first _:c14n552 ;
+	rdf:rest _:c14n554 .
+_:c14n554 rdf:first _:c14n555 ;
 	rdf:rest rdf:nil .
-_:c14n55 sh:description "Artificial illumination type. Refer to BSI PAS-1883 Section 5.3.3.d." ;
-	sh:in _:c14n938 ;
+_:c14n555 sh:class sdo:QuantitativeValue .
+_:c14n556 sh:datatype xsd:decimal ;
+	sh:nodeKind sh:Literal .
+_:c14n557 rdf:first _:c14n556 ;
+	rdf:rest _:c14n558 .
+_:c14n558 rdf:first _:c14n559 ;
+	rdf:rest rdf:nil .
+_:c14n559 sh:class sdo:QuantitativeValue .
+_:c14n56 sh:description "Artificial illumination type. Refer to BSI PAS-1883 Section 5.3.3.d." ;
+	sh:in _:c14n941 ;
 	sh:maxCount 1 ;
 	sh:order 15 ;
 	sh:path openlabel_v2:IlluminationArtificial .
-_:c14n550 sh:class sdo:QuantitativeValue .
-_:c14n551 sh:datatype xsd:decimal ;
+_:c14n560 sh:datatype xsd:decimal ;
 	sh:nodeKind sh:Literal .
-_:c14n552 rdf:first _:c14n551 ;
-	rdf:rest _:c14n553 .
-_:c14n553 rdf:first _:c14n554 ;
+_:c14n561 rdf:first _:c14n560 ;
+	rdf:rest _:c14n562 .
+_:c14n562 rdf:first _:c14n563 ;
 	rdf:rest rdf:nil .
-_:c14n554 sh:class sdo:QuantitativeValue .
-_:c14n555 sh:datatype xsd:decimal ;
+_:c14n563 sh:class sdo:QuantitativeValue .
+_:c14n564 sh:datatype xsd:decimal ;
 	sh:nodeKind sh:Literal .
-_:c14n556 rdf:first _:c14n555 ;
-	rdf:rest _:c14n557 .
-_:c14n557 rdf:first _:c14n558 ;
+_:c14n565 rdf:first _:c14n564 ;
+	rdf:rest _:c14n566 .
+_:c14n566 rdf:first _:c14n567 ;
 	rdf:rest rdf:nil .
-_:c14n558 sh:class sdo:QuantitativeValue .
-_:c14n559 sh:datatype xsd:decimal ;
+_:c14n567 sh:class sdo:QuantitativeValue .
+_:c14n568 sh:datatype xsd:decimal ;
 	sh:nodeKind sh:Literal .
-_:c14n56 sh:datatype xsd:boolean ;
+_:c14n569 rdf:first _:c14n568 ;
+	rdf:rest _:c14n570 .
+_:c14n57 sh:datatype xsd:boolean ;
 	sh:description "Up-slope flag. Refer to BSI PAS-1883 Section 5.2.3.3.i." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 31 ;
 	sh:path openlabel_v2:LongitudinalUpSlope .
-_:c14n560 rdf:first _:c14n559 ;
-	rdf:rest _:c14n561 .
-_:c14n561 rdf:first _:c14n562 ;
+_:c14n570 rdf:first _:c14n571 ;
 	rdf:rest rdf:nil .
-_:c14n562 sh:class sdo:QuantitativeValue .
-_:c14n563 sh:datatype xsd:decimal ;
+_:c14n571 sh:class sdo:QuantitativeValue .
+_:c14n572 sh:datatype xsd:decimal ;
 	sh:nodeKind sh:Literal .
-_:c14n564 rdf:first _:c14n563 ;
-	rdf:rest _:c14n565 .
-_:c14n565 rdf:first _:c14n566 ;
+_:c14n573 rdf:first _:c14n572 ;
+	rdf:rest _:c14n574 .
+_:c14n574 rdf:first _:c14n575 ;
 	rdf:rest rdf:nil .
-_:c14n566 sh:class sdo:QuantitativeValue .
-_:c14n567 sh:datatype xsd:decimal ;
+_:c14n575 sh:class sdo:QuantitativeValue .
+_:c14n576 sh:datatype xsd:decimal ;
 	sh:nodeKind sh:Literal .
-_:c14n568 rdf:first _:c14n567 ;
-	rdf:rest _:c14n569 .
-_:c14n569 rdf:first _:c14n570 ;
+_:c14n577 rdf:first _:c14n576 ;
+	rdf:rest _:c14n578 .
+_:c14n578 rdf:first _:c14n579 ;
 	rdf:rest rdf:nil .
-_:c14n57 sh:datatype xsd:boolean ;
+_:c14n579 sh:class sdo:QuantitativeValue .
+_:c14n58 sh:datatype xsd:boolean ;
 	sh:description "Number of lanes flag. Refer to BSI PAS-1883 Section 5.2.3.4.d." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 23 ;
 	sh:path openlabel_v2:LaneSpecificationLaneCount .
-_:c14n570 sh:class sdo:QuantitativeValue .
-_:c14n571 sh:datatype xsd:decimal ;
-	sh:nodeKind sh:Literal .
-_:c14n572 rdf:first _:c14n571 ;
-	rdf:rest _:c14n573 .
-_:c14n573 rdf:first _:c14n574 ;
+_:c14n580 rdf:first openlabel_v2:SurfaceFeaturePothole ;
+	rdf:rest _:c14n582 .
+_:c14n581 rdf:first openlabel_v2:SurfaceFeatureCrack ;
+	rdf:rest _:c14n580 .
+_:c14n582 rdf:first openlabel_v2:SurfaceFeatureRut ;
+	rdf:rest _:c14n583 .
+_:c14n583 rdf:first openlabel_v2:SurfaceFeatureSwell ;
 	rdf:rest rdf:nil .
-_:c14n574 sh:class sdo:QuantitativeValue .
-_:c14n575 sh:datatype xsd:decimal ;
-	sh:nodeKind sh:Literal .
-_:c14n576 rdf:first _:c14n575 ;
-	rdf:rest _:c14n577 .
-_:c14n577 rdf:first _:c14n578 ;
+_:c14n584 rdf:first openlabel_v2:SurfaceFeaturePothole ;
+	rdf:rest _:c14n586 .
+_:c14n585 rdf:first openlabel_v2:SurfaceFeatureCrack ;
+	rdf:rest _:c14n584 .
+_:c14n586 rdf:first openlabel_v2:SurfaceFeatureRut ;
+	rdf:rest _:c14n587 .
+_:c14n587 rdf:first openlabel_v2:SurfaceFeatureSwell ;
 	rdf:rest rdf:nil .
-_:c14n578 sh:class sdo:QuantitativeValue .
-_:c14n579 rdf:first openlabel_v2:SurfaceFeaturePothole ;
-	rdf:rest _:c14n581 .
-_:c14n58 sh:datatype xsd:string ;
+_:c14n588 rdf:first openlabel_v2:SurfaceFeaturePothole ;
+	rdf:rest _:c14n590 .
+_:c14n589 rdf:first openlabel_v2:SurfaceFeatureCrack ;
+	rdf:rest _:c14n588 .
+_:c14n59 sh:datatype xsd:string ;
 	sh:description "Universally unique identifier (UUID) assigned to the scenario which allows the scenario to be identified." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 10 ;
 	sh:path openlabel_v2:scenarioUniqueReference .
-_:c14n580 rdf:first openlabel_v2:SurfaceFeatureCrack ;
-	rdf:rest _:c14n579 .
-_:c14n581 rdf:first openlabel_v2:SurfaceFeatureRut ;
-	rdf:rest _:c14n582 .
-_:c14n582 rdf:first openlabel_v2:SurfaceFeatureSwell ;
-	rdf:rest rdf:nil .
-_:c14n583 rdf:first openlabel_v2:SurfaceFeaturePothole ;
-	rdf:rest _:c14n585 .
-_:c14n584 rdf:first openlabel_v2:SurfaceFeatureCrack ;
-	rdf:rest _:c14n583 .
-_:c14n585 rdf:first openlabel_v2:SurfaceFeatureRut ;
-	rdf:rest _:c14n586 .
-_:c14n586 rdf:first openlabel_v2:SurfaceFeatureSwell ;
-	rdf:rest rdf:nil .
-_:c14n587 rdf:first openlabel_v2:SurfaceFeaturePothole ;
-	rdf:rest _:c14n589 .
-_:c14n588 rdf:first openlabel_v2:SurfaceFeatureCrack ;
-	rdf:rest _:c14n587 .
-_:c14n589 rdf:first openlabel_v2:SurfaceFeatureRut ;
-	rdf:rest _:c14n590 .
-_:c14n59 sh:description "Direction of travel. Refer to BSI PAS-1883 Section 5.2.3.4.e." ;
-	sh:in _:c14n956 ;
-	sh:order 26 ;
-	sh:path openlabel_v2:LaneSpecificationTravelDirection .
-_:c14n590 rdf:first openlabel_v2:SurfaceFeatureSwell ;
-	rdf:rest rdf:nil .
-_:c14n591 rdf:first openlabel_v2:SurfaceFeaturePothole ;
-	rdf:rest _:c14n593 .
-_:c14n592 rdf:first openlabel_v2:SurfaceFeatureCrack ;
+_:c14n590 rdf:first openlabel_v2:SurfaceFeatureRut ;
 	rdf:rest _:c14n591 .
-_:c14n593 rdf:first openlabel_v2:SurfaceFeatureRut ;
+_:c14n591 rdf:first openlabel_v2:SurfaceFeatureSwell ;
+	rdf:rest rdf:nil .
+_:c14n592 rdf:first openlabel_v2:SurfaceFeaturePothole ;
 	rdf:rest _:c14n594 .
-_:c14n594 rdf:first openlabel_v2:SurfaceFeatureSwell ;
+_:c14n593 rdf:first openlabel_v2:SurfaceFeatureCrack ;
+	rdf:rest _:c14n592 .
+_:c14n594 rdf:first openlabel_v2:SurfaceFeatureRut ;
+	rdf:rest _:c14n595 .
+_:c14n595 rdf:first openlabel_v2:SurfaceFeatureSwell ;
 	rdf:rest rdf:nil .
-_:c14n595 rdf:first openlabel_v2:EdgeNone ;
-	rdf:rest _:c14n596 .
-_:c14n596 rdf:first openlabel_v2:EdgeShoulderGrass ;
+_:c14n596 rdf:first openlabel_v2:EdgeNone ;
 	rdf:rest _:c14n597 .
-_:c14n597 rdf:first openlabel_v2:EdgeShoulderPavedOrGravel ;
+_:c14n597 rdf:first openlabel_v2:EdgeShoulderGrass ;
 	rdf:rest _:c14n598 .
-_:c14n598 rdf:first openlabel_v2:EdgeSolidBarriers ;
+_:c14n598 rdf:first openlabel_v2:EdgeShoulderPavedOrGravel ;
 	rdf:rest _:c14n599 .
-_:c14n599 rdf:first openlabel_v2:EdgeTemporaryLineMarkers ;
-	rdf:rest rdf:nil .
+_:c14n599 rdf:first openlabel_v2:EdgeSolidBarriers ;
+	rdf:rest _:c14n600 .
 _:c14n6 sh:description "Low light condition. Refer to BSI PAS-1883 Section 5.3.3.b." ;
-	sh:in _:c14n944 ;
+	sh:in _:c14n943 ;
 	sh:maxCount 1 ;
 	sh:order 18 ;
 	sh:path openlabel_v2:IlluminationLowLight .
-_:c14n60 sh:description "Communication connectivity type. Refer to BSI PAS-1883 Section 5.3.4.a." ;
-	sh:in _:c14n530 ;
+_:c14n60 sh:description "Direction of travel. Refer to BSI PAS-1883 Section 5.2.3.4.e." ;
+	sh:in _:c14n955 ;
+	sh:order 26 ;
+	sh:path openlabel_v2:LaneSpecificationTravelDirection .
+_:c14n600 rdf:first openlabel_v2:EdgeTemporaryLineMarkers ;
+	rdf:rest rdf:nil .
+_:c14n601 rdf:first openlabel_v2:EdgeLineMarkers ;
+	rdf:rest _:c14n596 .
+_:c14n602 rdf:first openlabel_v2:EdgeNone ;
+	rdf:rest _:c14n603 .
+_:c14n603 rdf:first openlabel_v2:EdgeShoulderGrass ;
+	rdf:rest _:c14n604 .
+_:c14n604 rdf:first openlabel_v2:EdgeShoulderPavedOrGravel ;
+	rdf:rest _:c14n605 .
+_:c14n605 rdf:first openlabel_v2:EdgeSolidBarriers ;
+	rdf:rest _:c14n606 .
+_:c14n606 rdf:first openlabel_v2:EdgeTemporaryLineMarkers ;
+	rdf:rest rdf:nil .
+_:c14n607 rdf:first openlabel_v2:EdgeLineMarkers ;
+	rdf:rest _:c14n602 .
+_:c14n608 rdf:first openlabel_v2:EdgeNone ;
+	rdf:rest _:c14n609 .
+_:c14n609 rdf:first openlabel_v2:EdgeShoulderGrass ;
+	rdf:rest _:c14n610 .
+_:c14n61 sh:description "Communication connectivity type. Refer to BSI PAS-1883 Section 5.3.4.a." ;
+	sh:in _:c14n531 ;
 	sh:maxCount 1 ;
 	sh:order 0 ;
 	sh:path openlabel_v2:ConnectivityCommunication .
-_:c14n600 rdf:first openlabel_v2:EdgeLineMarkers ;
-	rdf:rest _:c14n595 .
-_:c14n601 rdf:first openlabel_v2:EdgeNone ;
-	rdf:rest _:c14n602 .
-_:c14n602 rdf:first openlabel_v2:EdgeShoulderGrass ;
-	rdf:rest _:c14n603 .
-_:c14n603 rdf:first openlabel_v2:EdgeShoulderPavedOrGravel ;
-	rdf:rest _:c14n604 .
-_:c14n604 rdf:first openlabel_v2:EdgeSolidBarriers ;
-	rdf:rest _:c14n605 .
-_:c14n605 rdf:first openlabel_v2:EdgeTemporaryLineMarkers ;
+_:c14n610 rdf:first openlabel_v2:EdgeShoulderPavedOrGravel ;
+	rdf:rest _:c14n611 .
+_:c14n611 rdf:first openlabel_v2:EdgeSolidBarriers ;
+	rdf:rest _:c14n612 .
+_:c14n612 rdf:first openlabel_v2:EdgeTemporaryLineMarkers ;
 	rdf:rest rdf:nil .
-_:c14n606 rdf:first openlabel_v2:EdgeLineMarkers ;
-	rdf:rest _:c14n601 .
-_:c14n607 rdf:first openlabel_v2:EdgeNone ;
+_:c14n613 rdf:first openlabel_v2:EdgeLineMarkers ;
 	rdf:rest _:c14n608 .
-_:c14n608 rdf:first openlabel_v2:EdgeShoulderGrass ;
-	rdf:rest _:c14n609 .
-_:c14n609 rdf:first openlabel_v2:EdgeShoulderPavedOrGravel ;
-	rdf:rest _:c14n610 .
-_:c14n61 sh:description "Road surface condition. Refer to BSI PAS-1883 Section 5.2.3.7.c." ;
-	sh:in _:c14n691 ;
+_:c14n614 rdf:first openlabel_v2:EdgeNone ;
+	rdf:rest _:c14n615 .
+_:c14n615 rdf:first openlabel_v2:EdgeShoulderGrass ;
+	rdf:rest _:c14n616 .
+_:c14n616 rdf:first openlabel_v2:EdgeShoulderPavedOrGravel ;
+	rdf:rest _:c14n617 .
+_:c14n617 rdf:first openlabel_v2:EdgeSolidBarriers ;
+	rdf:rest _:c14n618 .
+_:c14n618 rdf:first openlabel_v2:EdgeTemporaryLineMarkers ;
+	rdf:rest rdf:nil .
+_:c14n619 rdf:first openlabel_v2:EdgeLineMarkers ;
+	rdf:rest _:c14n614 .
+_:c14n62 sh:description "Road surface condition. Refer to BSI PAS-1883 Section 5.2.3.7.c." ;
+	sh:in _:c14n685 ;
 	sh:order 6 ;
 	sh:path openlabel_v2:DrivableAreaSurfaceCondition .
-_:c14n610 rdf:first openlabel_v2:EdgeSolidBarriers ;
-	rdf:rest _:c14n611 .
-_:c14n611 rdf:first openlabel_v2:EdgeTemporaryLineMarkers ;
-	rdf:rest rdf:nil .
-_:c14n612 rdf:first openlabel_v2:EdgeLineMarkers ;
-	rdf:rest _:c14n607 .
-_:c14n613 rdf:first openlabel_v2:EdgeNone ;
-	rdf:rest _:c14n614 .
-_:c14n614 rdf:first openlabel_v2:EdgeShoulderGrass ;
-	rdf:rest _:c14n615 .
-_:c14n615 rdf:first openlabel_v2:EdgeShoulderPavedOrGravel ;
-	rdf:rest _:c14n616 .
-_:c14n616 rdf:first openlabel_v2:EdgeSolidBarriers ;
-	rdf:rest _:c14n617 .
-_:c14n617 rdf:first openlabel_v2:EdgeTemporaryLineMarkers ;
-	rdf:rest rdf:nil .
-_:c14n618 rdf:first openlabel_v2:EdgeLineMarkers ;
-	rdf:rest _:c14n613 .
-_:c14n619 rdf:first openlabel_v2:RoundaboutMiniSignal ;
-	rdf:rest _:c14n620 .
-_:c14n62 rdf:first openlabel_v2:CommunicationHorn ;
-	rdf:rest _:c14n90 .
-_:c14n620 rdf:first openlabel_v2:RoundaboutNormalNosignal ;
+_:c14n620 rdf:first openlabel_v2:RoundaboutMiniSignal ;
 	rdf:rest _:c14n621 .
-_:c14n621 rdf:first openlabel_v2:RoundaboutNormalSignal ;
-	rdf:rest rdf:nil .
-_:c14n622 rdf:first openlabel_v2:RoundaboutMiniNosignal ;
-	rdf:rest _:c14n619 .
-_:c14n623 rdf:first openlabel_v2:RoundaboutLargeSignal ;
+_:c14n621 rdf:first openlabel_v2:RoundaboutNormalNosignal ;
 	rdf:rest _:c14n622 .
-_:c14n624 rdf:first openlabel_v2:RoundaboutLargeNosignal ;
+_:c14n622 rdf:first openlabel_v2:RoundaboutNormalSignal ;
+	rdf:rest rdf:nil .
+_:c14n623 rdf:first openlabel_v2:RoundaboutMiniNosignal ;
+	rdf:rest _:c14n620 .
+_:c14n624 rdf:first openlabel_v2:RoundaboutLargeSignal ;
 	rdf:rest _:c14n623 .
-_:c14n625 rdf:first openlabel_v2:RoundaboutDoubleSignal ;
+_:c14n625 rdf:first openlabel_v2:RoundaboutLargeNosignal ;
 	rdf:rest _:c14n624 .
-_:c14n626 rdf:first openlabel_v2:RoundaboutDoubleNosignal ;
+_:c14n626 rdf:first openlabel_v2:RoundaboutDoubleSignal ;
 	rdf:rest _:c14n625 .
-_:c14n627 rdf:first openlabel_v2:RoundaboutCompactSignal ;
+_:c14n627 rdf:first openlabel_v2:RoundaboutDoubleNosignal ;
 	rdf:rest _:c14n626 .
-_:c14n628 rdf:first openlabel_v2:RoundaboutCompactNosignal ;
+_:c14n628 rdf:first openlabel_v2:RoundaboutCompactSignal ;
 	rdf:rest _:c14n627 .
-_:c14n629 rdf:first openlabel_v2:RoundaboutMiniSignal ;
+_:c14n629 rdf:first openlabel_v2:RoundaboutCompactNosignal ;
+	rdf:rest _:c14n628 .
+_:c14n63 rdf:first openlabel_v2:CommunicationHorn ;
+	rdf:rest _:c14n91 .
+_:c14n630 rdf:first openlabel_v2:RoundaboutMiniSignal ;
+	rdf:rest _:c14n631 .
+_:c14n631 rdf:first openlabel_v2:RoundaboutNormalNosignal ;
+	rdf:rest _:c14n632 .
+_:c14n632 rdf:first openlabel_v2:RoundaboutNormalSignal ;
+	rdf:rest rdf:nil .
+_:c14n633 rdf:first openlabel_v2:RoundaboutMiniNosignal ;
 	rdf:rest _:c14n630 .
-_:c14n63 sh:datatype xsd:boolean ;
+_:c14n634 rdf:first openlabel_v2:RoundaboutLargeSignal ;
+	rdf:rest _:c14n633 .
+_:c14n635 rdf:first openlabel_v2:RoundaboutLargeNosignal ;
+	rdf:rest _:c14n634 .
+_:c14n636 rdf:first openlabel_v2:RoundaboutDoubleSignal ;
+	rdf:rest _:c14n635 .
+_:c14n637 rdf:first openlabel_v2:RoundaboutDoubleNosignal ;
+	rdf:rest _:c14n636 .
+_:c14n638 rdf:first openlabel_v2:RoundaboutCompactSignal ;
+	rdf:rest _:c14n637 .
+_:c14n639 rdf:first openlabel_v2:RoundaboutCompactNosignal ;
+	rdf:rest _:c14n638 .
+_:c14n64 sh:datatype xsd:boolean ;
 	sh:description "An activity where the subject starts behind and ends up in front by changing lanes." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 13 ;
 	sh:path openlabel_v2:MotionOvertake .
-_:c14n630 rdf:first openlabel_v2:RoundaboutNormalNosignal ;
-	rdf:rest _:c14n631 .
-_:c14n631 rdf:first openlabel_v2:RoundaboutNormalSignal ;
+_:c14n640 rdf:first openlabel_v2:RoundaboutMiniSignal ;
+	rdf:rest _:c14n641 .
+_:c14n641 rdf:first openlabel_v2:RoundaboutNormalNosignal ;
+	rdf:rest _:c14n642 .
+_:c14n642 rdf:first openlabel_v2:RoundaboutNormalSignal ;
 	rdf:rest rdf:nil .
-_:c14n632 rdf:first openlabel_v2:RoundaboutMiniNosignal ;
-	rdf:rest _:c14n629 .
-_:c14n633 rdf:first openlabel_v2:RoundaboutLargeSignal ;
-	rdf:rest _:c14n632 .
-_:c14n634 rdf:first openlabel_v2:RoundaboutLargeNosignal ;
-	rdf:rest _:c14n633 .
-_:c14n635 rdf:first openlabel_v2:RoundaboutDoubleSignal ;
-	rdf:rest _:c14n634 .
-_:c14n636 rdf:first openlabel_v2:RoundaboutDoubleNosignal ;
-	rdf:rest _:c14n635 .
-_:c14n637 rdf:first openlabel_v2:RoundaboutCompactSignal ;
-	rdf:rest _:c14n636 .
-_:c14n638 rdf:first openlabel_v2:RoundaboutCompactNosignal ;
-	rdf:rest _:c14n637 .
-_:c14n639 rdf:first openlabel_v2:RoundaboutMiniSignal ;
+_:c14n643 rdf:first openlabel_v2:RoundaboutMiniNosignal ;
 	rdf:rest _:c14n640 .
-_:c14n64 sh:datatype xsd:boolean ;
+_:c14n644 rdf:first openlabel_v2:RoundaboutLargeSignal ;
+	rdf:rest _:c14n643 .
+_:c14n645 rdf:first openlabel_v2:RoundaboutLargeNosignal ;
+	rdf:rest _:c14n644 .
+_:c14n646 rdf:first openlabel_v2:RoundaboutDoubleSignal ;
+	rdf:rest _:c14n645 .
+_:c14n647 rdf:first openlabel_v2:RoundaboutDoubleNosignal ;
+	rdf:rest _:c14n646 .
+_:c14n648 rdf:first openlabel_v2:RoundaboutCompactSignal ;
+	rdf:rest _:c14n647 .
+_:c14n649 rdf:first openlabel_v2:RoundaboutCompactNosignal ;
+	rdf:rest _:c14n648 .
+_:c14n65 sh:datatype xsd:boolean ;
 	sh:description "Curves flag. Refer to BSI PAS-1883 Section 5.2.3.3." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 12 ;
 	sh:path openlabel_v2:HorizontalCurves .
-_:c14n640 rdf:first openlabel_v2:RoundaboutNormalNosignal ;
-	rdf:rest _:c14n641 .
-_:c14n641 rdf:first openlabel_v2:RoundaboutNormalSignal ;
+_:c14n650 rdf:first openlabel_v2:RoundaboutMiniSignal ;
+	rdf:rest _:c14n651 .
+_:c14n651 rdf:first openlabel_v2:RoundaboutNormalNosignal ;
+	rdf:rest _:c14n652 .
+_:c14n652 rdf:first openlabel_v2:RoundaboutNormalSignal ;
 	rdf:rest rdf:nil .
-_:c14n642 rdf:first openlabel_v2:RoundaboutMiniNosignal ;
-	rdf:rest _:c14n639 .
-_:c14n643 rdf:first openlabel_v2:RoundaboutLargeSignal ;
-	rdf:rest _:c14n642 .
-_:c14n644 rdf:first openlabel_v2:RoundaboutLargeNosignal ;
-	rdf:rest _:c14n643 .
-_:c14n645 rdf:first openlabel_v2:RoundaboutDoubleSignal ;
-	rdf:rest _:c14n644 .
-_:c14n646 rdf:first openlabel_v2:RoundaboutDoubleNosignal ;
-	rdf:rest _:c14n645 .
-_:c14n647 rdf:first openlabel_v2:RoundaboutCompactSignal ;
-	rdf:rest _:c14n646 .
-_:c14n648 rdf:first openlabel_v2:RoundaboutCompactNosignal ;
-	rdf:rest _:c14n647 .
-_:c14n649 rdf:first openlabel_v2:RoundaboutMiniSignal ;
+_:c14n653 rdf:first openlabel_v2:RoundaboutMiniNosignal ;
 	rdf:rest _:c14n650 .
-_:c14n65 sh:description "Regulatory sign type. Refer to BSI PAS-1883 Section 5.2.3.5.b." ;
-	sh:in _:c14n829 ;
+_:c14n654 rdf:first openlabel_v2:RoundaboutLargeSignal ;
+	rdf:rest _:c14n653 .
+_:c14n655 rdf:first openlabel_v2:RoundaboutLargeNosignal ;
+	rdf:rest _:c14n654 .
+_:c14n656 rdf:first openlabel_v2:RoundaboutDoubleSignal ;
+	rdf:rest _:c14n655 .
+_:c14n657 rdf:first openlabel_v2:RoundaboutDoubleNosignal ;
+	rdf:rest _:c14n656 .
+_:c14n658 rdf:first openlabel_v2:RoundaboutCompactSignal ;
+	rdf:rest _:c14n657 .
+_:c14n659 rdf:first openlabel_v2:RoundaboutCompactNosignal ;
+	rdf:rest _:c14n658 .
+_:c14n66 sh:description "Regulatory sign type. Refer to BSI PAS-1883 Section 5.2.3.5.b." ;
+	sh:in _:c14n838 ;
 	sh:order 45 ;
 	sh:path openlabel_v2:SignsRegulatory .
-_:c14n650 rdf:first openlabel_v2:RoundaboutNormalNosignal ;
-	rdf:rest _:c14n651 .
-_:c14n651 rdf:first openlabel_v2:RoundaboutNormalSignal ;
+_:c14n660 rdf:first openlabel_v2:HumanCyclist ;
+	rdf:rest _:c14n661 .
+_:c14n661 rdf:first openlabel_v2:HumanDriver ;
+	rdf:rest _:c14n662 .
+_:c14n662 rdf:first openlabel_v2:HumanMotorcyclist ;
+	rdf:rest _:c14n663 .
+_:c14n663 rdf:first openlabel_v2:HumanPassenger ;
+	rdf:rest _:c14n664 .
+_:c14n664 rdf:first openlabel_v2:HumanPedestrian ;
+	rdf:rest _:c14n665 .
+_:c14n665 rdf:first openlabel_v2:HumanWheelchairUser ;
 	rdf:rest rdf:nil .
-_:c14n652 rdf:first openlabel_v2:RoundaboutMiniNosignal ;
-	rdf:rest _:c14n649 .
-_:c14n653 rdf:first openlabel_v2:RoundaboutLargeSignal ;
-	rdf:rest _:c14n652 .
-_:c14n654 rdf:first openlabel_v2:RoundaboutLargeNosignal ;
-	rdf:rest _:c14n653 .
-_:c14n655 rdf:first openlabel_v2:RoundaboutDoubleSignal ;
-	rdf:rest _:c14n654 .
-_:c14n656 rdf:first openlabel_v2:RoundaboutDoubleNosignal ;
-	rdf:rest _:c14n655 .
-_:c14n657 rdf:first openlabel_v2:RoundaboutCompactSignal ;
-	rdf:rest _:c14n656 .
-_:c14n658 rdf:first openlabel_v2:RoundaboutCompactNosignal ;
-	rdf:rest _:c14n657 .
-_:c14n659 rdf:first openlabel_v2:HumanCyclist ;
+_:c14n666 rdf:first openlabel_v2:HumanAnimalRider ;
 	rdf:rest _:c14n660 .
-_:c14n66 sh:description "Transverse geometry type. Refer to BSI PAS-1883 Section 5.2.3.3.b." ;
-	sh:in _:c14n914 ;
+_:c14n667 rdf:first openlabel_v2:SunPositionBehind ;
+	rdf:rest _:c14n668 .
+_:c14n668 rdf:first openlabel_v2:SunPositionFront ;
+	rdf:rest _:c14n669 .
+_:c14n669 rdf:first openlabel_v2:SunPositionLeft ;
+	rdf:rest _:c14n670 .
+_:c14n67 sh:description "Transverse geometry type. Refer to BSI PAS-1883 Section 5.2.3.3.b." ;
+	sh:in _:c14n930 ;
 	sh:order 11 ;
 	sh:path openlabel_v2:GeometryTransverse .
-_:c14n660 rdf:first openlabel_v2:HumanDriver ;
-	rdf:rest _:c14n661 .
-_:c14n661 rdf:first openlabel_v2:HumanMotorcyclist ;
-	rdf:rest _:c14n662 .
-_:c14n662 rdf:first openlabel_v2:HumanPassenger ;
-	rdf:rest _:c14n663 .
-_:c14n663 rdf:first openlabel_v2:HumanPedestrian ;
-	rdf:rest _:c14n664 .
-_:c14n664 rdf:first openlabel_v2:HumanWheelchairUser ;
+_:c14n670 rdf:first openlabel_v2:SunPositionRight ;
 	rdf:rest rdf:nil .
-_:c14n665 rdf:first openlabel_v2:HumanAnimalRider ;
-	rdf:rest _:c14n659 .
-_:c14n666 rdf:first openlabel_v2:SunPositionBehind ;
-	rdf:rest _:c14n667 .
-_:c14n667 rdf:first openlabel_v2:SunPositionFront ;
-	rdf:rest _:c14n668 .
-_:c14n668 rdf:first openlabel_v2:SunPositionLeft ;
-	rdf:rest _:c14n669 .
-_:c14n669 rdf:first openlabel_v2:SunPositionRight ;
+_:c14n671 rdf:first openlabel_v2:SunPositionBehind ;
+	rdf:rest _:c14n672 .
+_:c14n672 rdf:first openlabel_v2:SunPositionFront ;
+	rdf:rest _:c14n673 .
+_:c14n673 rdf:first openlabel_v2:SunPositionLeft ;
+	rdf:rest _:c14n674 .
+_:c14n674 rdf:first openlabel_v2:SunPositionRight ;
 	rdf:rest rdf:nil .
-_:c14n67 sh:datatype xsd:boolean ;
+_:c14n675 rdf:first openlabel_v2:SunPositionBehind ;
+	rdf:rest _:c14n676 .
+_:c14n676 rdf:first openlabel_v2:SunPositionFront ;
+	rdf:rest _:c14n677 .
+_:c14n677 rdf:first openlabel_v2:SunPositionLeft ;
+	rdf:rest _:c14n678 .
+_:c14n678 rdf:first openlabel_v2:SunPositionRight ;
+	rdf:rest rdf:nil .
+_:c14n679 rdf:first openlabel_v2:SunPositionBehind ;
+	rdf:rest _:c14n680 .
+_:c14n68 sh:datatype xsd:boolean ;
 	sh:description "Traffic agent type classification flag. Refer to BSI PAS-1883 Section 5.4.a.4." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 51 ;
 	sh:path openlabel_v2:TrafficAgentType .
-_:c14n670 rdf:first openlabel_v2:SunPositionBehind ;
-	rdf:rest _:c14n671 .
-_:c14n671 rdf:first openlabel_v2:SunPositionFront ;
-	rdf:rest _:c14n672 .
-_:c14n672 rdf:first openlabel_v2:SunPositionLeft ;
-	rdf:rest _:c14n673 .
-_:c14n673 rdf:first openlabel_v2:SunPositionRight ;
+_:c14n680 rdf:first openlabel_v2:SunPositionFront ;
+	rdf:rest _:c14n681 .
+_:c14n681 rdf:first openlabel_v2:SunPositionLeft ;
+	rdf:rest _:c14n682 .
+_:c14n682 rdf:first openlabel_v2:SunPositionRight ;
 	rdf:rest rdf:nil .
-_:c14n674 rdf:first openlabel_v2:SunPositionBehind ;
-	rdf:rest _:c14n675 .
-_:c14n675 rdf:first openlabel_v2:SunPositionFront ;
-	rdf:rest _:c14n676 .
-_:c14n676 rdf:first openlabel_v2:SunPositionLeft ;
-	rdf:rest _:c14n677 .
-_:c14n677 rdf:first openlabel_v2:SunPositionRight ;
+_:c14n683 rdf:first openlabel_v2:SurfaceConditionIcy ;
+	rdf:rest _:c14n686 .
+_:c14n684 rdf:first openlabel_v2:SurfaceConditionFlooded ;
+	rdf:rest _:c14n683 .
+_:c14n685 rdf:first openlabel_v2:SurfaceConditionContamination ;
+	rdf:rest _:c14n684 .
+_:c14n686 rdf:first openlabel_v2:SurfaceConditionMirage ;
+	rdf:rest _:c14n687 .
+_:c14n687 rdf:first openlabel_v2:SurfaceConditionSnow ;
+	rdf:rest _:c14n688 .
+_:c14n688 rdf:first openlabel_v2:SurfaceConditionStandingWater ;
+	rdf:rest _:c14n689 .
+_:c14n689 rdf:first openlabel_v2:SurfaceConditionWet ;
 	rdf:rest rdf:nil .
-_:c14n678 rdf:first openlabel_v2:SunPositionBehind ;
-	rdf:rest _:c14n679 .
-_:c14n679 rdf:first openlabel_v2:SunPositionFront ;
-	rdf:rest _:c14n680 .
-_:c14n68 sh:datatype xsd:integer ;
+_:c14n69 sh:datatype xsd:integer ;
 	sh:description "Density (vehicles/km). Refer to BSI PAS-1883 Section 5.4.a.1." ;
 	sh:maxCount 1 ;
 	sh:minInclusive 0 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 50 ;
 	sh:path openlabel_v2:trafficAgentDensityValue .
-_:c14n680 rdf:first openlabel_v2:SunPositionLeft ;
-	rdf:rest _:c14n681 .
-_:c14n681 rdf:first openlabel_v2:SunPositionRight ;
+_:c14n690 rdf:first openlabel_v2:SurfaceConditionIcy ;
+	rdf:rest _:c14n693 .
+_:c14n691 rdf:first openlabel_v2:SurfaceConditionFlooded ;
+	rdf:rest _:c14n690 .
+_:c14n692 rdf:first openlabel_v2:SurfaceConditionContamination ;
+	rdf:rest _:c14n691 .
+_:c14n693 rdf:first openlabel_v2:SurfaceConditionMirage ;
+	rdf:rest _:c14n694 .
+_:c14n694 rdf:first openlabel_v2:SurfaceConditionSnow ;
+	rdf:rest _:c14n695 .
+_:c14n695 rdf:first openlabel_v2:SurfaceConditionStandingWater ;
+	rdf:rest _:c14n696 .
+_:c14n696 rdf:first openlabel_v2:SurfaceConditionWet ;
 	rdf:rest rdf:nil .
-_:c14n682 rdf:first openlabel_v2:SurfaceConditionIcy ;
-	rdf:rest _:c14n685 .
-_:c14n683 rdf:first openlabel_v2:SurfaceConditionFlooded ;
-	rdf:rest _:c14n682 .
-_:c14n684 rdf:first openlabel_v2:SurfaceConditionContamination ;
-	rdf:rest _:c14n683 .
-_:c14n685 rdf:first openlabel_v2:SurfaceConditionMirage ;
-	rdf:rest _:c14n686 .
-_:c14n686 rdf:first openlabel_v2:SurfaceConditionSnow ;
-	rdf:rest _:c14n687 .
-_:c14n687 rdf:first openlabel_v2:SurfaceConditionStandingWater ;
-	rdf:rest _:c14n688 .
-_:c14n688 rdf:first openlabel_v2:SurfaceConditionWet ;
-	rdf:rest rdf:nil .
-_:c14n689 rdf:first openlabel_v2:SurfaceConditionIcy ;
-	rdf:rest _:c14n692 .
-_:c14n69 sh:datatype xsd:string ;
+_:c14n697 rdf:first openlabel_v2:SurfaceConditionIcy ;
+	rdf:rest _:c14n700 .
+_:c14n698 rdf:first openlabel_v2:SurfaceConditionFlooded ;
+	rdf:rest _:c14n697 .
+_:c14n699 rdf:first openlabel_v2:SurfaceConditionContamination ;
+	rdf:rest _:c14n698 .
+_:c14n7 sh:description "Fixed road structure. Refer to BSI PAS-1883 Section 5.2.1.e." ;
+	sh:in _:c14n900 ;
+	sh:order 40 ;
+	sh:path openlabel_v2:SceneryFixedStructure .
+_:c14n70 sh:datatype xsd:string ;
 	sh:description "Universally unique identifier (UUID) which identifies the scenario which this one has been derived from." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 9 ;
 	sh:path openlabel_v2:scenarioParentReference .
-_:c14n690 rdf:first openlabel_v2:SurfaceConditionFlooded ;
-	rdf:rest _:c14n689 .
-_:c14n691 rdf:first openlabel_v2:SurfaceConditionContamination ;
-	rdf:rest _:c14n690 .
-_:c14n692 rdf:first openlabel_v2:SurfaceConditionMirage ;
-	rdf:rest _:c14n693 .
-_:c14n693 rdf:first openlabel_v2:SurfaceConditionSnow ;
-	rdf:rest _:c14n694 .
-_:c14n694 rdf:first openlabel_v2:SurfaceConditionStandingWater ;
-	rdf:rest _:c14n695 .
-_:c14n695 rdf:first openlabel_v2:SurfaceConditionWet ;
+_:c14n700 rdf:first openlabel_v2:SurfaceConditionMirage ;
+	rdf:rest _:c14n701 .
+_:c14n701 rdf:first openlabel_v2:SurfaceConditionSnow ;
+	rdf:rest _:c14n702 .
+_:c14n702 rdf:first openlabel_v2:SurfaceConditionStandingWater ;
+	rdf:rest _:c14n703 .
+_:c14n703 rdf:first openlabel_v2:SurfaceConditionWet ;
 	rdf:rest rdf:nil .
-_:c14n696 rdf:first openlabel_v2:SurfaceConditionIcy ;
-	rdf:rest _:c14n699 .
-_:c14n697 rdf:first openlabel_v2:SurfaceConditionFlooded ;
-	rdf:rest _:c14n696 .
-_:c14n698 rdf:first openlabel_v2:SurfaceConditionContamination ;
-	rdf:rest _:c14n697 .
-_:c14n699 rdf:first openlabel_v2:SurfaceConditionMirage ;
-	rdf:rest _:c14n700 .
-_:c14n7 sh:description "Fixed road structure. Refer to BSI PAS-1883 Section 5.2.1.e." ;
-	sh:in _:c14n899 ;
-	sh:order 40 ;
-	sh:path openlabel_v2:SceneryFixedStructure .
-_:c14n70 sh:description "Human road user type." ;
-	sh:in _:c14n665 ;
+_:c14n704 rdf:first openlabel_v2:SurfaceConditionIcy ;
+	rdf:rest _:c14n707 .
+_:c14n705 rdf:first openlabel_v2:SurfaceConditionFlooded ;
+	rdf:rest _:c14n704 .
+_:c14n706 rdf:first openlabel_v2:SurfaceConditionContamination ;
+	rdf:rest _:c14n705 .
+_:c14n707 rdf:first openlabel_v2:SurfaceConditionMirage ;
+	rdf:rest _:c14n708 .
+_:c14n708 rdf:first openlabel_v2:SurfaceConditionSnow ;
+	rdf:rest _:c14n709 .
+_:c14n709 rdf:first openlabel_v2:SurfaceConditionStandingWater ;
+	rdf:rest _:c14n710 .
+_:c14n71 sh:description "Human road user type." ;
+	sh:in _:c14n666 ;
 	sh:maxCount 1 ;
 	sh:order 1 ;
 	sh:path openlabel_v2:RoadUserHuman .
-_:c14n700 rdf:first openlabel_v2:SurfaceConditionSnow ;
-	rdf:rest _:c14n701 .
-_:c14n701 rdf:first openlabel_v2:SurfaceConditionStandingWater ;
-	rdf:rest _:c14n702 .
-_:c14n702 rdf:first openlabel_v2:SurfaceConditionWet ;
+_:c14n710 rdf:first openlabel_v2:SurfaceConditionWet ;
 	rdf:rest rdf:nil .
-_:c14n703 rdf:first openlabel_v2:SurfaceConditionIcy ;
-	rdf:rest _:c14n706 .
-_:c14n704 rdf:first openlabel_v2:SurfaceConditionFlooded ;
-	rdf:rest _:c14n703 .
-_:c14n705 rdf:first openlabel_v2:SurfaceConditionContamination ;
-	rdf:rest _:c14n704 .
-_:c14n706 rdf:first openlabel_v2:SurfaceConditionMirage ;
-	rdf:rest _:c14n707 .
-_:c14n707 rdf:first openlabel_v2:SurfaceConditionSnow ;
-	rdf:rest _:c14n708 .
-_:c14n708 rdf:first openlabel_v2:SurfaceConditionStandingWater ;
-	rdf:rest _:c14n709 .
-_:c14n709 rdf:first openlabel_v2:SurfaceConditionWet ;
+_:c14n711 rdf:first openlabel_v2:SpecialStructureAutoAccess ;
+	rdf:rest _:c14n712 .
+_:c14n712 rdf:first openlabel_v2:SpecialStructureBridge ;
+	rdf:rest _:c14n713 .
+_:c14n713 rdf:first openlabel_v2:SpecialStructurePedestrianCrossing ;
+	rdf:rest _:c14n714 .
+_:c14n714 rdf:first openlabel_v2:SpecialStructureRailCrossing ;
+	rdf:rest _:c14n715 .
+_:c14n715 rdf:first openlabel_v2:SpecialStructureTollPlaza ;
+	rdf:rest _:c14n716 .
+_:c14n716 rdf:first openlabel_v2:SpecialStructureTunnel ;
 	rdf:rest rdf:nil .
-_:c14n71 sh:datatype xsd:boolean ;
+_:c14n717 rdf:first openlabel_v2:SpecialStructureAutoAccess ;
+	rdf:rest _:c14n718 .
+_:c14n718 rdf:first openlabel_v2:SpecialStructureBridge ;
+	rdf:rest _:c14n719 .
+_:c14n719 rdf:first openlabel_v2:SpecialStructurePedestrianCrossing ;
+	rdf:rest _:c14n720 .
+_:c14n72 sh:datatype xsd:boolean ;
 	sh:description "Wind flag. Refer to BSI PAS-1883 Section 5.3.1.1." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 62 ;
 	sh:path openlabel_v2:WeatherWind .
-_:c14n710 rdf:first openlabel_v2:SpecialStructureAutoAccess ;
-	rdf:rest _:c14n711 .
-_:c14n711 rdf:first openlabel_v2:SpecialStructureBridge ;
-	rdf:rest _:c14n712 .
-_:c14n712 rdf:first openlabel_v2:SpecialStructurePedestrianCrossing ;
-	rdf:rest _:c14n713 .
-_:c14n713 rdf:first openlabel_v2:SpecialStructureRailCrossing ;
-	rdf:rest _:c14n714 .
-_:c14n714 rdf:first openlabel_v2:SpecialStructureTollPlaza ;
-	rdf:rest _:c14n715 .
-_:c14n715 rdf:first openlabel_v2:SpecialStructureTunnel ;
+_:c14n720 rdf:first openlabel_v2:SpecialStructureRailCrossing ;
+	rdf:rest _:c14n721 .
+_:c14n721 rdf:first openlabel_v2:SpecialStructureTollPlaza ;
+	rdf:rest _:c14n722 .
+_:c14n722 rdf:first openlabel_v2:SpecialStructureTunnel ;
 	rdf:rest rdf:nil .
-_:c14n716 rdf:first openlabel_v2:SpecialStructureAutoAccess ;
-	rdf:rest _:c14n717 .
-_:c14n717 rdf:first openlabel_v2:SpecialStructureBridge ;
-	rdf:rest _:c14n718 .
-_:c14n718 rdf:first openlabel_v2:SpecialStructurePedestrianCrossing ;
-	rdf:rest _:c14n719 .
-_:c14n719 rdf:first openlabel_v2:SpecialStructureRailCrossing ;
-	rdf:rest _:c14n720 .
-_:c14n72 sh:description "Road surface feature. Refer to BSI PAS-1883 Section 5.2.3.7.b." ;
-	sh:in _:c14n588 ;
+_:c14n723 rdf:first openlabel_v2:SpecialStructureAutoAccess ;
+	rdf:rest _:c14n724 .
+_:c14n724 rdf:first openlabel_v2:SpecialStructureBridge ;
+	rdf:rest _:c14n725 .
+_:c14n725 rdf:first openlabel_v2:SpecialStructurePedestrianCrossing ;
+	rdf:rest _:c14n726 .
+_:c14n726 rdf:first openlabel_v2:SpecialStructureRailCrossing ;
+	rdf:rest _:c14n727 .
+_:c14n727 rdf:first openlabel_v2:SpecialStructureTollPlaza ;
+	rdf:rest _:c14n728 .
+_:c14n728 rdf:first openlabel_v2:SpecialStructureTunnel ;
+	rdf:rest rdf:nil .
+_:c14n729 rdf:first openlabel_v2:SpecialStructureAutoAccess ;
+	rdf:rest _:c14n730 .
+_:c14n73 sh:description "Road surface feature. Refer to BSI PAS-1883 Section 5.2.3.7.b." ;
+	sh:in _:c14n581 ;
 	sh:order 7 ;
 	sh:path openlabel_v2:DrivableAreaSurfaceFeature .
-_:c14n720 rdf:first openlabel_v2:SpecialStructureTollPlaza ;
-	rdf:rest _:c14n721 .
-_:c14n721 rdf:first openlabel_v2:SpecialStructureTunnel ;
+_:c14n730 rdf:first openlabel_v2:SpecialStructureBridge ;
+	rdf:rest _:c14n731 .
+_:c14n731 rdf:first openlabel_v2:SpecialStructurePedestrianCrossing ;
+	rdf:rest _:c14n732 .
+_:c14n732 rdf:first openlabel_v2:SpecialStructureRailCrossing ;
+	rdf:rest _:c14n733 .
+_:c14n733 rdf:first openlabel_v2:SpecialStructureTollPlaza ;
+	rdf:rest _:c14n734 .
+_:c14n734 rdf:first openlabel_v2:SpecialStructureTunnel ;
 	rdf:rest rdf:nil .
-_:c14n722 rdf:first openlabel_v2:SpecialStructureAutoAccess ;
-	rdf:rest _:c14n723 .
-_:c14n723 rdf:first openlabel_v2:SpecialStructureBridge ;
-	rdf:rest _:c14n724 .
-_:c14n724 rdf:first openlabel_v2:SpecialStructurePedestrianCrossing ;
-	rdf:rest _:c14n725 .
-_:c14n725 rdf:first openlabel_v2:SpecialStructureRailCrossing ;
-	rdf:rest _:c14n726 .
-_:c14n726 rdf:first openlabel_v2:SpecialStructureTollPlaza ;
-	rdf:rest _:c14n727 .
-_:c14n727 rdf:first openlabel_v2:SpecialStructureTunnel ;
+_:c14n735 rdf:first openlabel_v2:RoadTypeSlip ;
 	rdf:rest rdf:nil .
-_:c14n728 rdf:first openlabel_v2:SpecialStructureAutoAccess ;
-	rdf:rest _:c14n729 .
-_:c14n729 rdf:first openlabel_v2:SpecialStructureBridge ;
-	rdf:rest _:c14n730 .
-_:c14n73 sh:datatype xsd:decimal ;
+_:c14n736 rdf:first openlabel_v2:RoadTypeShared ;
+	rdf:rest _:c14n735 .
+_:c14n737 rdf:first openlabel_v2:RoadTypeRadial ;
+	rdf:rest _:c14n736 .
+_:c14n738 rdf:first openlabel_v2:RoadTypeParking ;
+	rdf:rest _:c14n737 .
+_:c14n739 rdf:first openlabel_v2:MotorwayUnmanaged ;
+	rdf:rest _:c14n738 .
+_:c14n74 sh:datatype xsd:decimal ;
 	sh:description "Sun elevation (degrees). Refer to BSI PAS-1883 Section 5.3.3.a.1." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 3 ;
 	sh:path openlabel_v2:daySunElevationValue .
-_:c14n730 rdf:first openlabel_v2:SpecialStructurePedestrianCrossing ;
-	rdf:rest _:c14n731 .
-_:c14n731 rdf:first openlabel_v2:SpecialStructureRailCrossing ;
-	rdf:rest _:c14n732 .
-_:c14n732 rdf:first openlabel_v2:SpecialStructureTollPlaza ;
-	rdf:rest _:c14n733 .
-_:c14n733 rdf:first openlabel_v2:SpecialStructureTunnel ;
+_:c14n740 rdf:first openlabel_v2:MotorwayManaged ;
+	rdf:rest _:c14n739 .
+_:c14n741 rdf:first openlabel_v2:RoadTypeMotorway ;
+	rdf:rest _:c14n740 .
+_:c14n742 rdf:first openlabel_v2:RoadTypeMinor ;
+	rdf:rest _:c14n741 .
+_:c14n743 rdf:first openlabel_v2:RoadTypeDistributor ;
+	rdf:rest _:c14n742 .
+_:c14n744 rdf:first openlabel_v2:RoadTypeSlip ;
 	rdf:rest rdf:nil .
-_:c14n734 rdf:first openlabel_v2:RoadTypeSlip ;
-	rdf:rest rdf:nil .
-_:c14n735 rdf:first openlabel_v2:RoadTypeShared ;
-	rdf:rest _:c14n734 .
-_:c14n736 rdf:first openlabel_v2:RoadTypeRadial ;
-	rdf:rest _:c14n735 .
-_:c14n737 rdf:first openlabel_v2:RoadTypeParking ;
-	rdf:rest _:c14n736 .
-_:c14n738 rdf:first openlabel_v2:MotorwayUnmanaged ;
-	rdf:rest _:c14n737 .
-_:c14n739 rdf:first openlabel_v2:MotorwayManaged ;
-	rdf:rest _:c14n738 .
-_:c14n74 sh:description "Intersection type. Refer to BSI PAS-1883 Section 5.2.4." ;
-	sh:in _:c14n788 ;
+_:c14n745 rdf:first openlabel_v2:RoadTypeShared ;
+	rdf:rest _:c14n744 .
+_:c14n746 rdf:first openlabel_v2:RoadTypeRadial ;
+	rdf:rest _:c14n745 .
+_:c14n747 rdf:first openlabel_v2:RoadTypeParking ;
+	rdf:rest _:c14n746 .
+_:c14n748 rdf:first openlabel_v2:MotorwayUnmanaged ;
+	rdf:rest _:c14n747 .
+_:c14n749 rdf:first openlabel_v2:MotorwayManaged ;
+	rdf:rest _:c14n748 .
+_:c14n75 sh:description "Intersection type. Refer to BSI PAS-1883 Section 5.2.4." ;
+	sh:in _:c14n774 ;
 	sh:maxCount 1 ;
 	sh:order 19 ;
 	sh:path openlabel_v2:JunctionIntersection .
-_:c14n740 rdf:first openlabel_v2:RoadTypeMotorway ;
-	rdf:rest _:c14n739 .
-_:c14n741 rdf:first openlabel_v2:RoadTypeMinor ;
-	rdf:rest _:c14n740 .
-_:c14n742 rdf:first openlabel_v2:RoadTypeDistributor ;
-	rdf:rest _:c14n741 .
-_:c14n743 rdf:first openlabel_v2:RoadTypeSlip ;
+_:c14n750 rdf:first openlabel_v2:RoadTypeMotorway ;
+	rdf:rest _:c14n749 .
+_:c14n751 rdf:first openlabel_v2:RoadTypeMinor ;
+	rdf:rest _:c14n750 .
+_:c14n752 rdf:first openlabel_v2:RoadTypeDistributor ;
+	rdf:rest _:c14n751 .
+_:c14n753 rdf:first openlabel_v2:RoadTypeSlip ;
 	rdf:rest rdf:nil .
-_:c14n744 rdf:first openlabel_v2:RoadTypeShared ;
-	rdf:rest _:c14n743 .
-_:c14n745 rdf:first openlabel_v2:RoadTypeRadial ;
-	rdf:rest _:c14n744 .
-_:c14n746 rdf:first openlabel_v2:RoadTypeParking ;
-	rdf:rest _:c14n745 .
-_:c14n747 rdf:first openlabel_v2:MotorwayUnmanaged ;
-	rdf:rest _:c14n746 .
-_:c14n748 rdf:first openlabel_v2:MotorwayManaged ;
-	rdf:rest _:c14n747 .
-_:c14n749 rdf:first openlabel_v2:RoadTypeMotorway ;
-	rdf:rest _:c14n748 .
-_:c14n75 sh:description "Intersection type. Refer to BSI PAS-1883 Section 5.2.4." ;
-	sh:in _:c14n773 ;
+_:c14n754 rdf:first openlabel_v2:RoadTypeShared ;
+	rdf:rest _:c14n753 .
+_:c14n755 rdf:first openlabel_v2:RoadTypeRadial ;
+	rdf:rest _:c14n754 .
+_:c14n756 rdf:first openlabel_v2:RoadTypeParking ;
+	rdf:rest _:c14n755 .
+_:c14n757 rdf:first openlabel_v2:MotorwayUnmanaged ;
+	rdf:rest _:c14n756 .
+_:c14n758 rdf:first openlabel_v2:MotorwayManaged ;
+	rdf:rest _:c14n757 .
+_:c14n759 rdf:first openlabel_v2:RoadTypeMotorway ;
+	rdf:rest _:c14n758 .
+_:c14n76 sh:description "Intersection type. Refer to BSI PAS-1883 Section 5.2.4." ;
+	sh:in _:c14n779 ;
 	sh:order 19 ;
 	sh:path openlabel_v2:JunctionIntersection .
-_:c14n750 rdf:first openlabel_v2:RoadTypeMinor ;
-	rdf:rest _:c14n749 .
-_:c14n751 rdf:first openlabel_v2:RoadTypeDistributor ;
-	rdf:rest _:c14n750 .
-_:c14n752 rdf:first openlabel_v2:RoadTypeSlip ;
+_:c14n760 rdf:first openlabel_v2:RoadTypeMinor ;
+	rdf:rest _:c14n759 .
+_:c14n761 rdf:first openlabel_v2:RoadTypeDistributor ;
+	rdf:rest _:c14n760 .
+_:c14n762 rdf:first openlabel_v2:RoadTypeSlip ;
 	rdf:rest rdf:nil .
-_:c14n753 rdf:first openlabel_v2:RoadTypeShared ;
-	rdf:rest _:c14n752 .
-_:c14n754 rdf:first openlabel_v2:RoadTypeRadial ;
-	rdf:rest _:c14n753 .
-_:c14n755 rdf:first openlabel_v2:RoadTypeParking ;
-	rdf:rest _:c14n754 .
-_:c14n756 rdf:first openlabel_v2:MotorwayUnmanaged ;
-	rdf:rest _:c14n755 .
-_:c14n757 rdf:first openlabel_v2:MotorwayManaged ;
-	rdf:rest _:c14n756 .
-_:c14n758 rdf:first openlabel_v2:RoadTypeMotorway ;
-	rdf:rest _:c14n757 .
-_:c14n759 rdf:first openlabel_v2:RoadTypeMinor ;
-	rdf:rest _:c14n758 .
-_:c14n76 sh:description "Road surface feature. Refer to BSI PAS-1883 Section 5.2.3.7.b." ;
-	sh:in _:c14n584 ;
+_:c14n763 rdf:first openlabel_v2:RoadTypeShared ;
+	rdf:rest _:c14n762 .
+_:c14n764 rdf:first openlabel_v2:RoadTypeRadial ;
+	rdf:rest _:c14n763 .
+_:c14n765 rdf:first openlabel_v2:RoadTypeParking ;
+	rdf:rest _:c14n764 .
+_:c14n766 rdf:first openlabel_v2:MotorwayUnmanaged ;
+	rdf:rest _:c14n765 .
+_:c14n767 rdf:first openlabel_v2:MotorwayManaged ;
+	rdf:rest _:c14n766 .
+_:c14n768 rdf:first openlabel_v2:RoadTypeMotorway ;
+	rdf:rest _:c14n767 .
+_:c14n769 rdf:first openlabel_v2:RoadTypeMinor ;
+	rdf:rest _:c14n768 .
+_:c14n77 sh:description "Road surface feature. Refer to BSI PAS-1883 Section 5.2.3.7.b." ;
+	sh:in _:c14n589 ;
 	sh:maxCount 1 ;
 	sh:order 7 ;
 	sh:path openlabel_v2:DrivableAreaSurfaceFeature .
-_:c14n760 rdf:first openlabel_v2:RoadTypeDistributor ;
-	rdf:rest _:c14n759 .
-_:c14n761 rdf:first openlabel_v2:RoadTypeSlip ;
+_:c14n770 rdf:first openlabel_v2:RoadTypeDistributor ;
+	rdf:rest _:c14n769 .
+_:c14n771 rdf:first openlabel_v2:IntersectionTJunction ;
+	rdf:rest _:c14n775 .
+_:c14n772 rdf:first openlabel_v2:IntersectionStaggered ;
+	rdf:rest _:c14n771 .
+_:c14n773 rdf:first openlabel_v2:IntersectionGradeSeperated ;
+	rdf:rest _:c14n772 .
+_:c14n774 rdf:first openlabel_v2:IntersectionCrossroad ;
+	rdf:rest _:c14n773 .
+_:c14n775 rdf:first openlabel_v2:IntersectionYJunction ;
 	rdf:rest rdf:nil .
-_:c14n762 rdf:first openlabel_v2:RoadTypeShared ;
-	rdf:rest _:c14n761 .
-_:c14n763 rdf:first openlabel_v2:RoadTypeRadial ;
-	rdf:rest _:c14n762 .
-_:c14n764 rdf:first openlabel_v2:RoadTypeParking ;
-	rdf:rest _:c14n763 .
-_:c14n765 rdf:first openlabel_v2:MotorwayUnmanaged ;
-	rdf:rest _:c14n764 .
-_:c14n766 rdf:first openlabel_v2:MotorwayManaged ;
-	rdf:rest _:c14n765 .
-_:c14n767 rdf:first openlabel_v2:RoadTypeMotorway ;
-	rdf:rest _:c14n766 .
-_:c14n768 rdf:first openlabel_v2:RoadTypeMinor ;
-	rdf:rest _:c14n767 .
-_:c14n769 rdf:first openlabel_v2:RoadTypeDistributor ;
-	rdf:rest _:c14n768 .
-_:c14n77 sh:datatype xsd:decimal ;
+_:c14n776 rdf:first openlabel_v2:IntersectionTJunction ;
+	rdf:rest _:c14n780 .
+_:c14n777 rdf:first openlabel_v2:IntersectionStaggered ;
+	rdf:rest _:c14n776 .
+_:c14n778 rdf:first openlabel_v2:IntersectionGradeSeperated ;
+	rdf:rest _:c14n777 .
+_:c14n779 rdf:first openlabel_v2:IntersectionCrossroad ;
+	rdf:rest _:c14n778 .
+_:c14n78 sh:datatype xsd:decimal ;
 	sh:description "Gradient (%). Refer to BSI PAS-1883 Section 5.2.3.3.ii." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 29 ;
 	sh:path openlabel_v2:longitudinalDownSlopeValue .
-_:c14n770 rdf:first openlabel_v2:IntersectionTJunction ;
-	rdf:rest _:c14n774 .
-_:c14n771 rdf:first openlabel_v2:IntersectionStaggered ;
-	rdf:rest _:c14n770 .
-_:c14n772 rdf:first openlabel_v2:IntersectionGradeSeperated ;
-	rdf:rest _:c14n771 .
-_:c14n773 rdf:first openlabel_v2:IntersectionCrossroad ;
-	rdf:rest _:c14n772 .
-_:c14n774 rdf:first openlabel_v2:IntersectionYJunction ;
+_:c14n780 rdf:first openlabel_v2:IntersectionYJunction ;
 	rdf:rest rdf:nil .
-_:c14n775 rdf:first openlabel_v2:IntersectionTJunction ;
-	rdf:rest _:c14n779 .
-_:c14n776 rdf:first openlabel_v2:IntersectionStaggered ;
-	rdf:rest _:c14n775 .
-_:c14n777 rdf:first openlabel_v2:IntersectionGradeSeperated ;
-	rdf:rest _:c14n776 .
-_:c14n778 rdf:first openlabel_v2:IntersectionCrossroad ;
-	rdf:rest _:c14n777 .
-_:c14n779 rdf:first openlabel_v2:IntersectionYJunction ;
+_:c14n781 rdf:first openlabel_v2:IntersectionTJunction ;
+	rdf:rest _:c14n785 .
+_:c14n782 rdf:first openlabel_v2:IntersectionStaggered ;
+	rdf:rest _:c14n781 .
+_:c14n783 rdf:first openlabel_v2:IntersectionGradeSeperated ;
+	rdf:rest _:c14n782 .
+_:c14n784 rdf:first openlabel_v2:IntersectionCrossroad ;
+	rdf:rest _:c14n783 .
+_:c14n785 rdf:first openlabel_v2:IntersectionYJunction ;
 	rdf:rest rdf:nil .
-_:c14n78 sh:description "Rainfall type. Refer to BSI PAS-1883 Section 5.3.1.2." ;
-	sh:in _:c14n846 ;
+_:c14n786 rdf:first openlabel_v2:IntersectionTJunction ;
+	rdf:rest _:c14n790 .
+_:c14n787 rdf:first openlabel_v2:IntersectionStaggered ;
+	rdf:rest _:c14n786 .
+_:c14n788 rdf:first openlabel_v2:IntersectionGradeSeperated ;
+	rdf:rest _:c14n787 .
+_:c14n789 rdf:first openlabel_v2:IntersectionCrossroad ;
+	rdf:rest _:c14n788 .
+_:c14n79 sh:description "Rainfall type. Refer to BSI PAS-1883 Section 5.3.1.2." ;
+	sh:in _:c14n841 ;
 	sh:maxCount 1 ;
 	sh:order 39 ;
 	sh:path openlabel_v2:RainType .
-_:c14n780 rdf:first openlabel_v2:IntersectionTJunction ;
-	rdf:rest _:c14n784 .
-_:c14n781 rdf:first openlabel_v2:IntersectionStaggered ;
-	rdf:rest _:c14n780 .
-_:c14n782 rdf:first openlabel_v2:IntersectionGradeSeperated ;
-	rdf:rest _:c14n781 .
-_:c14n783 rdf:first openlabel_v2:IntersectionCrossroad ;
-	rdf:rest _:c14n782 .
-_:c14n784 rdf:first openlabel_v2:IntersectionYJunction ;
+_:c14n790 rdf:first openlabel_v2:IntersectionYJunction ;
 	rdf:rest rdf:nil .
-_:c14n785 rdf:first openlabel_v2:IntersectionTJunction ;
-	rdf:rest _:c14n789 .
-_:c14n786 rdf:first openlabel_v2:IntersectionStaggered ;
-	rdf:rest _:c14n785 .
-_:c14n787 rdf:first openlabel_v2:IntersectionGradeSeperated ;
-	rdf:rest _:c14n786 .
-_:c14n788 rdf:first openlabel_v2:IntersectionCrossroad ;
-	rdf:rest _:c14n787 .
-_:c14n789 rdf:first openlabel_v2:IntersectionYJunction ;
-	rdf:rest rdf:nil .
-_:c14n79 sh:datatype xsd:boolean ;
-	sh:description "Straight lines flag. Refer to BSI PAS-1883 Section 5.2.3.3." ;
-	sh:nodeKind sh:Literal ;
-	sh:order 14 ;
-	sh:path openlabel_v2:HorizontalStraights .
-_:c14n790 rdf:first openlabel_v2:ZoneSchool ;
-	rdf:rest _:c14n794 .
-_:c14n791 rdf:first openlabel_v2:ZoneRegion ;
-	rdf:rest _:c14n790 .
-_:c14n792 rdf:first openlabel_v2:ZoneInterference ;
-	rdf:rest _:c14n791 .
-_:c14n793 rdf:first openlabel_v2:ZoneGeoFenced ;
-	rdf:rest _:c14n792 .
-_:c14n794 rdf:first openlabel_v2:ZoneTrafficManagement ;
-	rdf:rest rdf:nil .
-_:c14n795 rdf:first openlabel_v2:ZoneSchool ;
-	rdf:rest _:c14n799 .
-_:c14n796 rdf:first openlabel_v2:ZoneRegion ;
+_:c14n791 rdf:first openlabel_v2:ZoneSchool ;
 	rdf:rest _:c14n795 .
-_:c14n797 rdf:first openlabel_v2:ZoneInterference ;
-	rdf:rest _:c14n796 .
-_:c14n798 rdf:first openlabel_v2:ZoneGeoFenced ;
-	rdf:rest _:c14n797 .
-_:c14n799 rdf:first openlabel_v2:ZoneTrafficManagement ;
+_:c14n792 rdf:first openlabel_v2:ZoneRegion ;
+	rdf:rest _:c14n791 .
+_:c14n793 rdf:first openlabel_v2:ZoneInterference ;
+	rdf:rest _:c14n792 .
+_:c14n794 rdf:first openlabel_v2:ZoneGeoFenced ;
+	rdf:rest _:c14n793 .
+_:c14n795 rdf:first openlabel_v2:ZoneTrafficManagement ;
 	rdf:rest rdf:nil .
+_:c14n796 rdf:first openlabel_v2:ZoneSchool ;
+	rdf:rest _:c14n800 .
+_:c14n797 rdf:first openlabel_v2:ZoneRegion ;
+	rdf:rest _:c14n796 .
+_:c14n798 rdf:first openlabel_v2:ZoneInterference ;
+	rdf:rest _:c14n797 .
+_:c14n799 rdf:first openlabel_v2:ZoneGeoFenced ;
+	rdf:rest _:c14n798 .
 _:c14n8 sh:datatype xsd:boolean ;
 	sh:description "Level plane flag. Refer to BSI PAS-1883 Section 5.2.3.3.iii." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 30 ;
 	sh:path openlabel_v2:LongitudinalLevelPlane .
-_:c14n80 sh:datatype xsd:decimal ;
+_:c14n80 sh:datatype xsd:boolean ;
+	sh:description "Straight lines flag. Refer to BSI PAS-1883 Section 5.2.3.3." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 14 ;
+	sh:path openlabel_v2:HorizontalStraights .
+_:c14n800 rdf:first openlabel_v2:ZoneTrafficManagement ;
+	rdf:rest rdf:nil .
+_:c14n801 rdf:first openlabel_v2:ZoneSchool ;
+	rdf:rest _:c14n805 .
+_:c14n802 rdf:first openlabel_v2:ZoneRegion ;
+	rdf:rest _:c14n801 .
+_:c14n803 rdf:first openlabel_v2:ZoneInterference ;
+	rdf:rest _:c14n802 .
+_:c14n804 rdf:first openlabel_v2:ZoneGeoFenced ;
+	rdf:rest _:c14n803 .
+_:c14n805 rdf:first openlabel_v2:ZoneTrafficManagement ;
+	rdf:rest rdf:nil .
+_:c14n806 rdf:first openlabel_v2:ZoneSchool ;
+	rdf:rest _:c14n810 .
+_:c14n807 rdf:first openlabel_v2:ZoneRegion ;
+	rdf:rest _:c14n806 .
+_:c14n808 rdf:first openlabel_v2:ZoneInterference ;
+	rdf:rest _:c14n807 .
+_:c14n809 rdf:first openlabel_v2:ZoneGeoFenced ;
+	rdf:rest _:c14n808 .
+_:c14n81 sh:datatype xsd:decimal ;
 	sh:description "Wind speed (m/s). Refer to BSI PAS-1883 Section 5.3.1.1." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 63 ;
 	sh:path openlabel_v2:weatherWindValue .
-_:c14n800 rdf:first openlabel_v2:ZoneSchool ;
-	rdf:rest _:c14n804 .
-_:c14n801 rdf:first openlabel_v2:ZoneRegion ;
-	rdf:rest _:c14n800 .
-_:c14n802 rdf:first openlabel_v2:ZoneInterference ;
-	rdf:rest _:c14n801 .
-_:c14n803 rdf:first openlabel_v2:ZoneGeoFenced ;
-	rdf:rest _:c14n802 .
-_:c14n804 rdf:first openlabel_v2:ZoneTrafficManagement ;
+_:c14n810 rdf:first openlabel_v2:ZoneTrafficManagement ;
 	rdf:rest rdf:nil .
-_:c14n805 rdf:first openlabel_v2:ZoneSchool ;
-	rdf:rest _:c14n809 .
-_:c14n806 rdf:first openlabel_v2:ZoneRegion ;
-	rdf:rest _:c14n805 .
-_:c14n807 rdf:first openlabel_v2:ZoneInterference ;
-	rdf:rest _:c14n806 .
-_:c14n808 rdf:first openlabel_v2:ZoneGeoFenced ;
-	rdf:rest _:c14n807 .
-_:c14n809 rdf:first openlabel_v2:ZoneTrafficManagement ;
+_:c14n811 rdf:first openlabel_v2:PositioningGlonass ;
+	rdf:rest _:c14n812 .
+_:c14n812 rdf:first openlabel_v2:PositioningGps ;
 	rdf:rest rdf:nil .
-_:c14n81 sh:datatype xsd:integer ;
+_:c14n813 rdf:first openlabel_v2:PositioningGalileo ;
+	rdf:rest _:c14n811 .
+_:c14n814 rdf:first openlabel_v2:PositioningGlonass ;
+	rdf:rest _:c14n815 .
+_:c14n815 rdf:first openlabel_v2:PositioningGps ;
+	rdf:rest rdf:nil .
+_:c14n816 rdf:first openlabel_v2:PositioningGalileo ;
+	rdf:rest _:c14n814 .
+_:c14n817 rdf:first openlabel_v2:PositioningGlonass ;
+	rdf:rest _:c14n818 .
+_:c14n818 rdf:first openlabel_v2:PositioningGps ;
+	rdf:rest rdf:nil .
+_:c14n819 rdf:first openlabel_v2:PositioningGalileo ;
+	rdf:rest _:c14n817 .
+_:c14n82 sh:datatype xsd:integer ;
 	sh:description "Volume (vehicle km). Refer to BSI PAS-1883 Section 5.4.a.2." ;
 	sh:minInclusive 0 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 57 ;
 	sh:path openlabel_v2:trafficVolumeValue .
-_:c14n810 rdf:first openlabel_v2:PositioningGlonass ;
-	rdf:rest _:c14n811 .
-_:c14n811 rdf:first openlabel_v2:PositioningGps ;
+_:c14n820 rdf:first openlabel_v2:PositioningGlonass ;
+	rdf:rest _:c14n821 .
+_:c14n821 rdf:first openlabel_v2:PositioningGps ;
 	rdf:rest rdf:nil .
-_:c14n812 rdf:first openlabel_v2:PositioningGalileo ;
-	rdf:rest _:c14n810 .
-_:c14n813 rdf:first openlabel_v2:PositioningGlonass ;
-	rdf:rest _:c14n814 .
-_:c14n814 rdf:first openlabel_v2:PositioningGps ;
-	rdf:rest rdf:nil .
-_:c14n815 rdf:first openlabel_v2:PositioningGalileo ;
-	rdf:rest _:c14n813 .
-_:c14n816 rdf:first openlabel_v2:PositioningGlonass ;
-	rdf:rest _:c14n817 .
-_:c14n817 rdf:first openlabel_v2:PositioningGps ;
-	rdf:rest rdf:nil .
-_:c14n818 rdf:first openlabel_v2:PositioningGalileo ;
-	rdf:rest _:c14n816 .
-_:c14n819 rdf:first openlabel_v2:PositioningGlonass ;
+_:c14n822 rdf:first openlabel_v2:PositioningGalileo ;
 	rdf:rest _:c14n820 .
-_:c14n82 sh:datatype xsd:integer ;
+_:c14n823 rdf:first openlabel_v2:RegulatorySignsVariableFullTime ;
+	rdf:rest _:c14n824 .
+_:c14n824 rdf:first openlabel_v2:RegulatorySignsVariableTemporary ;
+	rdf:rest rdf:nil .
+_:c14n825 rdf:first openlabel_v2:RegulatorySignsUniformTemporary ;
+	rdf:rest _:c14n823 .
+_:c14n826 rdf:first openlabel_v2:RegulatorySignsUniformFullTime ;
+	rdf:rest _:c14n825 .
+_:c14n827 rdf:first openlabel_v2:RegulatorySignsVariableFullTime ;
+	rdf:rest _:c14n828 .
+_:c14n828 rdf:first openlabel_v2:RegulatorySignsVariableTemporary ;
+	rdf:rest rdf:nil .
+_:c14n829 rdf:first openlabel_v2:RegulatorySignsUniformTemporary ;
+	rdf:rest _:c14n827 .
+_:c14n83 sh:datatype xsd:integer ;
 	sh:description "Density (vehicles/km). Refer to BSI PAS-1883 Section 5.4.a.1." ;
 	sh:minInclusive 0 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 50 ;
 	sh:path openlabel_v2:trafficAgentDensityValue .
-_:c14n820 rdf:first openlabel_v2:PositioningGps ;
+_:c14n830 rdf:first openlabel_v2:RegulatorySignsUniformFullTime ;
+	rdf:rest _:c14n829 .
+_:c14n831 rdf:first openlabel_v2:RegulatorySignsVariableFullTime ;
+	rdf:rest _:c14n832 .
+_:c14n832 rdf:first openlabel_v2:RegulatorySignsVariableTemporary ;
 	rdf:rest rdf:nil .
-_:c14n821 rdf:first openlabel_v2:PositioningGalileo ;
-	rdf:rest _:c14n819 .
-_:c14n822 rdf:first openlabel_v2:RegulatorySignsVariableFullTime ;
-	rdf:rest _:c14n823 .
-_:c14n823 rdf:first openlabel_v2:RegulatorySignsVariableTemporary ;
+_:c14n833 rdf:first openlabel_v2:RegulatorySignsUniformTemporary ;
+	rdf:rest _:c14n831 .
+_:c14n834 rdf:first openlabel_v2:RegulatorySignsUniformFullTime ;
+	rdf:rest _:c14n833 .
+_:c14n835 rdf:first openlabel_v2:RegulatorySignsVariableFullTime ;
+	rdf:rest _:c14n836 .
+_:c14n836 rdf:first openlabel_v2:RegulatorySignsVariableTemporary ;
 	rdf:rest rdf:nil .
-_:c14n824 rdf:first openlabel_v2:RegulatorySignsUniformTemporary ;
-	rdf:rest _:c14n822 .
-_:c14n825 rdf:first openlabel_v2:RegulatorySignsUniformFullTime ;
-	rdf:rest _:c14n824 .
-_:c14n826 rdf:first openlabel_v2:RegulatorySignsVariableFullTime ;
-	rdf:rest _:c14n827 .
-_:c14n827 rdf:first openlabel_v2:RegulatorySignsVariableTemporary ;
-	rdf:rest rdf:nil .
-_:c14n828 rdf:first openlabel_v2:RegulatorySignsUniformTemporary ;
-	rdf:rest _:c14n826 .
-_:c14n829 rdf:first openlabel_v2:RegulatorySignsUniformFullTime ;
-	rdf:rest _:c14n828 .
-_:c14n83 sh:description "Regulatory sign type. Refer to BSI PAS-1883 Section 5.2.3.5.b." ;
-	sh:in _:c14n837 ;
+_:c14n837 rdf:first openlabel_v2:RegulatorySignsUniformTemporary ;
+	rdf:rest _:c14n835 .
+_:c14n838 rdf:first openlabel_v2:RegulatorySignsUniformFullTime ;
+	rdf:rest _:c14n837 .
+_:c14n839 rdf:first openlabel_v2:RainTypeDynamic ;
+	rdf:rest _:c14n840 .
+_:c14n84 sh:description "Regulatory sign type. Refer to BSI PAS-1883 Section 5.2.3.5.b." ;
+	sh:in _:c14n830 ;
 	sh:order 45 ;
 	sh:path openlabel_v2:SignsRegulatory .
-_:c14n830 rdf:first openlabel_v2:RegulatorySignsVariableFullTime ;
-	rdf:rest _:c14n831 .
-_:c14n831 rdf:first openlabel_v2:RegulatorySignsVariableTemporary ;
+_:c14n840 rdf:first openlabel_v2:RainTypeOrographic ;
 	rdf:rest rdf:nil .
-_:c14n832 rdf:first openlabel_v2:RegulatorySignsUniformTemporary ;
-	rdf:rest _:c14n830 .
-_:c14n833 rdf:first openlabel_v2:RegulatorySignsUniformFullTime ;
-	rdf:rest _:c14n832 .
-_:c14n834 rdf:first openlabel_v2:RegulatorySignsVariableFullTime ;
-	rdf:rest _:c14n835 .
-_:c14n835 rdf:first openlabel_v2:RegulatorySignsVariableTemporary ;
-	rdf:rest rdf:nil .
-_:c14n836 rdf:first openlabel_v2:RegulatorySignsUniformTemporary ;
-	rdf:rest _:c14n834 .
-_:c14n837 rdf:first openlabel_v2:RegulatorySignsUniformFullTime ;
-	rdf:rest _:c14n836 .
-_:c14n838 rdf:first openlabel_v2:RainTypeDynamic ;
+_:c14n841 rdf:first openlabel_v2:RainTypeConvective ;
 	rdf:rest _:c14n839 .
-_:c14n839 rdf:first openlabel_v2:RainTypeOrographic ;
+_:c14n842 rdf:first openlabel_v2:RainTypeDynamic ;
+	rdf:rest _:c14n843 .
+_:c14n843 rdf:first openlabel_v2:RainTypeOrographic ;
 	rdf:rest rdf:nil .
-_:c14n84 sh:datatype xsd:boolean ;
+_:c14n844 rdf:first openlabel_v2:RainTypeConvective ;
+	rdf:rest _:c14n842 .
+_:c14n845 rdf:first openlabel_v2:RainTypeDynamic ;
+	rdf:rest _:c14n846 .
+_:c14n846 rdf:first openlabel_v2:RainTypeOrographic ;
+	rdf:rest rdf:nil .
+_:c14n847 rdf:first openlabel_v2:RainTypeConvective ;
+	rdf:rest _:c14n845 .
+_:c14n848 rdf:first openlabel_v2:RainTypeDynamic ;
+	rdf:rest _:c14n849 .
+_:c14n849 rdf:first openlabel_v2:RainTypeOrographic ;
+	rdf:rest rdf:nil .
+_:c14n85 sh:datatype xsd:boolean ;
 	sh:description "Traffic flow rate flag. Refer to BSI PAS-1883 Section 5.4.a.3." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 53 ;
 	sh:path openlabel_v2:TrafficFlowRate .
-_:c14n840 rdf:first openlabel_v2:RainTypeConvective ;
-	rdf:rest _:c14n838 .
-_:c14n841 rdf:first openlabel_v2:RainTypeDynamic ;
-	rdf:rest _:c14n842 .
-_:c14n842 rdf:first openlabel_v2:RainTypeOrographic ;
-	rdf:rest rdf:nil .
-_:c14n843 rdf:first openlabel_v2:RainTypeConvective ;
-	rdf:rest _:c14n841 .
-_:c14n844 rdf:first openlabel_v2:RainTypeDynamic ;
-	rdf:rest _:c14n845 .
-_:c14n845 rdf:first openlabel_v2:RainTypeOrographic ;
-	rdf:rest rdf:nil .
-_:c14n846 rdf:first openlabel_v2:RainTypeConvective ;
-	rdf:rest _:c14n844 .
-_:c14n847 rdf:first openlabel_v2:RainTypeDynamic ;
+_:c14n850 rdf:first openlabel_v2:RainTypeConvective ;
 	rdf:rest _:c14n848 .
-_:c14n848 rdf:first openlabel_v2:RainTypeOrographic ;
+_:c14n851 rdf:first _:c14n854 ;
+	rdf:rest _:c14n852 .
+_:c14n852 rdf:first _:c14n853 ;
 	rdf:rest rdf:nil .
-_:c14n849 rdf:first openlabel_v2:RainTypeConvective ;
-	rdf:rest _:c14n847 .
-_:c14n85 sh:description "Lane width (m). Refer to BSI PAS-1883 Section 5.2.3.4.a." ;
+_:c14n853 sh:class sdo:QuantitativeValue .
+_:c14n854 sh:datatype xsd:integer ;
+	sh:nodeKind sh:Literal .
+_:c14n855 rdf:first _:c14n858 ;
+	rdf:rest _:c14n856 .
+_:c14n856 rdf:first _:c14n857 ;
+	rdf:rest rdf:nil .
+_:c14n857 sh:class sdo:QuantitativeValue .
+_:c14n858 sh:datatype xsd:integer ;
+	sh:nodeKind sh:Literal .
+_:c14n859 rdf:first _:c14n862 ;
+	rdf:rest _:c14n860 .
+_:c14n86 sh:description "Lane width (m). Refer to BSI PAS-1883 Section 5.2.3.4.a." ;
 	sh:maxCount 1 ;
-	sh:or _:c14n556 ;
+	sh:or _:c14n549 ;
 	sh:order 22 ;
 	sh:path openlabel_v2:laneSpecificationDimensionsValue .
-_:c14n850 rdf:first _:c14n853 ;
-	rdf:rest _:c14n851 .
-_:c14n851 rdf:first _:c14n852 ;
+_:c14n860 rdf:first _:c14n861 ;
 	rdf:rest rdf:nil .
-_:c14n852 sh:class sdo:QuantitativeValue .
-_:c14n853 sh:datatype xsd:integer ;
+_:c14n861 sh:class sdo:QuantitativeValue .
+_:c14n862 sh:datatype xsd:integer ;
 	sh:nodeKind sh:Literal .
-_:c14n854 rdf:first _:c14n857 ;
-	rdf:rest _:c14n855 .
-_:c14n855 rdf:first _:c14n856 ;
+_:c14n863 rdf:first _:c14n866 ;
+	rdf:rest _:c14n864 .
+_:c14n864 rdf:first _:c14n865 ;
 	rdf:rest rdf:nil .
-_:c14n856 sh:class sdo:QuantitativeValue .
-_:c14n857 sh:datatype xsd:integer ;
+_:c14n865 sh:class sdo:QuantitativeValue .
+_:c14n866 sh:datatype xsd:integer ;
 	sh:nodeKind sh:Literal .
-_:c14n858 rdf:first _:c14n861 ;
-	rdf:rest _:c14n859 .
-_:c14n859 rdf:first _:c14n860 ;
+_:c14n867 rdf:first _:c14n870 ;
+	rdf:rest _:c14n868 .
+_:c14n868 rdf:first _:c14n869 ;
 	rdf:rest rdf:nil .
-_:c14n86 sh:datatype xsd:boolean ;
+_:c14n869 sh:class sdo:QuantitativeValue .
+_:c14n87 sh:datatype xsd:boolean ;
 	sh:description "Volcanic ash flag. Refer to BSI PAS-1883 Section 5.3.2.e." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 36 ;
 	sh:path openlabel_v2:ParticulatesVolcanic .
-_:c14n860 sh:class sdo:QuantitativeValue .
-_:c14n861 sh:datatype xsd:integer ;
+_:c14n870 sh:datatype xsd:integer ;
 	sh:nodeKind sh:Literal .
-_:c14n862 rdf:first _:c14n865 ;
-	rdf:rest _:c14n863 .
-_:c14n863 rdf:first _:c14n864 ;
+_:c14n871 rdf:first _:c14n874 ;
+	rdf:rest _:c14n872 .
+_:c14n872 rdf:first _:c14n873 ;
 	rdf:rest rdf:nil .
-_:c14n864 sh:class sdo:QuantitativeValue .
-_:c14n865 sh:datatype xsd:integer ;
+_:c14n873 sh:class sdo:QuantitativeValue .
+_:c14n874 sh:datatype xsd:integer ;
 	sh:nodeKind sh:Literal .
-_:c14n866 rdf:first _:c14n869 ;
-	rdf:rest _:c14n867 .
-_:c14n867 rdf:first _:c14n868 ;
+_:c14n875 rdf:first _:c14n878 ;
+	rdf:rest _:c14n876 .
+_:c14n876 rdf:first _:c14n877 ;
 	rdf:rest rdf:nil .
-_:c14n868 sh:class sdo:QuantitativeValue .
-_:c14n869 sh:datatype xsd:integer ;
+_:c14n877 sh:class sdo:QuantitativeValue .
+_:c14n878 sh:datatype xsd:integer ;
 	sh:nodeKind sh:Literal .
-_:c14n87 sh:datatype xsd:decimal ;
+_:c14n879 rdf:first _:c14n882 ;
+	rdf:rest _:c14n880 .
+_:c14n88 sh:datatype xsd:decimal ;
 	sh:description "Meteorological Optical Range (MOR) (m). Refer to BSI PAS-1883 Section 5.3.2.b." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 38 ;
 	sh:path openlabel_v2:particulatesWaterValue .
-_:c14n870 rdf:first _:c14n873 ;
-	rdf:rest _:c14n871 .
-_:c14n871 rdf:first _:c14n872 ;
+_:c14n880 rdf:first _:c14n881 ;
 	rdf:rest rdf:nil .
-_:c14n872 sh:class sdo:QuantitativeValue .
-_:c14n873 sh:datatype xsd:integer ;
+_:c14n881 sh:class sdo:QuantitativeValue .
+_:c14n882 sh:datatype xsd:integer ;
 	sh:nodeKind sh:Literal .
-_:c14n874 rdf:first _:c14n877 ;
-	rdf:rest _:c14n875 .
-_:c14n875 rdf:first _:c14n876 ;
+_:c14n883 rdf:first openlabel_v2:TemporaryStructureConstructionDetour ;
+	rdf:rest _:c14n884 .
+_:c14n884 rdf:first openlabel_v2:TemporaryStructureRefuseCollection ;
+	rdf:rest _:c14n885 .
+_:c14n885 rdf:first openlabel_v2:TemporaryStructureRoadSignage ;
+	rdf:rest _:c14n886 .
+_:c14n886 rdf:first openlabel_v2:TemporaryStructureRoadWorks ;
 	rdf:rest rdf:nil .
-_:c14n876 sh:class sdo:QuantitativeValue .
-_:c14n877 sh:datatype xsd:integer ;
-	sh:nodeKind sh:Literal .
-_:c14n878 rdf:first _:c14n881 ;
-	rdf:rest _:c14n879 .
-_:c14n879 rdf:first _:c14n880 ;
-	rdf:rest rdf:nil .
-_:c14n88 sh:datatype xsd:integer ;
+_:c14n887 rdf:first openlabel_v2:TemporaryStructureConstructionDetour ;
+	rdf:rest _:c14n888 .
+_:c14n888 rdf:first openlabel_v2:TemporaryStructureRefuseCollection ;
+	rdf:rest _:c14n889 .
+_:c14n889 rdf:first openlabel_v2:TemporaryStructureRoadSignage ;
+	rdf:rest _:c14n890 .
+_:c14n89 sh:datatype xsd:integer ;
 	sh:description "Volume (vehicle km). Refer to BSI PAS-1883 Section 5.4.a.2." ;
 	sh:maxCount 1 ;
 	sh:minInclusive 0 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 57 ;
 	sh:path openlabel_v2:trafficVolumeValue .
-_:c14n880 sh:class sdo:QuantitativeValue .
-_:c14n881 sh:datatype xsd:integer ;
-	sh:nodeKind sh:Literal .
-_:c14n882 rdf:first openlabel_v2:TemporaryStructureConstructionDetour ;
-	rdf:rest _:c14n883 .
-_:c14n883 rdf:first openlabel_v2:TemporaryStructureRefuseCollection ;
-	rdf:rest _:c14n884 .
-_:c14n884 rdf:first openlabel_v2:TemporaryStructureRoadSignage ;
-	rdf:rest _:c14n885 .
-_:c14n885 rdf:first openlabel_v2:TemporaryStructureRoadWorks ;
+_:c14n890 rdf:first openlabel_v2:TemporaryStructureRoadWorks ;
 	rdf:rest rdf:nil .
-_:c14n886 rdf:first openlabel_v2:TemporaryStructureConstructionDetour ;
-	rdf:rest _:c14n887 .
-_:c14n887 rdf:first openlabel_v2:TemporaryStructureRefuseCollection ;
-	rdf:rest _:c14n888 .
-_:c14n888 rdf:first openlabel_v2:TemporaryStructureRoadSignage ;
-	rdf:rest _:c14n889 .
-_:c14n889 rdf:first openlabel_v2:TemporaryStructureRoadWorks ;
-	rdf:rest rdf:nil .
-_:c14n89 sh:datatype xsd:boolean ;
-	sh:description "Non-precipitating water droplets or ice crystals (mist/fog) flag. Refer to BSI PAS-1883 Section 5.3.2.b." ;
-	sh:nodeKind sh:Literal ;
-	sh:order 37 ;
-	sh:path openlabel_v2:ParticulatesWater .
-_:c14n890 rdf:first openlabel_v2:TemporaryStructureConstructionDetour ;
-	rdf:rest _:c14n891 .
-_:c14n891 rdf:first openlabel_v2:TemporaryStructureRefuseCollection ;
+_:c14n891 rdf:first openlabel_v2:TemporaryStructureConstructionDetour ;
 	rdf:rest _:c14n892 .
-_:c14n892 rdf:first openlabel_v2:TemporaryStructureRoadSignage ;
+_:c14n892 rdf:first openlabel_v2:TemporaryStructureRefuseCollection ;
 	rdf:rest _:c14n893 .
-_:c14n893 rdf:first openlabel_v2:TemporaryStructureRoadWorks ;
+_:c14n893 rdf:first openlabel_v2:TemporaryStructureRoadSignage ;
+	rdf:rest _:c14n894 .
+_:c14n894 rdf:first openlabel_v2:TemporaryStructureRoadWorks ;
 	rdf:rest rdf:nil .
-_:c14n894 rdf:first openlabel_v2:TemporaryStructureConstructionDetour ;
-	rdf:rest _:c14n895 .
-_:c14n895 rdf:first openlabel_v2:TemporaryStructureRefuseCollection ;
+_:c14n895 rdf:first openlabel_v2:TemporaryStructureConstructionDetour ;
 	rdf:rest _:c14n896 .
-_:c14n896 rdf:first openlabel_v2:TemporaryStructureRoadSignage ;
+_:c14n896 rdf:first openlabel_v2:TemporaryStructureRefuseCollection ;
 	rdf:rest _:c14n897 .
-_:c14n897 rdf:first openlabel_v2:TemporaryStructureRoadWorks ;
-	rdf:rest rdf:nil .
-_:c14n898 rdf:first openlabel_v2:FixedStructureStreetFurniture ;
-	rdf:rest _:c14n900 .
-_:c14n899 rdf:first openlabel_v2:FixedStructureBuilding ;
+_:c14n897 rdf:first openlabel_v2:TemporaryStructureRoadSignage ;
 	rdf:rest _:c14n898 .
+_:c14n898 rdf:first openlabel_v2:TemporaryStructureRoadWorks ;
+	rdf:rest rdf:nil .
+_:c14n899 rdf:first openlabel_v2:FixedStructureStreetFurniture ;
+	rdf:rest _:c14n901 .
 _:c14n9 sh:datatype xsd:boolean ;
 	sh:description "Number of lanes flag. Refer to BSI PAS-1883 Section 5.2.3.4.d." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 23 ;
 	sh:path openlabel_v2:LaneSpecificationLaneCount .
-_:c14n90 rdf:first openlabel_v2:CommunicationSignalEmergency ;
-	rdf:rest _:c14n26 .
-_:c14n900 rdf:first openlabel_v2:FixedStructureStreetlight ;
-	rdf:rest _:c14n901 .
-_:c14n901 rdf:first openlabel_v2:FixedStructureVegetation ;
-	rdf:rest rdf:nil .
-_:c14n902 rdf:first openlabel_v2:FixedStructureStreetFurniture ;
-	rdf:rest _:c14n904 .
-_:c14n903 rdf:first openlabel_v2:FixedStructureBuilding ;
+_:c14n90 sh:datatype xsd:boolean ;
+	sh:description "Non-precipitating water droplets or ice crystals (mist/fog) flag. Refer to BSI PAS-1883 Section 5.3.2.b." ;
+	sh:nodeKind sh:Literal ;
+	sh:order 37 ;
+	sh:path openlabel_v2:ParticulatesWater .
+_:c14n900 rdf:first openlabel_v2:FixedStructureBuilding ;
+	rdf:rest _:c14n899 .
+_:c14n901 rdf:first openlabel_v2:FixedStructureStreetlight ;
 	rdf:rest _:c14n902 .
-_:c14n904 rdf:first openlabel_v2:FixedStructureStreetlight ;
+_:c14n902 rdf:first openlabel_v2:FixedStructureVegetation ;
+	rdf:rest rdf:nil .
+_:c14n903 rdf:first openlabel_v2:FixedStructureStreetFurniture ;
 	rdf:rest _:c14n905 .
-_:c14n905 rdf:first openlabel_v2:FixedStructureVegetation ;
-	rdf:rest rdf:nil .
-_:c14n906 rdf:first openlabel_v2:FixedStructureStreetFurniture ;
-	rdf:rest _:c14n908 .
-_:c14n907 rdf:first openlabel_v2:FixedStructureBuilding ;
+_:c14n904 rdf:first openlabel_v2:FixedStructureBuilding ;
+	rdf:rest _:c14n903 .
+_:c14n905 rdf:first openlabel_v2:FixedStructureStreetlight ;
 	rdf:rest _:c14n906 .
-_:c14n908 rdf:first openlabel_v2:FixedStructureStreetlight ;
-	rdf:rest _:c14n909 .
-_:c14n909 rdf:first openlabel_v2:FixedStructureVegetation ;
+_:c14n906 rdf:first openlabel_v2:FixedStructureVegetation ;
 	rdf:rest rdf:nil .
-_:c14n91 sh:datatype xsd:decimal ;
+_:c14n907 rdf:first openlabel_v2:FixedStructureStreetFurniture ;
+	rdf:rest _:c14n909 .
+_:c14n908 rdf:first openlabel_v2:FixedStructureBuilding ;
+	rdf:rest _:c14n907 .
+_:c14n909 rdf:first openlabel_v2:FixedStructureStreetlight ;
+	rdf:rest _:c14n910 .
+_:c14n91 rdf:first openlabel_v2:CommunicationSignalEmergency ;
+	rdf:rest _:c14n26 .
+_:c14n910 rdf:first openlabel_v2:FixedStructureVegetation ;
+	rdf:rest rdf:nil .
+_:c14n911 rdf:first openlabel_v2:FixedStructureStreetFurniture ;
+	rdf:rest _:c14n913 .
+_:c14n912 rdf:first openlabel_v2:FixedStructureBuilding ;
+	rdf:rest _:c14n911 .
+_:c14n913 rdf:first openlabel_v2:FixedStructureStreetlight ;
+	rdf:rest _:c14n914 .
+_:c14n914 rdf:first openlabel_v2:FixedStructureVegetation ;
+	rdf:rest rdf:nil .
+_:c14n915 rdf:first openlabel_v2:TransverseBarriers ;
+	rdf:rest _:c14n916 .
+_:c14n916 rdf:first openlabel_v2:TransverseDivided ;
+	rdf:rest _:c14n917 .
+_:c14n917 rdf:first openlabel_v2:TransverseLanesTogether ;
+	rdf:rest _:c14n918 .
+_:c14n918 rdf:first openlabel_v2:TransversePavements ;
+	rdf:rest _:c14n919 .
+_:c14n919 rdf:first openlabel_v2:TransverseUndivided ;
+	rdf:rest rdf:nil .
+_:c14n92 sh:datatype xsd:decimal ;
 	sh:description "Lower bound inferred via RDFS from schema:minValue being a subPropertyOf cmns-q:hasLowerBound in schema.org OWL." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 2 ;
 	sh:path cmns-q:hasLowerBound .
-_:c14n910 rdf:first openlabel_v2:FixedStructureStreetFurniture ;
-	rdf:rest _:c14n912 .
-_:c14n911 rdf:first openlabel_v2:FixedStructureBuilding ;
-	rdf:rest _:c14n910 .
-_:c14n912 rdf:first openlabel_v2:FixedStructureStreetlight ;
-	rdf:rest _:c14n913 .
-_:c14n913 rdf:first openlabel_v2:FixedStructureVegetation ;
+_:c14n920 rdf:first openlabel_v2:TransverseBarriers ;
+	rdf:rest _:c14n921 .
+_:c14n921 rdf:first openlabel_v2:TransverseDivided ;
+	rdf:rest _:c14n922 .
+_:c14n922 rdf:first openlabel_v2:TransverseLanesTogether ;
+	rdf:rest _:c14n923 .
+_:c14n923 rdf:first openlabel_v2:TransversePavements ;
+	rdf:rest _:c14n924 .
+_:c14n924 rdf:first openlabel_v2:TransverseUndivided ;
 	rdf:rest rdf:nil .
-_:c14n914 rdf:first openlabel_v2:TransverseBarriers ;
-	rdf:rest _:c14n915 .
-_:c14n915 rdf:first openlabel_v2:TransverseDivided ;
-	rdf:rest _:c14n916 .
-_:c14n916 rdf:first openlabel_v2:TransverseLanesTogether ;
-	rdf:rest _:c14n917 .
-_:c14n917 rdf:first openlabel_v2:TransversePavements ;
-	rdf:rest _:c14n918 .
-_:c14n918 rdf:first openlabel_v2:TransverseUndivided ;
+_:c14n925 rdf:first openlabel_v2:TransverseBarriers ;
+	rdf:rest _:c14n926 .
+_:c14n926 rdf:first openlabel_v2:TransverseDivided ;
+	rdf:rest _:c14n927 .
+_:c14n927 rdf:first openlabel_v2:TransverseLanesTogether ;
+	rdf:rest _:c14n928 .
+_:c14n928 rdf:first openlabel_v2:TransversePavements ;
+	rdf:rest _:c14n929 .
+_:c14n929 rdf:first openlabel_v2:TransverseUndivided ;
 	rdf:rest rdf:nil .
-_:c14n919 rdf:first openlabel_v2:TransverseBarriers ;
-	rdf:rest _:c14n920 .
-_:c14n92 sh:description "Rainfall type. Refer to BSI PAS-1883 Section 5.3.1.2." ;
-	sh:in _:c14n840 ;
+_:c14n93 sh:description "Rainfall type. Refer to BSI PAS-1883 Section 5.3.1.2." ;
+	sh:in _:c14n844 ;
 	sh:order 39 ;
 	sh:path openlabel_v2:RainType .
-_:c14n920 rdf:first openlabel_v2:TransverseDivided ;
-	rdf:rest _:c14n921 .
-_:c14n921 rdf:first openlabel_v2:TransverseLanesTogether ;
-	rdf:rest _:c14n922 .
-_:c14n922 rdf:first openlabel_v2:TransversePavements ;
-	rdf:rest _:c14n923 .
-_:c14n923 rdf:first openlabel_v2:TransverseUndivided ;
+_:c14n930 rdf:first openlabel_v2:TransverseBarriers ;
+	rdf:rest _:c14n931 .
+_:c14n931 rdf:first openlabel_v2:TransverseDivided ;
+	rdf:rest _:c14n932 .
+_:c14n932 rdf:first openlabel_v2:TransverseLanesTogether ;
+	rdf:rest _:c14n933 .
+_:c14n933 rdf:first openlabel_v2:TransversePavements ;
+	rdf:rest _:c14n934 .
+_:c14n934 rdf:first openlabel_v2:TransverseUndivided ;
 	rdf:rest rdf:nil .
-_:c14n924 rdf:first openlabel_v2:TransverseBarriers ;
-	rdf:rest _:c14n925 .
-_:c14n925 rdf:first openlabel_v2:TransverseDivided ;
-	rdf:rest _:c14n926 .
-_:c14n926 rdf:first openlabel_v2:TransverseLanesTogether ;
-	rdf:rest _:c14n927 .
-_:c14n927 rdf:first openlabel_v2:TransversePavements ;
-	rdf:rest _:c14n928 .
-_:c14n928 rdf:first openlabel_v2:TransverseUndivided ;
+_:c14n935 rdf:first openlabel_v2:ArtificialStreetLighting ;
+	rdf:rest _:c14n936 .
+_:c14n936 rdf:first openlabel_v2:ArtificialVehicleLighting ;
 	rdf:rest rdf:nil .
-_:c14n929 rdf:first openlabel_v2:TransverseBarriers ;
-	rdf:rest _:c14n930 .
-_:c14n93 sh:datatype xsd:boolean ;
+_:c14n937 rdf:first openlabel_v2:ArtificialStreetLighting ;
+	rdf:rest _:c14n938 .
+_:c14n938 rdf:first openlabel_v2:ArtificialVehicleLighting ;
+	rdf:rest rdf:nil .
+_:c14n939 rdf:first openlabel_v2:ArtificialStreetLighting ;
+	rdf:rest _:c14n940 .
+_:c14n94 sh:datatype xsd:boolean ;
 	sh:description "Traffic volume flag. Refer to BSI PAS-1883 Section 5.4.a.2." ;
 	sh:nodeKind sh:Literal ;
 	sh:order 56 ;
 	sh:path openlabel_v2:TrafficVolume .
-_:c14n930 rdf:first openlabel_v2:TransverseDivided ;
-	rdf:rest _:c14n931 .
-_:c14n931 rdf:first openlabel_v2:TransverseLanesTogether ;
-	rdf:rest _:c14n932 .
-_:c14n932 rdf:first openlabel_v2:TransversePavements ;
-	rdf:rest _:c14n933 .
-_:c14n933 rdf:first openlabel_v2:TransverseUndivided ;
+_:c14n940 rdf:first openlabel_v2:ArtificialVehicleLighting ;
 	rdf:rest rdf:nil .
-_:c14n934 rdf:first openlabel_v2:ArtificialStreetLighting ;
-	rdf:rest _:c14n935 .
-_:c14n935 rdf:first openlabel_v2:ArtificialVehicleLighting ;
+_:c14n941 rdf:first openlabel_v2:ArtificialStreetLighting ;
+	rdf:rest _:c14n942 .
+_:c14n942 rdf:first openlabel_v2:ArtificialVehicleLighting ;
 	rdf:rest rdf:nil .
-_:c14n936 rdf:first openlabel_v2:ArtificialStreetLighting ;
-	rdf:rest _:c14n937 .
-_:c14n937 rdf:first openlabel_v2:ArtificialVehicleLighting ;
+_:c14n943 rdf:first openlabel_v2:LowLightAmbient ;
+	rdf:rest _:c14n944 .
+_:c14n944 rdf:first openlabel_v2:LowLightNight ;
 	rdf:rest rdf:nil .
-_:c14n938 rdf:first openlabel_v2:ArtificialStreetLighting ;
-	rdf:rest _:c14n939 .
-_:c14n939 rdf:first openlabel_v2:ArtificialVehicleLighting ;
+_:c14n945 rdf:first openlabel_v2:LowLightAmbient ;
+	rdf:rest _:c14n946 .
+_:c14n946 rdf:first openlabel_v2:LowLightNight ;
 	rdf:rest rdf:nil .
-_:c14n94 sh:datatype xsd:boolean ;
+_:c14n947 rdf:first openlabel_v2:LowLightAmbient ;
+	rdf:rest _:c14n948 .
+_:c14n948 rdf:first openlabel_v2:LowLightNight ;
+	rdf:rest rdf:nil .
+_:c14n949 rdf:first openlabel_v2:LowLightAmbient ;
+	rdf:rest _:c14n950 .
+_:c14n95 sh:datatype xsd:boolean ;
 	sh:description "Smoke and pollution flag. Refer to BSI PAS-1883 Section 5.3.2.d." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 35 ;
 	sh:path openlabel_v2:ParticulatesPollution .
-_:c14n940 rdf:first openlabel_v2:ArtificialStreetLighting ;
-	rdf:rest _:c14n941 .
-_:c14n941 rdf:first openlabel_v2:ArtificialVehicleLighting ;
+_:c14n950 rdf:first openlabel_v2:LowLightNight ;
 	rdf:rest rdf:nil .
-_:c14n942 rdf:first openlabel_v2:LowLightAmbient ;
-	rdf:rest _:c14n943 .
-_:c14n943 rdf:first openlabel_v2:LowLightNight ;
+_:c14n951 rdf:first openlabel_v2:TravelDirectionLeft ;
+	rdf:rest _:c14n952 .
+_:c14n952 rdf:first openlabel_v2:TravelDirectionRight ;
 	rdf:rest rdf:nil .
-_:c14n944 rdf:first openlabel_v2:LowLightAmbient ;
-	rdf:rest _:c14n945 .
-_:c14n945 rdf:first openlabel_v2:LowLightNight ;
+_:c14n953 rdf:first openlabel_v2:TravelDirectionLeft ;
+	rdf:rest _:c14n954 .
+_:c14n954 rdf:first openlabel_v2:TravelDirectionRight ;
 	rdf:rest rdf:nil .
-_:c14n946 rdf:first openlabel_v2:LowLightAmbient ;
-	rdf:rest _:c14n947 .
-_:c14n947 rdf:first openlabel_v2:LowLightNight ;
+_:c14n955 rdf:first openlabel_v2:TravelDirectionLeft ;
+	rdf:rest _:c14n956 .
+_:c14n956 rdf:first openlabel_v2:TravelDirectionRight ;
 	rdf:rest rdf:nil .
-_:c14n948 rdf:first openlabel_v2:LowLightAmbient ;
-	rdf:rest _:c14n949 .
-_:c14n949 rdf:first openlabel_v2:LowLightNight ;
+_:c14n957 rdf:first openlabel_v2:TravelDirectionLeft ;
+	rdf:rest _:c14n958 .
+_:c14n958 rdf:first openlabel_v2:TravelDirectionRight ;
 	rdf:rest rdf:nil .
-_:c14n95 sh:description "Position of the sun. Refer to BSI PAS-1883 Section 5.3.3.a.2." ;
-	sh:in _:c14n670 ;
+_:c14n96 sh:description "Position of the sun. Refer to BSI PAS-1883 Section 5.3.3.a.2." ;
+	sh:in _:c14n667 ;
 	sh:order 4 ;
 	sh:path openlabel_v2:DaySunPosition .
-_:c14n950 rdf:first openlabel_v2:TravelDirectionLeft ;
-	rdf:rest _:c14n951 .
-_:c14n951 rdf:first openlabel_v2:TravelDirectionRight ;
-	rdf:rest rdf:nil .
-_:c14n952 rdf:first openlabel_v2:TravelDirectionLeft ;
-	rdf:rest _:c14n953 .
-_:c14n953 rdf:first openlabel_v2:TravelDirectionRight ;
-	rdf:rest rdf:nil .
-_:c14n954 rdf:first openlabel_v2:TravelDirectionLeft ;
-	rdf:rest _:c14n955 .
-_:c14n955 rdf:first openlabel_v2:TravelDirectionRight ;
-	rdf:rest rdf:nil .
-_:c14n956 rdf:first openlabel_v2:TravelDirectionLeft ;
-	rdf:rest _:c14n957 .
-_:c14n957 rdf:first openlabel_v2:TravelDirectionRight ;
-	rdf:rest rdf:nil .
-_:c14n96 sh:datatype xsd:boolean ;
+_:c14n97 sh:datatype xsd:boolean ;
 	sh:description "Volcanic ash flag. Refer to BSI PAS-1883 Section 5.3.2.e." ;
 	sh:maxCount 1 ;
 	sh:nodeKind sh:Literal ;
 	sh:order 36 ;
 	sh:path openlabel_v2:ParticulatesVolcanic .
-_:c14n97 sh:description "Transverse geometry type. Refer to BSI PAS-1883 Section 5.2.3.3.b." ;
-	sh:in _:c14n924 ;
+_:c14n98 sh:description "Transverse geometry type. Refer to BSI PAS-1883 Section 5.2.3.3.b." ;
+	sh:in _:c14n925 ;
 	sh:maxCount 1 ;
 	sh:order 11 ;
 	sh:path openlabel_v2:GeometryTransverse .
-_:c14n98 sh:description "Warning sign type. Refer to BSI PAS-1883 Section 5.2.3.5.c." ;
-	sh:in _:c14n399 ;
+_:c14n99 sh:description "Warning sign type. Refer to BSI PAS-1883 Section 5.2.3.5.c." ;
+	sh:in _:c14n400 ;
 	sh:order 46 ;
 	sh:path openlabel_v2:SignsWarning .
-_:c14n99 sh:datatype xsd:decimal ;
-	sh:description "Wind speed (m/s). Refer to BSI PAS-1883 Section 5.3.1.1." ;
-	sh:maxCount 1 ;
-	sh:nodeKind sh:Literal ;
-	sh:order 63 ;
-	sh:path openlabel_v2:weatherWindValue .

--- a/linkml/openlabel-v2/openlabel-v2.yaml
+++ b/linkml/openlabel-v2/openlabel-v2.yaml
@@ -74,6 +74,7 @@ classes:
       - scenarioUniqueReference
       - scenarioVersion
       - scenarioVisualisationURL
+      - scenarioComment
 
   # ---------------------------------------------------------------------------
   # Behaviour
@@ -962,6 +963,11 @@ slots:
       Relative or absolute URL of a static image or animation of the scenario
       to allow users to easily see what the scenario represents.
     slot_uri: openlabel_v2:scenarioVisualisationURL
+    range: string
+
+  scenarioComment:
+    description: An optional free-text comment for the scenario.
+    slot_uri: openlabel_v2:scenarioComment
     range: string
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Demo: Upstream RDFC-1.0 Diff-Stability Problem

**DO NOT MERGE** — This PR exists solely to demonstrate the blank-node renumbering problem with upstream [linkml/linkml#3407](https://github.com/linkml/linkml/pull/3407).

### What this shows

**Commit 1** (baseline): Regenerates openlabel-v2 OWL and SHACL artifacts using upstream's pyoxigraph RDFC-1.0 canonicalization. Blank node IDs become sequential `_:c14nN`.

**Commit 2** (small change): Adds a **single string slot** (`scenarioComment`) to the `AdminTag` class — a 3-line model change.

### The problem

| File | Lines changed | Actual content lines |
|------|:---:|:---:|
| `openlabel-v2.owl.ttl` | **~2340** | **5** |
| `openlabel-v2.shacl.ttl` | **~3026** | **~6** |

**~5000 lines of diff from adding one slot.** Only ~11 lines are real content — the rest is `_:c14nN` to `_:c14nM` renumbering caused by RDFC-1.0's sequential blank-node canonicalization.

### Why this matters

When generated RDF artifacts are version-controlled (as they are in this repository), every PR should show **what actually changed** in the ontology. With sequential `_:c14nN` IDs, inserting one triple early in canonical order renumbers all subsequent blank nodes, producing a diff that is technically correct but **completely unreadable** for human reviewers.

RDFC-1.0 solves **"did anything change?"** (binary check), but not **"what changed?"** (which is what PR reviewers need).

### Our proposed solution

[ASCS-eV/linkml `feat/deterministic-output-v2`](https://github.com/ASCS-eV/linkml/tree/feat/deterministic-output-v2) adds a `--deterministic` flag that layers **Weisfeiler-Lehman structural hashing** on top of RDFC-1.0:

1. RDFC-1.0 canonicalization (upstream #3407) — correctness guarantee
2. WL hashing — replaces sequential `_:c14nN` with content-based `_:b<sha256>` IDs
3. rdflib re-serialization — idiomatic Turtle (inline blanks, collections, preserved `xsd:string`)

With WL hashing, the same one-slot addition produces a **~15-line diff** — only the lines that actually changed.

See also: [ASCS-eV/linkml#1](https://github.com/ASCS-eV/linkml/pull/1) for the original discussion and benchmark results.
