### PR TITLE
docs: add ASAM OpenX standards reference library as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "submodules/linkml"]
 	path = submodules/linkml
 	url = https://github.com/ASCS-eV/linkml.git
+[submodule "submodules/asam-openx-standards"]
+	path = submodules/asam-openx-standards
+	url = https://github.com/ASCS-eV/asam-openx-standards.git


### PR DESCRIPTION
## Summary

Adds the [ASCS-eV/asam-openx-standards](https://github.com/ASCS-eV/asam-openx-standards)
repository as a submodule at `submodules/asam-openx-standards`. This provides
version-pinned markdown copies of all publicly available ASAM OpenX simulation standards,
following the [harbour-credentials](https://github.com/reachhaven/harbour-credentials/)
pattern of embedding reference specifications alongside ontology source code.

## Motivation

The ENVITED-X ontologies (openlabel-v2, hdmap, scenario, etc.) are all rooted in
ASAM OpenX standards and ISO 345xx. By having the full spec text available as
markdown in a linked submodule, AI agents can:

1. Implement LinkML schemas with exact section-level citations
2. Identify shared terminology across standards (reducing naming inconsistencies)
3. Cross-reference definitions between standards when adding new classes/slots
4. Validate that our ontology models correctly represent the underlying standards

## Changes

### New: Submodule `submodules/asam-openx-standards`

Points to `ASCS-eV/asam-openx-standards` @ dd056af which includes:

| Directory | Standard | Files | Coverage |
|-----------|----------|-------|----------|
| `asam-openodd/` | ASAM OpenODD® v1.0.0 | 62 | Full spec + ISO 34503 taxonomy |
| `asam-opendrive/` | ASAM OpenDRIVE® v1.9.0 | 95 | Full spec (roads, lanes, junctions, signals) |
| `asam-openscenario-dsl/` | ASAM OpenSCENARIO® DSL v2.2.0 | 59 | Full spec (language reference + domain model) |
| `asam-openmaterial-3d/` | ASAM OpenMATERIAL® 3D BS 1.0.0 | 27 | Full spec (geometry + material schemas) |
| `asam-openlabel/` | ASAM OpenLABEL® v1.0.0 | 2 | Overview + JSON schema reference |
| `asam-osi/` | ASAM OSI® v3.7+ | 1 | Overview (nested MPL-2.0 submodule) |
| `asam-opencrg/` | ASAM OpenCRG® v1.2 | 1 | Overview (nested Apache-2.0 submodule) |
| `asam-traffic-participants/` | ASAM TrafficParticipants v1.0.2 | 1 | Overview (spec not public) |
| `iso-345xx/` | ISO 34503:2023 | 1 | Paraphrased summary (copyright-compliant) |

**Total: 251 chapter files across 8 domains + 2 nested submodules (OSI, OpenCRG)**

### Modified: `.gitmodules`

Added entry for `submodules/asam-openx-standards`.

## Legal Basis

Each ASAM OpenX standard on publications.pages.asam.net carries an
"Unrestricted Distribution" exception that replaces the restrictive §2(1)
of the standard ASAM license:

> "The licensor grants everyone a basic, non-exclusive and unlimited license
> to use the standard ASAM [Name]"

This was verified on: OpenDRIVE, OpenSCENARIO DSL, OpenODD, OpenLABEL,
OpenMATERIAL 3D. The submodule repo's LICENSE and NOTICE files document
the full legal basis.

## Domain Mapping (standards ↔ ontologies)

| ASAM Standard | ENVITED-X Domain | Semantic Overlap |
|---------------|-----------------|------------------|
| OpenODD® | openlabel-v2 (Odd class) | Same ISO 34503 taxonomy; OpenODD adds rule logic |
| OpenLABEL® | openlabel, openlabel-v2 | Direct source standard |
| OpenDRIVE® | hdmap | HD map format; road geometry, lanes, junctions |
| OpenSCENARIO® DSL | scenario | Scenario description; maneuvers, triggers |
| OSI® | ositrace | Sensor data interface; ground truth |
| OpenCRG® | surface-model | Road surface profiles |
| OpenMATERIAL® 3D | environment-model | Material properties for rendering/sensors |
| TrafficParticipants | scenario, openlabel-v2 | Road user classifications |

## Testing

- [x] No validation suite changes required (submodule addition only)
- [x] Pre-existing tests unaffected (XSD schemas in `imports/` remain in place)
- [x] Compliance audit passed (5 independent agents verified redistribution legality)

## Notes

- XSD schemas in `imports/` stay in place — they serve a different purpose (build-time
  dependencies for `xsd_shacl_sync.py` and `xsd_enum_extractor.py`)
- The submodule repo has its own download automation (`scripts/download_asam_specs.py`)
  for updating when new standard versions are published

## Related Issues

N/A — proactive documentation infrastructure for AI-driven ontology development
