### PR TITLE
fix(scenario): rename formatType to 'ASAM OpenSCENARIO XML'

### DIFF
--- a/artifacts/scenario/scenario.shacl.ttl
+++ b/artifacts/scenario/scenario.shacl.ttl
@@ -171,9 +171,9 @@ scenario:ContentOrDynamicAnnotationShape a sh:NodeShape ;
 ### Detailed Shapes (Expanded based on Instance Data)
 scenario:FormatShape a sh:NodeShape ;
     sh:closed false ;
-    sh:property [ skos:example "ASAM OpenSCENARIO" ;
+    sh:property [ skos:example "ASAM OpenSCENARIO XML" ;
             sh:description "Defines the type of data format used for the scenario asset."@en ;
-            sh:in ("ASAM OpenSCENARIO" "ASAM OpenSCENARIO DSL" "Other") ;
+            sh:in ("ASAM OpenSCENARIO XML" "ASAM OpenSCENARIO DSL" "Other") ;
             sh:maxCount 1 ;
             sh:message "Validation of type failed!"@en ;
             sh:name "type"@en ;

--- a/tests/data/scenario/invalid/fail01_false_value_scenario_instance.json
+++ b/tests/data/scenario/invalid/fail01_false_value_scenario_instance.json
@@ -37,7 +37,7 @@
       "@type": "scenario:DomainSpecification",
       "scenario:hasFormat": {
          "@type": "scenario:Format",
-         "scenario:formatType": "ASAM OpenSCENARIO",
+         "scenario:formatType": "ASAM OpenSCENARIO XML",
          "scenario:version": "1.2"
       },
       "scenario:hasContent": [

--- a/tests/data/scenario/invalid/fail02_misspelled_property_scenario_instance.json
+++ b/tests/data/scenario/invalid/fail02_misspelled_property_scenario_instance.json
@@ -36,7 +36,7 @@
       "@type": "scenario:DomainSpecification",
       "scenario:hasFormat": {
          "@type": "scenario:Format",
-         "scenario:formatType": "ASAM OpenSCENARIO",
+         "scenario:formatType": "ASAM OpenSCENARIO XML",
          "scenario:version": {
             "@value": "1.2",
             "@type": "xsd:string"

--- a/tests/data/scenario/invalid/fail03_prefixed_float_bypass_coercion.json
+++ b/tests/data/scenario/invalid/fail03_prefixed_float_bypass_coercion.json
@@ -33,7 +33,7 @@
       "@type": "scenario:DomainSpecification",
       "scenario:hasFormat": {
          "@type": "scenario:Format",
-         "scenario:formatType": "ASAM OpenSCENARIO",
+         "scenario:formatType": "ASAM OpenSCENARIO XML",
          "scenario:version": "1.2"
       },
       "scenario:hasContent": [

--- a/tests/data/scenario/invalid/fail04_prefixed_geo_bypass_coercion.json
+++ b/tests/data/scenario/invalid/fail04_prefixed_geo_bypass_coercion.json
@@ -33,7 +33,7 @@
       "@type": "scenario:DomainSpecification",
       "scenario:hasFormat": {
          "@type": "scenario:Format",
-         "scenario:formatType": "ASAM OpenSCENARIO",
+         "scenario:formatType": "ASAM OpenSCENARIO XML",
          "scenario:version": "1.2"
       },
       "scenario:hasContent": [

--- a/tests/data/scenario/invalid/fail05_prefixed_filepath_bypass_coercion.json
+++ b/tests/data/scenario/invalid/fail05_prefixed_filepath_bypass_coercion.json
@@ -33,7 +33,7 @@
       "@type": "scenario:DomainSpecification",
       "scenario:hasFormat": {
          "@type": "scenario:Format",
-         "scenario:formatType": "ASAM OpenSCENARIO",
+         "scenario:formatType": "ASAM OpenSCENARIO XML",
          "scenario:version": "1.2"
       },
       "scenario:hasContent": [

--- a/tests/data/scenario/invalid/fail06_string_value_for_float.json
+++ b/tests/data/scenario/invalid/fail06_string_value_for_float.json
@@ -33,7 +33,7 @@
       "@type": "scenario:DomainSpecification",
       "scenario:hasFormat": {
          "@type": "scenario:Format",
-         "formatType": "ASAM OpenSCENARIO",
+         "formatType": "ASAM OpenSCENARIO XML",
          "version": "1.2"
       },
       "scenario:hasContent": [

--- a/tests/data/scenario/invalid/fail07_boolean_value_for_float.json
+++ b/tests/data/scenario/invalid/fail07_boolean_value_for_float.json
@@ -33,7 +33,7 @@
       "@type": "scenario:DomainSpecification",
       "scenario:hasFormat": {
          "@type": "scenario:Format",
-         "formatType": "ASAM OpenSCENARIO",
+         "formatType": "ASAM OpenSCENARIO XML",
          "version": "1.2"
       },
       "scenario:hasContent": [

--- a/tests/data/scenario/invalid/fail08_string_value_for_integer.json
+++ b/tests/data/scenario/invalid/fail08_string_value_for_integer.json
@@ -33,7 +33,7 @@
       "@type": "scenario:DomainSpecification",
       "scenario:hasFormat": {
          "@type": "scenario:Format",
-         "formatType": "ASAM OpenSCENARIO",
+         "formatType": "ASAM OpenSCENARIO XML",
          "version": "1.2"
       },
       "scenario:hasContent": [

--- a/tests/data/scenario/invalid/fail09_float_value_for_integer.json
+++ b/tests/data/scenario/invalid/fail09_float_value_for_integer.json
@@ -33,7 +33,7 @@
       "@type": "scenario:DomainSpecification",
       "scenario:hasFormat": {
          "@type": "scenario:Format",
-         "formatType": "ASAM OpenSCENARIO",
+         "formatType": "ASAM OpenSCENARIO XML",
          "version": "1.2"
       },
       "scenario:hasContent": [

--- a/tests/data/scenario/invalid/fail11_object_value_for_literal.json
+++ b/tests/data/scenario/invalid/fail11_object_value_for_literal.json
@@ -33,7 +33,7 @@
       "@type": "scenario:DomainSpecification",
       "scenario:hasFormat": {
          "@type": "scenario:Format",
-         "formatType": "ASAM OpenSCENARIO",
+         "formatType": "ASAM OpenSCENARIO XML",
          "version": "1.2"
       },
       "scenario:hasContent": [

--- a/tests/data/scenario/invalid/fail12_wrong_enum_value_flat_context.json
+++ b/tests/data/scenario/invalid/fail12_wrong_enum_value_flat_context.json
@@ -30,7 +30,7 @@
       "@type": "scenario:DomainSpecification",
       "scenario:hasFormat": {
          "@type": "scenario:Format",
-         "formatType": "ASAM OpenSCENARIO",
+         "formatType": "ASAM OpenSCENARIO XML",
          "version": "1.2"
       },
       "scenario:hasContent": [

--- a/tests/data/scenario/valid/scenario_instance.json
+++ b/tests/data/scenario/valid/scenario_instance.json
@@ -30,7 +30,7 @@
       "@type": "scenario:DomainSpecification",
       "scenario:hasFormat": {
          "@type": "scenario:Format",
-         "formatType": "ASAM OpenSCENARIO",
+         "formatType": "ASAM OpenSCENARIO XML",
          "version": "1.2"
       },
       "scenario:hasContent": [

--- a/tests/data/scenario/valid/scenario_minimal_instance.json
+++ b/tests/data/scenario/valid/scenario_minimal_instance.json
@@ -32,7 +32,7 @@
       "@type": "scenario:DomainSpecification",
       "scenario:hasFormat": {
          "@type": "scenario:Format",
-         "scenario:formatType": "ASAM OpenSCENARIO",
+         "scenario:formatType": "ASAM OpenSCENARIO XML",
          "scenario:version": "1.3"
       },
       "scenario:hasContent": {


### PR DESCRIPTION
## Summary

Rename the generic `"ASAM OpenSCENARIO"` value in the `scenario:formatType` `sh:in` constraint to `"ASAM OpenSCENARIO XML"`.

## Motivation

Since January 2024, ASAM officially split OpenSCENARIO into two independent standards:

- **ASAM OpenSCENARIO XML** (formerly v1.x) — XML-based format
- **ASAM OpenSCENARIO DSL** (formerly v2.x) — Domain-Specific Language

The generic `"ASAM OpenSCENARIO"` is no longer specific enough as it does not distinguish between these two distinct standards.

## Changes

- `artifacts/scenario/scenario.shacl.ttl`: Updated `sh:in` and `skos:example` from `"ASAM OpenSCENARIO"` to `"ASAM OpenSCENARIO XML"`
- Updated all 13 test fixtures (valid + invalid) to use the new value

## References

- [ASAM announcement: OpenSCENARIO 1 and 2 split into separate standards (Jan 2024)](https://www.asam.net/news-media/detail/news/asam-openscenarior-1-and-2-split-into-separate-standards/)
- [ASAM OpenSCENARIO XML BS 1.4.0 Specification](https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/index.html)
- [ASAM OpenSCENARIO DSL BS 2.2.0 Specification](https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_DSL/latest/normative_references.html)

## Backward compatibility

The sl-5-8-asset-tools pipeline will infer the suffix from the version number for data that still uses the old generic name:
- Version 1.x → `"ASAM OpenSCENARIO XML"`
- Version 2.x → `"ASAM OpenSCENARIO DSL"`