### PR TITLE
fix(build): normalize line endings in generated artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,9 +208,9 @@ _generate_default:
 	for domain in $$DOMAINS_TO_BUILD; do \
 		echo "  Processing $$domain..."; \
 		mkdir -p artifacts/$$domain; \
-		"$(GEN_OWL)" --deterministic --normalize-prefixes --xsd-anyuri-as-iri --no-metadata --default-language en --ontology-uri-suffix "" linkml/$$domain/$$domain.yaml > artifacts/$$domain/$$domain.owl.ttl 2>/dev/null; \
-		"$(GEN_SHACL)" --deterministic --normalize-prefixes --no-metadata --default-language en --message-template "{name} ({class}): {description}" linkml/$$domain/$$domain.yaml > artifacts/$$domain/$$domain.shacl.ttl 2>/dev/null; \
-		"$(GEN_JSONLD_CONTEXT)" --deterministic --normalize-prefixes --no-metadata --exclude-external-imports --xsd-anyuri-as-iri linkml/$$domain/$$domain.yaml > artifacts/$$domain/$$domain.context.jsonld 2>/dev/null; \
+		"$(GEN_OWL)" --deterministic --normalize-prefixes --xsd-anyuri-as-iri --no-metadata --default-language en --ontology-uri-suffix "" linkml/$$domain/$$domain.yaml 2>/dev/null | tr -d '\r' > artifacts/$$domain/$$domain.owl.ttl; \
+		"$(GEN_SHACL)" --deterministic --normalize-prefixes --no-metadata --default-language en --message-template "{name} ({class}): {description}" linkml/$$domain/$$domain.yaml 2>/dev/null | tr -d '\r' > artifacts/$$domain/$$domain.shacl.ttl; \
+		"$(GEN_JSONLD_CONTEXT)" --deterministic --normalize-prefixes --no-metadata --exclude-external-imports --xsd-anyuri-as-iri linkml/$$domain/$$domain.yaml 2>/dev/null | tr -d '\r' > artifacts/$$domain/$$domain.context.jsonld; \
 	done
 	@echo "[OK] Artifacts generated"
 


### PR DESCRIPTION
## Summary

On Windows, LinkML generators write CRLF to stdout. When piped through shell redirection, generated `.ttl` and `.jsonld` files end up with `\r\n` line endings, causing pre-commit hooks to enter an infinite fix-loop:

1. `generate-linkml` hook produces CRLF artifacts
2. `mixed-line-ending` hook fixes to LF
3. Hooks report "files modified" -- commit fails
4. Retry triggers step 1 again

## Changes

- Pipe all three generator outputs (`gen-owl`, `gen-shacl`, `gen-jsonld-context`) through `tr -d '\r'` before shell redirection
- Move `2>/dev/null` before the pipe so stderr is suppressed before `tr` sees it
- On Linux/macOS this is a no-op (no `\r` bytes to strip)

## Testing

- Verified on Windows: generated artifacts have zero CRLF after `make generate`
- On Linux: `tr -d '\r'` is a no-op, no behavioral change
- PR #74 CI "Generate Artifacts" job passes (confirms no difference on Linux)