### PR TITLE
demo: WL structural hashing — diff-stable determinism (DO NOT MERGE)

### DIFF
--- a/artifacts/openlabel-v2/openlabel-v2.owl.ttl
+++ b/artifacts/openlabel-v2/openlabel-v2.owl.ttl
@@ -2086,6 +2086,12 @@ openlabel_v2:ownerURL a owl:DatatypeProperty ;
     skos:definition "The URL of the legal entity who owns the rights to the scenario."@en ;
     skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
 
+openlabel_v2:scenarioComment a owl:DatatypeProperty ;
+    rdfs:label "scenarioComment"@en ;
+    rdfs:range xsd:string ;
+    skos:definition "A free-text comment about the scenario."@en ;
+    skos:inScheme <https://w3id.org/ascs-ev/envited-x/openlabel/v2> .
+
 openlabel_v2:scenarioCreatedDate a owl:DatatypeProperty ;
     rdfs:label "scenarioCreatedDate"@en ;
     rdfs:range xsd:dateTime ;
@@ -2236,6 +2242,9 @@ openlabel_v2:AdminTag a owl:Class,
             owl:onProperty openlabel_v2:scenarioVersion ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty openlabel_v2:scenarioComment ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty openlabel_v2:scenarioDescription ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
@@ -2246,6 +2255,9 @@ openlabel_v2:AdminTag a owl:Class,
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty openlabel_v2:scenarioParentReference ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty openlabel_v2:scenarioComment ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty openlabel_v2:scenarioDescription ],
@@ -2261,6 +2273,9 @@ openlabel_v2:AdminTag a owl:Class,
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty openlabel_v2:scenarioVersion ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty openlabel_v2:scenarioComment ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty openlabel_v2:licenseURI ],

--- a/artifacts/openlabel-v2/openlabel-v2.shacl.ttl
+++ b/artifacts/openlabel-v2/openlabel-v2.shacl.ttl
@@ -1379,6 +1379,13 @@ openlabel_v2:AdminTag a sh:NodeShape ;
             sh:order 9 ;
             sh:path openlabel_v2:scenarioParentReference ],
         [ sh:datatype xsd:string ;
+            sh:description "A free-text comment about the scenario."@en ;
+            sh:maxCount 1 ;
+            sh:message "scenarioComment (AdminTag): A free-text comment about the scenario."@en ;
+            sh:nodeKind sh:Literal ;
+            sh:order 13 ;
+            sh:path openlabel_v2:scenarioComment ],
+        [ sh:datatype xsd:string ;
             sh:description "A description of the scenario."@en ;
             sh:maxCount 1 ;
             sh:message "scenarioDescription (AdminTag): A description of the scenario."@en ;

--- a/linkml/openlabel-v2/openlabel-v2.yaml
+++ b/linkml/openlabel-v2/openlabel-v2.yaml
@@ -74,6 +74,7 @@ classes:
       - scenarioUniqueReference
       - scenarioVersion
       - scenarioVisualisationURL
+      - scenarioComment
 
   # ---------------------------------------------------------------------------
   # Behaviour
@@ -962,6 +963,11 @@ slots:
       Relative or absolute URL of a static image or animation of the scenario
       to allow users to easily see what the scenario represents.
     slot_uri: openlabel_v2:scenarioVisualisationURL
+    range: string
+
+  scenarioComment:
+    description: A free-text comment about the scenario.
+    slot_uri: openlabel_v2:scenarioComment
     range: string
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Demo: WL Structural Hashing — Diff-Stable Determinism

**DO NOT MERGE** — This PR exists to demonstrate diff-stable deterministic serialization using Weisfeiler-Lehman structural hashing.

**Compare with [#67](https://github.com/ASCS-eV/ontology-management-base/pull/67)** — same model change, upstream RDFC-1.0 only.

### What this shows

**Commit 1** (baseline): Regenerates openlabel-v2 artifacts using `--deterministic` flag (RDFC-1.0 + WL hashing). Blank node IDs are content-based `_:b<sha256>` hashes.

**Commit 2** (small change): Adds the same single string slot (`scenarioComment`) to `AdminTag`.

### The result

| File | Lines changed | Content |
|------|:---:|---------|
| `openlabel-v2.owl.ttl` | **+16** | scenarioComment property + 3 OWL restrictions |
| `openlabel-v2.shacl.ttl` | **+6** | scenarioComment SHACL property shape |
| **Total** | **22** | 100% real content, 0% renumbering noise |

### Comparison with upstream RDFC-1.0 ([PR #67](https://github.com/ASCS-eV/ontology-management-base/pull/67))

| Metric | RDFC-1.0 (PR #67) | WL Hashing (this PR) | Reduction |
|--------|:---:|:---:|:---:|
| OWL diff | ~2340 lines | 16 lines | **146x** |
| SHACL diff | ~3026 lines | 6 lines | **504x** |
| Total diff | ~5366 lines | 22 lines | **244x** |
| Signal-to-noise | ~0.2% signal | **100% signal** | — |

### Why it works

WL hashing computes each blank node's ID based on its **structural neighbourhood** (the triples it participates in), not its position in canonical ordering. When you add one slot:

- **RDFC-1.0:** The new triple shifts canonical order → all subsequent `_:c14nN` IDs increment → massive renumbering cascade
- **WL hashing:** Only the new blank nodes get new IDs → existing IDs are unchanged → diff shows only the actual change

### Implementation

The `--deterministic` flag on [ASCS-eV/linkml `feat/deterministic-output-v2`](https://github.com/ASCS-eV/linkml/tree/feat/deterministic-output-v2) layers three steps on top of upstream's RDFC-1.0:

1. **RDFC-1.0 canonicalization** (upstream #3407) — correctness guarantee
2. **WL structural hashing** — replaces `_:c14nN` with `_:b<sha256>` content-based IDs
3. **rdflib re-serialization** — idiomatic Turtle (inline blank nodes `[ ... ]`, collection syntax `( ... )`)

This builds ON TOP of the upstream work, not as a replacement.
