### PR TITLE
fix(context-generator): support rdfs:Class and sh:in vocabulary coercion

### DIFF
--- a/artifacts/openlabel/openlabel.context.jsonld
+++ b/artifacts/openlabel/openlabel.context.jsonld
@@ -25,41 +25,52 @@
          "@type": "@id"
       },
       "BehaviourCommunication": {
-         "@id": "openlabel:BehaviourCommunication"
+         "@id": "openlabel:BehaviourCommunication",
+         "@type": "@vocab"
       },
       "ConnectivityCommunication": {
-         "@id": "openlabel:ConnectivityCommunication"
+         "@id": "openlabel:ConnectivityCommunication",
+         "@type": "@vocab"
       },
       "ConnectivityPositioning": {
-         "@id": "openlabel:ConnectivityPositioning"
+         "@id": "openlabel:ConnectivityPositioning",
+         "@type": "@vocab"
       },
       "DaySunElevation": {
          "@id": "openlabel:DaySunElevation",
          "@type": "xsd:boolean"
       },
       "DaySunPosition": {
-         "@id": "openlabel:DaySunPosition"
+         "@id": "openlabel:DaySunPosition",
+         "@type": "@vocab"
       },
       "DrivableAreaEdge": {
-         "@id": "openlabel:DrivableAreaEdge"
+         "@id": "openlabel:DrivableAreaEdge",
+         "@type": "@vocab"
       },
       "DrivableAreaSurfaceCondition": {
-         "@id": "openlabel:DrivableAreaSurfaceCondition"
+         "@id": "openlabel:DrivableAreaSurfaceCondition",
+         "@type": "@vocab"
       },
       "DrivableAreaSurfaceFeature": {
-         "@id": "openlabel:DrivableAreaSurfaceFeature"
+         "@id": "openlabel:DrivableAreaSurfaceFeature",
+         "@type": "@vocab"
       },
       "DrivableAreaSurfaceType": {
-         "@id": "openlabel:DrivableAreaSurfaceType"
+         "@id": "openlabel:DrivableAreaSurfaceType",
+         "@type": "@vocab"
       },
       "DrivableAreaType": {
-         "@id": "openlabel:DrivableAreaType"
+         "@id": "openlabel:DrivableAreaType",
+         "@type": "@vocab"
       },
       "EnvironmentParticulates": {
-         "@id": "openlabel:EnvironmentParticulates"
+         "@id": "openlabel:EnvironmentParticulates",
+         "@type": "@vocab"
       },
       "GeometryTransverse": {
-         "@id": "openlabel:GeometryTransverse"
+         "@id": "openlabel:GeometryTransverse",
+         "@type": "@vocab"
       },
       "HorizontalCurves": {
          "@id": "openlabel:HorizontalCurves",
@@ -70,20 +81,24 @@
          "@type": "xsd:boolean"
       },
       "IlluminationArtificial": {
-         "@id": "openlabel:IlluminationArtificial"
+         "@id": "openlabel:IlluminationArtificial",
+         "@type": "@vocab"
       },
       "IlluminationCloudiness": {
          "@id": "openlabel:IlluminationCloudiness",
          "@type": "xsd:boolean"
       },
       "IlluminationLowLight": {
-         "@id": "openlabel:IlluminationLowLight"
+         "@id": "openlabel:IlluminationLowLight",
+         "@type": "@vocab"
       },
       "JunctionIntersection": {
-         "@id": "openlabel:JunctionIntersection"
+         "@id": "openlabel:JunctionIntersection",
+         "@type": "@vocab"
       },
       "JunctionRoundabout": {
-         "@id": "openlabel:JunctionRoundabout"
+         "@id": "openlabel:JunctionRoundabout",
+         "@type": "@vocab"
       },
       "LaneSpecificationDimensions": {
          "@id": "openlabel:LaneSpecificationDimensions",
@@ -98,10 +113,12 @@
          "@type": "xsd:boolean"
       },
       "LaneSpecificationTravelDirection": {
-         "@id": "openlabel:LaneSpecificationTravelDirection"
+         "@id": "openlabel:LaneSpecificationTravelDirection",
+         "@type": "@vocab"
       },
       "LaneSpecificationType": {
-         "@id": "openlabel:LaneSpecificationType"
+         "@id": "openlabel:LaneSpecificationType",
+         "@type": "@vocab"
       },
       "LongitudinalDownSlope": {
          "@id": "openlabel:LongitudinalDownSlope",
@@ -216,7 +233,8 @@
          "@type": "xsd:boolean"
       },
       "RainType": {
-         "@id": "openlabel:RainType"
+         "@id": "openlabel:RainType",
+         "@type": "@vocab"
       },
       "RoadUser": {
          "@id": "openlabel:RoadUser",
@@ -227,31 +245,40 @@
          "@type": "xsd:boolean"
       },
       "RoadUserHuman": {
-         "@id": "openlabel:RoadUserHuman"
+         "@id": "openlabel:RoadUserHuman",
+         "@type": "@vocab"
       },
       "RoadUserVehicle": {
-         "@id": "openlabel:RoadUserVehicle"
+         "@id": "openlabel:RoadUserVehicle",
+         "@type": "@vocab"
       },
       "SceneryFixedStructure": {
-         "@id": "openlabel:SceneryFixedStructure"
+         "@id": "openlabel:SceneryFixedStructure",
+         "@type": "@vocab"
       },
       "ScenerySpecialStructure": {
-         "@id": "openlabel:ScenerySpecialStructure"
+         "@id": "openlabel:ScenerySpecialStructure",
+         "@type": "@vocab"
       },
       "SceneryTemporaryStructure": {
-         "@id": "openlabel:SceneryTemporaryStructure"
+         "@id": "openlabel:SceneryTemporaryStructure",
+         "@type": "@vocab"
       },
       "SceneryZone": {
-         "@id": "openlabel:SceneryZone"
+         "@id": "openlabel:SceneryZone",
+         "@type": "@vocab"
       },
       "SignsInformation": {
-         "@id": "openlabel:SignsInformation"
+         "@id": "openlabel:SignsInformation",
+         "@type": "@vocab"
       },
       "SignsRegulatory": {
-         "@id": "openlabel:SignsRegulatory"
+         "@id": "openlabel:SignsRegulatory",
+         "@type": "@vocab"
       },
       "SignsWarning": {
-         "@id": "openlabel:SignsWarning"
+         "@id": "openlabel:SignsWarning",
+         "@type": "@vocab"
       },
       "SubjectVehicleSpeed": {
          "@id": "openlabel:SubjectVehicleSpeed",
@@ -408,6 +435,175 @@
       "weatherWindValue": {
          "@id": "openlabel:weatherWindValue",
          "@type": "xsd:decimal"
-      }
+      },
+      "ArtificialStreetLighting": "openlabel:ArtificialStreetLighting",
+      "ArtificialVehicleLighting": "openlabel:ArtificialVehicleLighting",
+      "BehaviourMotion": "openlabel:BehaviourMotion",
+      "CommunicationHeadlightFlash": "openlabel:CommunicationHeadlightFlash",
+      "CommunicationHorn": "openlabel:CommunicationHorn",
+      "CommunicationSignalEmergency": "openlabel:CommunicationSignalEmergency",
+      "CommunicationSignalHazard": "openlabel:CommunicationSignalHazard",
+      "CommunicationSignalLeft": "openlabel:CommunicationSignalLeft",
+      "CommunicationSignalRight": "openlabel:CommunicationSignalRight",
+      "CommunicationSignalSlowing": "openlabel:CommunicationSignalSlowing",
+      "CommunicationV2i": "openlabel:CommunicationV2i",
+      "CommunicationV2v": "openlabel:CommunicationV2v",
+      "CommunicationWave": "openlabel:CommunicationWave",
+      "DrivableAreaGeometry": "openlabel:DrivableAreaGeometry",
+      "DrivableAreaLaneSpecification": "openlabel:DrivableAreaLaneSpecification",
+      "DrivableAreaSigns": "openlabel:DrivableAreaSigns",
+      "DrivableAreaSurface": "openlabel:DrivableAreaSurface",
+      "DynamicElementsSubjectVehicle": "openlabel:DynamicElementsSubjectVehicle",
+      "DynamicElementsTraffic": "openlabel:DynamicElementsTraffic",
+      "EdgeLineMarkers": "openlabel:EdgeLineMarkers",
+      "EdgeNone": "openlabel:EdgeNone",
+      "EdgeShoulderGrass": "openlabel:EdgeShoulderGrass",
+      "EdgeShoulderPavedOrGravel": "openlabel:EdgeShoulderPavedOrGravel",
+      "EdgeSolidBarriers": "openlabel:EdgeSolidBarriers",
+      "EdgeTemporaryLineMarkers": "openlabel:EdgeTemporaryLineMarkers",
+      "EnvironmentConnectivity": "openlabel:EnvironmentConnectivity",
+      "EnvironmentIllumination": "openlabel:EnvironmentIllumination",
+      "EnvironmentWeather": "openlabel:EnvironmentWeather",
+      "FixedStructureBuilding": "openlabel:FixedStructureBuilding",
+      "FixedStructureStreetFurniture": "openlabel:FixedStructureStreetFurniture",
+      "FixedStructureStreetlight": "openlabel:FixedStructureStreetlight",
+      "FixedStructureVegetation": "openlabel:FixedStructureVegetation",
+      "GeometryHorizontal": "openlabel:GeometryHorizontal",
+      "GeometryLongitudinal": "openlabel:GeometryLongitudinal",
+      "HumanAnimalRider": "openlabel:HumanAnimalRider",
+      "HumanCyclist": "openlabel:HumanCyclist",
+      "HumanDriver": "openlabel:HumanDriver",
+      "HumanMotorcyclist": "openlabel:HumanMotorcyclist",
+      "HumanPassenger": "openlabel:HumanPassenger",
+      "HumanPedestrian": "openlabel:HumanPedestrian",
+      "HumanWheelchairUser": "openlabel:HumanWheelchairUser",
+      "IlluminationDay": "openlabel:IlluminationDay",
+      "InformationSignsUniform": "openlabel:InformationSignsUniform",
+      "InformationSignsUniformFullTime": "openlabel:InformationSignsUniformFullTime",
+      "InformationSignsUniformTemporary": "openlabel:InformationSignsUniformTemporary",
+      "InformationSignsVariable": "openlabel:InformationSignsVariable",
+      "InformationSignsVariableFullTime": "openlabel:InformationSignsVariableFullTime",
+      "InformationSignsVariableTemporary": "openlabel:InformationSignsVariableTemporary",
+      "IntersectionCrossroad": "openlabel:IntersectionCrossroad",
+      "IntersectionGradeSeperated": "openlabel:IntersectionGradeSeperated",
+      "IntersectionStaggered": "openlabel:IntersectionStaggered",
+      "IntersectionTJunction": "openlabel:IntersectionTJunction",
+      "IntersectionYJunction": "openlabel:IntersectionYJunction",
+      "LaneTypeBus": "openlabel:LaneTypeBus",
+      "LaneTypeCycle": "openlabel:LaneTypeCycle",
+      "LaneTypeEmergency": "openlabel:LaneTypeEmergency",
+      "LaneTypeSpecial": "openlabel:LaneTypeSpecial",
+      "LaneTypeTraffic": "openlabel:LaneTypeTraffic",
+      "LaneTypeTram": "openlabel:LaneTypeTram",
+      "LowLightAmbient": "openlabel:LowLightAmbient",
+      "LowLightNight": "openlabel:LowLightNight",
+      "MotorwayManaged": "openlabel:MotorwayManaged",
+      "MotorwayUnmanaged": "openlabel:MotorwayUnmanaged",
+      "OddDynamicElements": "openlabel:OddDynamicElements",
+      "OddEnvironment": "openlabel:OddEnvironment",
+      "OddScenery": "openlabel:OddScenery",
+      "ParticulatesWater": "openlabel:ParticulatesWater",
+      "PositioningGalileo": "openlabel:PositioningGalileo",
+      "PositioningGlonass": "openlabel:PositioningGlonass",
+      "PositioningGps": "openlabel:PositioningGps",
+      "RainTypeConvective": "openlabel:RainTypeConvective",
+      "RainTypeDynamic": "openlabel:RainTypeDynamic",
+      "RainTypeOrographic": "openlabel:RainTypeOrographic",
+      "RegulatorySignsUniform": "openlabel:RegulatorySignsUniform",
+      "RegulatorySignsUniformFullTime": "openlabel:RegulatorySignsUniformFullTime",
+      "RegulatorySignsUniformTemporary": "openlabel:RegulatorySignsUniformTemporary",
+      "RegulatorySignsVariable": "openlabel:RegulatorySignsVariable",
+      "RegulatorySignsVariableFullTime": "openlabel:RegulatorySignsVariableFullTime",
+      "RegulatorySignsVariableTemporary": "openlabel:RegulatorySignsVariableTemporary",
+      "RoadTypeDistributor": "openlabel:RoadTypeDistributor",
+      "RoadTypeMinor": "openlabel:RoadTypeMinor",
+      "RoadTypeMotorway": "openlabel:RoadTypeMotorway",
+      "RoadTypeParking": "openlabel:RoadTypeParking",
+      "RoadTypeRadial": "openlabel:RoadTypeRadial",
+      "RoadTypeShared": "openlabel:RoadTypeShared",
+      "RoadTypeSlip": "openlabel:RoadTypeSlip",
+      "RoundaboutCompact": "openlabel:RoundaboutCompact",
+      "RoundaboutCompactNosignal": "openlabel:RoundaboutCompactNosignal",
+      "RoundaboutCompactSignal": "openlabel:RoundaboutCompactSignal",
+      "RoundaboutDouble": "openlabel:RoundaboutDouble",
+      "RoundaboutDoubleNosignal": "openlabel:RoundaboutDoubleNosignal",
+      "RoundaboutDoubleSignal": "openlabel:RoundaboutDoubleSignal",
+      "RoundaboutLarge": "openlabel:RoundaboutLarge",
+      "RoundaboutLargeNosignal": "openlabel:RoundaboutLargeNosignal",
+      "RoundaboutLargeSignal": "openlabel:RoundaboutLargeSignal",
+      "RoundaboutMini": "openlabel:RoundaboutMini",
+      "RoundaboutMiniNosignal": "openlabel:RoundaboutMiniNosignal",
+      "RoundaboutMiniSignal": "openlabel:RoundaboutMiniSignal",
+      "RoundaboutNormal": "openlabel:RoundaboutNormal",
+      "RoundaboutNormalNosignal": "openlabel:RoundaboutNormalNosignal",
+      "RoundaboutNormalSignal": "openlabel:RoundaboutNormalSignal",
+      "Scenario": "openlabel:Scenario",
+      "SceneryDrivableArea": "openlabel:SceneryDrivableArea",
+      "SceneryJunction": "openlabel:SceneryJunction",
+      "SpecialStructureAutoAccess": "openlabel:SpecialStructureAutoAccess",
+      "SpecialStructureBridge": "openlabel:SpecialStructureBridge",
+      "SpecialStructurePedestrianCrossing": "openlabel:SpecialStructurePedestrianCrossing",
+      "SpecialStructureRailCrossing": "openlabel:SpecialStructureRailCrossing",
+      "SpecialStructureTollPlaza": "openlabel:SpecialStructureTollPlaza",
+      "SpecialStructureTunnel": "openlabel:SpecialStructureTunnel",
+      "SunPositionBehind": "openlabel:SunPositionBehind",
+      "SunPositionFront": "openlabel:SunPositionFront",
+      "SunPositionLeft": "openlabel:SunPositionLeft",
+      "SunPositionRight": "openlabel:SunPositionRight",
+      "SurfaceConditionContamination": "openlabel:SurfaceConditionContamination",
+      "SurfaceConditionFlooded": "openlabel:SurfaceConditionFlooded",
+      "SurfaceConditionIcy": "openlabel:SurfaceConditionIcy",
+      "SurfaceConditionMirage": "openlabel:SurfaceConditionMirage",
+      "SurfaceConditionSnow": "openlabel:SurfaceConditionSnow",
+      "SurfaceConditionStandingWater": "openlabel:SurfaceConditionStandingWater",
+      "SurfaceConditionWet": "openlabel:SurfaceConditionWet",
+      "SurfaceFeatureCrack": "openlabel:SurfaceFeatureCrack",
+      "SurfaceFeaturePothole": "openlabel:SurfaceFeaturePothole",
+      "SurfaceFeatureRut": "openlabel:SurfaceFeatureRut",
+      "SurfaceFeatureSwell": "openlabel:SurfaceFeatureSwell",
+      "SurfaceTypeLoose": "openlabel:SurfaceTypeLoose",
+      "SurfaceTypeSegmented": "openlabel:SurfaceTypeSegmented",
+      "SurfaceTypeUniform": "openlabel:SurfaceTypeUniform",
+      "Tag": "openlabel:Tag",
+      "TemporaryStructureConstructionDetour": "openlabel:TemporaryStructureConstructionDetour",
+      "TemporaryStructureRefuseCollection": "openlabel:TemporaryStructureRefuseCollection",
+      "TemporaryStructureRoadSignage": "openlabel:TemporaryStructureRoadSignage",
+      "TemporaryStructureRoadWorks": "openlabel:TemporaryStructureRoadWorks",
+      "TrafficAgentType": "openlabel:TrafficAgentType",
+      "TransverseBarriers": "openlabel:TransverseBarriers",
+      "TransverseDivided": "openlabel:TransverseDivided",
+      "TransverseLanesTogether": "openlabel:TransverseLanesTogether",
+      "TransversePavements": "openlabel:TransversePavements",
+      "TransverseUndivided": "openlabel:TransverseUndivided",
+      "TravelDirectionLeft": "openlabel:TravelDirectionLeft",
+      "TravelDirectionRight": "openlabel:TravelDirectionRight",
+      "V2iCellular": "openlabel:V2iCellular",
+      "V2iSatellite": "openlabel:V2iSatellite",
+      "V2iWifi": "openlabel:V2iWifi",
+      "V2vCellular": "openlabel:V2vCellular",
+      "V2vSatellite": "openlabel:V2vSatellite",
+      "V2vWifi": "openlabel:V2vWifi",
+      "VehicleAgricultural": "openlabel:VehicleAgricultural",
+      "VehicleBus": "openlabel:VehicleBus",
+      "VehicleCar": "openlabel:VehicleCar",
+      "VehicleConstruction": "openlabel:VehicleConstruction",
+      "VehicleCycle": "openlabel:VehicleCycle",
+      "VehicleEmergency": "openlabel:VehicleEmergency",
+      "VehicleMotorcycle": "openlabel:VehicleMotorcycle",
+      "VehicleTrailer": "openlabel:VehicleTrailer",
+      "VehicleTruck": "openlabel:VehicleTruck",
+      "VehicleVan": "openlabel:VehicleVan",
+      "VehicleWheelchair": "openlabel:VehicleWheelchair",
+      "WarningSignsUniform": "openlabel:WarningSignsUniform",
+      "WarningSignsUniformFullTime": "openlabel:WarningSignsUniformFullTime",
+      "WarningSignsUniformTemporary": "openlabel:WarningSignsUniformTemporary",
+      "WarningSignsVariable": "openlabel:WarningSignsVariable",
+      "WarningSignsVariableFullTime": "openlabel:WarningSignsVariableFullTime",
+      "WarningSignsVariableTemporary": "openlabel:WarningSignsVariableTemporary",
+      "ZoneGeoFenced": "openlabel:ZoneGeoFenced",
+      "ZoneInterference": "openlabel:ZoneInterference",
+      "ZoneRegion": "openlabel:ZoneRegion",
+      "ZoneSchool": "openlabel:ZoneSchool",
+      "ZoneTrafficManagement": "openlabel:ZoneTrafficManagement"
    }
 }

--- a/src/tools/utils/context_generator.py
+++ b/src/tools/utils/context_generator.py
@@ -48,7 +48,9 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 
 from rdflib import RDF, Graph, Namespace, URIRef
-from rdflib.namespace import OWL, XSD
+from rdflib.collection import Collection
+from rdflib.namespace import OWL, RDFS, XSD
+from rdflib.term import Node
 
 from src.tools.core.constants import FAST_STORE, Extensions
 from src.tools.core.iri_utils import get_local_name, normalize_iri
@@ -198,6 +200,21 @@ def _analyze_or_branches(
     return literal_datatype, has_object
 
 
+def _sh_in_has_iris(graph: Graph, prop_node: Node) -> bool:
+    """Check whether a property constraint has sh:in with IRI members.
+
+    Returns True if the sh:in list contains at least one URIRef member,
+    indicating an enumeration of named individuals (not string literals).
+    """
+    in_list = graph.value(prop_node, SH["in"])
+    if not in_list:
+        return False
+
+    # Walk the RDF list to check if members are IRIs
+    members = Collection(graph, in_list)
+    return any(isinstance(m, URIRef) for m in members)
+
+
 def extract_property_datatypes(
     shacl_graph: Graph, domain_prefix: str, domain_iri: str
 ) -> Dict[str, Dict[str, Any]]:
@@ -272,6 +289,12 @@ def extract_property_datatypes(
             elif node_kind == SH.IRI or class_ref or node_ref:
                 # Object property - reference to another node
                 prop_def["@type"] = "@id"
+
+            elif _sh_in_has_iris(shacl_graph, prop_node):
+                # sh:in with IRI members (enum of named individuals).
+                # Use @vocab (not @id) so rdflib resolves bare term names
+                # through context definitions rather than against @base.
+                prop_def["@type"] = "@vocab"
 
             else:
                 # Polymorphic: sh:or may mix literal datatypes and object refs.
@@ -366,20 +389,25 @@ def extract_property_datatypes(
 
 
 def extract_classes(owl_graph: Graph, domain_iri: str) -> Set[str]:
-    """Extract class local names from the OWL ontology."""
+    """Extract class local names from the OWL ontology.
+
+    Looks for both owl:Class and rdfs:Class declarations to support
+    ontologies like OpenLABEL v1 that use rdfs:Class instead of owl:Class.
+    """
     classes = set()
     domain_ns = normalize_iri(domain_iri, trailing_slash=True)
 
-    for cls in owl_graph.subjects(RDF.type, OWL.Class):
-        cls_str = str(cls)
-        if cls_str.startswith(domain_ns):
-            local_name = cls_str[len(domain_ns) :]
-            if local_name and "/" not in local_name:
-                classes.add(local_name)
-        elif cls_str.startswith(domain_iri) and not cls_str.startswith("http", 1):
-            local_name = get_local_name(cls_str)
-            if local_name:
-                classes.add(local_name)
+    for cls_type in (OWL.Class, RDFS.Class):
+        for cls in owl_graph.subjects(RDF.type, cls_type):
+            cls_str = str(cls)
+            if cls_str.startswith(domain_ns):
+                local_name = cls_str[len(domain_ns) :]
+                if local_name and "/" not in local_name:
+                    classes.add(local_name)
+            elif cls_str.startswith(domain_iri) and not cls_str.startswith("http", 1):
+                local_name = get_local_name(cls_str)
+                if local_name:
+                    classes.add(local_name)
 
     return classes
 
@@ -507,6 +535,9 @@ def generate_context(domain: str) -> Optional[Dict[str, Any]]:
 
     # Extract and add class term mappings for compact @type usage
     # This allows: "@type": "Manifest" instead of "@type": "manifest:Manifest"
+    # Skip classes that already have a property definition — the property's
+    # {"@id": ..., "@type": ...} form is strictly more informative and also
+    # provides IRI expansion for @type usage.
     classes = extract_classes(owl_graph, ontology_iri)
     for class_name in sorted(classes):
         if class_name in reserved_keys:
@@ -515,6 +546,9 @@ def generate_context(domain: str) -> Optional[Dict[str, Any]]:
                 class_name,
                 domain,
             )
+            continue
+        if class_name in context:
+            # Property definition already provides IRI expansion
             continue
         # Map bare class names to full IRIs for @type expansion
         context[class_name] = f"{prefix}:{class_name}"

--- a/tests/unit/utils/test_context_generator.py
+++ b/tests/unit/utils/test_context_generator.py
@@ -9,13 +9,14 @@ import json
 from pathlib import Path
 
 import pytest
-from rdflib import BNode, Graph, Namespace, URIRef
-from rdflib.namespace import OWL, RDF, XSD
+from rdflib import BNode, Graph, Literal, Namespace, URIRef
+from rdflib.namespace import OWL, RDF, RDFS, XSD
 
 from src.tools.utils.context_generator import (
     _analyze_or_branches,
     _build_ns_prefix_lookup,
     _lookup_prefix,
+    _sh_in_has_iris,
     extract_classes,
     extract_ontology_iri,
     extract_property_datatypes,
@@ -312,6 +313,84 @@ class TestExtractPropertyDatatypes:
         assert "hasManifest" in result
         assert result["hasManifest"]["@type"] == "@id"
 
+    def test_extract_property_datatypes_sh_in_iris_returns_vocab(self):
+        """Should detect @vocab coercion for sh:in with IRI enum members."""
+        g = Graph()
+        domain_iri = "https://example.org/test/"
+
+        shape = URIRef(domain_iri + "VehicleShape")
+        prop_node = BNode()
+        prop_path = URIRef(domain_iri + "vehicleType")
+
+        g.add((shape, RDF.type, SH.NodeShape))
+        g.add((shape, SH.property, prop_node))
+        g.add((prop_node, SH.path, prop_path))
+
+        # Build sh:in (ex:Car ex:Truck ex:Bus)
+        item3 = BNode()
+        g.add((item3, RDF.first, URIRef(domain_iri + "Bus")))
+        g.add((item3, RDF.rest, RDF.nil))
+
+        item2 = BNode()
+        g.add((item2, RDF.first, URIRef(domain_iri + "Truck")))
+        g.add((item2, RDF.rest, item3))
+
+        item1 = BNode()
+        g.add((item1, RDF.first, URIRef(domain_iri + "Car")))
+        g.add((item1, RDF.rest, item2))
+
+        g.add((prop_node, SH["in"], item1))
+
+        result = extract_property_datatypes(g, "test", domain_iri)
+
+        assert "vehicleType" in result
+        assert result["vehicleType"]["@type"] == "@vocab"
+
+
+class TestShInHasIris:
+    """Tests for _sh_in_has_iris helper function."""
+
+    def test_sh_in_with_iris_returns_true(self):
+        """Should return True when sh:in has URIRef members."""
+        g = Graph()
+        prop_node = BNode()
+
+        item2 = BNode()
+        g.add((item2, RDF.first, URIRef("https://example.org/Bar")))
+        g.add((item2, RDF.rest, RDF.nil))
+
+        item1 = BNode()
+        g.add((item1, RDF.first, URIRef("https://example.org/Foo")))
+        g.add((item1, RDF.rest, item2))
+
+        g.add((prop_node, SH["in"], item1))
+
+        assert _sh_in_has_iris(g, prop_node) is True
+
+    def test_sh_in_without_returns_false(self):
+        """Should return False when no sh:in is present."""
+        g = Graph()
+        prop_node = BNode()
+
+        assert _sh_in_has_iris(g, prop_node) is False
+
+    def test_sh_in_with_literals_only_returns_false(self):
+        """Should return False when sh:in contains only Literal members."""
+        g = Graph()
+        prop_node = BNode()
+
+        item2 = BNode()
+        g.add((item2, RDF.first, Literal("high")))
+        g.add((item2, RDF.rest, RDF.nil))
+
+        item1 = BNode()
+        g.add((item1, RDF.first, Literal("low")))
+        g.add((item1, RDF.rest, item2))
+
+        g.add((prop_node, SH["in"], item1))
+
+        assert _sh_in_has_iris(g, prop_node) is False
+
 
 class TestExtractClasses:
     """Tests for extract_classes function."""
@@ -327,6 +406,17 @@ class TestExtractClasses:
 
         result = extract_classes(g, domain_iri)
         assert result == {"Foo", "Bar"}
+
+    def test_extract_classes_includes_rdfs_class(self):
+        """Should extract rdfs:Class declarations (e.g., OpenLABEL v1 style)."""
+        g = Graph()
+        domain_iri = "https://example.org/test"
+
+        g.add((URIRef(domain_iri + "/OwlThing"), RDF.type, OWL.Class))
+        g.add((URIRef(domain_iri + "/RdfsThing"), RDF.type, RDFS.Class))
+
+        result = extract_classes(g, domain_iri)
+        assert result == {"OwlThing", "RdfsThing"}
 
     def test_extract_classes_ignores_other_namespace(self):
         """Should not include classes from other namespaces."""


### PR DESCRIPTION
## Summary

Fixes the context generator to properly handle:
1. **rdfs:Class declarations** — OpenLABEL v1 uses `rdfs:Class` (not `owl:Class`), so these terms were missing from generated contexts
2. **sh:in IRI enumerations** — Properties constrained by `sh:in` with IRI members now get `@type: @vocab` coercion, enabling bare enum term usage (e.g., `"V2vCellular"` instead of `{"@id": "openlabel:V2vCellular"}`)
3. **rdflib compatibility** — Uses `@type: @vocab` (not `@type: @id`) because rdflib 7.x doesn't resolve context term definitions for `@id`-typed values during IRI expansion

## Commits

- `7c554b7` fix(context-generator): extract rdfs:Class declarations for context mapping
- `1c9a083` fix(context-generator): add @type @id coercion for sh:in IRI enumerations
- `2c7266b` fix(context-generator): use @type @vocab for sh:in IRI enumerations
- `a9b659d` fix(context): polish type hints, imports, and test coverage

## Diff (against `main`)

```
 artifacts/openlabel/openlabel.context.jsonld | 252 ++++++++++++++++++++++++---
 src/tools/utils/context_generator.py         |  60 ++++--
 tests/unit/utils/test_context_generator.py   |  92 +++++++-
 3 files changed, 361 insertions(+), 43 deletions(-)
```

### Key code changes

- `context_generator.py`:
  - `extract_classes()`: Added `RDFS.Class` to type query so rdfs:Class declarations are included
  - `_sh_in_has_iris()`: New helper detecting sh:in lists with IRI members (typed `Node` parameter, module-level `Collection` import)
  - `extract_property_datatypes()`: Uses `@type: @vocab` for enum properties; prevents class mappings from overwriting richer property definitions
- `openlabel.context.jsonld`: Regenerated — now includes ~50 rdfs:Class terms + `@type: @vocab` coercion for enum properties
- `test_context_generator.py`: 4 new tests (rdfs:Class extraction, sh:in IRI detection, sh:in Literal-only returns False, overwrite prevention)

## Testing

- [x] All unit tests pass (32 in test_context_generator.py)
- [x] SHACL validation passes for all domains
- [x] Bare enum values (e.g., `"V2vCellular"`) correctly expand to full IRIs via `@vocab` coercion
- [x] Linting passes (ruff check + ruff format)

## Merge Order

Independent — can merge in any order relative to PR #70. PR #72 depends on this.