### PR TITLE
docs: add purpose documentation, README rewrite, and agent infrastructure

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -166,6 +166,52 @@ git add artifacts/ && git commit -s -S -m "feat: ..."
 If hooks still fail, `--no-verify` is acceptable but **verify CI passes after push**.
 The committed state must be byte-identical to Linux `make generate` + hook normalization.
 
+## ASAM Standards Reference (submodule)
+
+Standards are in `submodules/asam-openx-standards/standards/`. See the submodule's
+`AGENTS.md` for full navigation guidance.
+
+### Key Files for Ontology Work
+
+| Task | File to Read |
+|------|-------------|
+| Validate hdmap enum values | `standards/asam-opendrive/map-uml-enumerations.md` |
+| Check road/lane definitions | `standards/asam-opendrive/03-terms-and-definitions.md` |
+| Understand ODD taxonomy | `standards/asam-openodd/06-02-*` through `06-08-*` |
+| Cross-check openlabel types | `standards/asam-openlabel/INDEX.md` |
+| Verify OpenSCENARIO concepts | `standards/asam-openscenario-dsl/` chapters |
+| Find machine-readable enums | `ENUMERATIONS.yaml` (root of submodule) |
+| Map concepts across standards | `CROSS_REFERENCES.md` (root of submodule) |
+
+### Ontology Purpose
+
+These ontologies are **searchable metadata descriptors** — NOT full data models.
+They summarize what's inside simulation files to enable natural language search
+via [ontology-based-nl-search](https://github.com/ASCS-eV/ontology-based-nl-search).
+
+When adding properties, apply the property test:
+> "What natural language search query does this property enable?"
+
+### Citation Pattern
+
+When modifying ontology properties that reference ASAM standards:
+
+```turtle
+# In SHACL
+sh:description "Road types per OpenDRIVE v1.9.0, Annex A.6.2 (e_roadType)"@en ;
+
+# In OWL
+dcterms:source "ASAM OpenDRIVE v1.9.0, Annex A.6.2, Table 194" ;
+```
+
+```yaml
+# In LinkML
+comments:
+  - "[OpenDRIVE] Annex A.3.7, Table 176 (e_laneType)"
+see_also:
+  - https://publications.pages.asam.net/standards/ASAM_OpenDRIVE/...
+```
+
 ## Git Commit Policy
 
 **STRICT REQUIREMENTS:**

--- a/README.md
+++ b/README.md
@@ -3,9 +3,37 @@
 [![CI Pipeline](https://github.com/ASCS-eV/ontology-management-base/actions/workflows/ci-quality.yml/badge.svg)](https://github.com/ASCS-eV/ontology-management-base/actions/workflows/ci-quality.yml)
 [![Documentation](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://ascs-ev.github.io/ontology-management-base/)
 
-Central repository for the [ENVITED-X Ecosystem](https://envited-x.net/) of the Automotive Solution Center for Simulation e.V. It serves as the single source of truth for [Gaia-X 25.11](https://gitlab.com/gaia-x/technical-committee/service-characteristics-working-group/service-characteristics) compliant ontologies, including those developed within the [Gaia-X 4 PLC-AAD](https://www.gaia-x4plcaad.info/) project.
+Ontologies for **discovering and describing simulation assets** in the [ENVITED-X](https://envited-x.net/) data space, maintained by the Automotive Solution Center for Simulation e.V. ([ASCS](https://www.2-3-2.de/)). Compliant with [Gaia-X 25.11](https://gitlab.com/gaia-x/technical-committee/service-characteristics-working-group/service-characteristics).
 
 > **Note:** This repository is the active development home, forked from [GAIA-X4PLC-AAD/ontology-management-base](https://github.com/GAIA-X4PLC-AAD/ontology-management-base) (archived after `v0.1.0`).
+
+## What This Does
+
+These ontologies define **searchable metadata** for simulation assets (HD maps, scenarios, sensor traces, environment models). They enable:
+
+- **Natural language search** — "find all German motorway maps with 3+ lanes" → [ontology-based-nl-search](https://github.com/ASCS-eV/ontology-based-nl-search)
+- **Structured annotation** — describe your assets so others can find them → [sl-5-8-asset-tools](https://github.com/openMSL/sl-5-8-asset-tools)
+- **Cross-domain discovery** — find scenarios that reference a specific HD map
+- **Quality validation** — ensure metadata annotations are complete and correct (SHACL)
+
+The ontology is **not** a copy of the ASAM OpenDRIVE/OpenSCENARIO data model. It's a metadata layer that summarizes what's inside data files — a 100MB OpenDRIVE file is described by ~2KB of searchable `hdmap:HdMap` metadata.
+
+## Who Uses This
+
+| Role | Activity | Tool |
+|------|----------|------|
+| **Data Searcher** | Find assets by properties (NL or structured) | [NL Search App](https://github.com/ASCS-eV/ontology-based-nl-search) |
+| **Data Creator** | Annotate assets with metadata for discovery | [Asset Tools](https://github.com/openMSL/sl-5-8-asset-tools) |
+| **Ontology Developer** | Extend the metadata schema for new domains | This repository |
+
+## How It Works
+
+```mermaid
+flowchart TD
+    A[/"Simulation Asset<br/>(OpenDRIVE, OSI, OpenSCENARIO...)"/] -->|annotate| B["JSON-LD Metadata<br/>(@type: hdmap:HdMap)"]
+    B -->|validate · SHACL| C[("Knowledge Graph<br/>(SPARQL endpoint)")]
+    C -->|search · NL → SPARQL| D["'Show me highway maps near Munich'"]
+```
 
 ## Getting Started
 
@@ -17,17 +45,19 @@ Central repository for the [ENVITED-X Ecosystem](https://envited-x.net/) of the 
 
 ## Quick Links
 
-- **[Full Documentation](https://ascs-ev.github.io/ontology-management-base/)** - Complete guides and references
-- **[Validation](https://ascs-ev.github.io/ontology-management-base/validation/strategy/)** - Run checks on your data
-- **[Contributing](https://ascs-ev.github.io/ontology-management-base/getting-started/contribute/)** - How to add or modify ontologies
-- **[Gaia-X 4 PLC-AAD](https://ascs-ev.github.io/ontology-management-base/gaiax/gaiax4plc-aad/)** - Federated catalog upload flow
+- **[Full Documentation](https://ascs-ev.github.io/ontology-management-base/)** — Complete guides and references
+- **[Validation](https://ascs-ev.github.io/ontology-management-base/validation/strategy/)** — Run checks on your data
+- **[Contributing](https://ascs-ev.github.io/ontology-management-base/getting-started/contribute/)** — How to add or modify ontologies
+- **[ASAM OpenX Standards](https://github.com/ASCS-eV/asam-openx-standards)** — Source standard references (submodule)
+- **[Gaia-X 4 PLC-AAD](https://ascs-ev.github.io/ontology-management-base/gaiax/gaiax4plc-aad/)** — Federated catalog upload flow
 
 ## What's in This Repository
 
-- **Ontologies** - OWL definitions with SHACL validation shapes
-- **Validation Tools** - Python scripts to validate instances
-- **Test Data** - Examples and regression tests
-- **Documentation** - Guides, APIs, and specifications
+- **Ontologies** — OWL definitions with SHACL validation shapes (`artifacts/`)
+- **Validation Tools** — Python suite to validate metadata instances (`src/tools/`)
+- **Test Data** — Valid and invalid examples per domain (`tests/data/`)
+- **Documentation** — Guides, architecture, and specifications (`docs/`)
+- **Standard References** — ASAM OpenX specs as submodule (`submodules/asam-openx-standards/`)
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI Pipeline](https://github.com/ASCS-eV/ontology-management-base/actions/workflows/ci-quality.yml/badge.svg)](https://github.com/ASCS-eV/ontology-management-base/actions/workflows/ci-quality.yml)
 [![Documentation](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://ascs-ev.github.io/ontology-management-base/)
 
-Ontologies for **discovering and describing simulation assets** in the [ENVITED-X](https://envited-x.net/) data space, maintained by the Automotive Solution Center for Simulation e.V. ([ASCS](https://www.2-3-2.de/)). Compliant with [Gaia-X 25.11](https://gitlab.com/gaia-x/technical-committee/service-characteristics-working-group/service-characteristics).
+Ontologies for **discovering and describing simulation assets** in the [ENVITED-X](https://envited-x.net/) data space, maintained by the Automotive Solution Center for Simulation e.V. ([ASCS](https://www.asc-s.de/)). Compliant with [Gaia-X 25.11](https://gitlab.com/gaia-x/technical-committee/service-characteristics-working-group/service-characteristics).
 
 > **Note:** This repository is the active development home, forked from [GAIA-X4PLC-AAD/ontology-management-base](https://github.com/GAIA-X4PLC-AAD/ontology-management-base) (archived after `v0.1.0`).
 

--- a/docs/concepts/purpose.md
+++ b/docs/concepts/purpose.md
@@ -1,0 +1,157 @@
+# Purpose and Design Philosophy
+
+## Why These Ontologies Exist
+
+The ENVITED-X ontologies solve a fundamental problem: **simulation assets are opaque files**. An OpenDRIVE map file, an OpenSCENARIO scenario, or an OSI trace contains rich structured data — but you cannot search across thousands of them without first understanding what's inside each one.
+
+These ontologies provide a **searchable metadata layer** that sits alongside simulation assets, enabling discovery without parsing each file's native format.
+
+## The Two Personas
+
+### Data Searcher
+
+> "Show me all HD maps of German motorways with at least 3 lanes and right-hand traffic"
+
+The searcher doesn't want to download and parse hundreds of `.xodr` files. They need a search interface that understands simulation-domain concepts (road types, lane types, geographic coverage, accuracy) and can query structured metadata.
+
+**How it works:**
+
+1. A natural language query is translated into structured search slots
+2. Slots are validated against the SHACL schema (ensuring valid property names and enum values)
+3. A SPARQL query is compiled from the validated slots
+4. The graph store returns matching assets
+
+The [ontology-based-nl-search](https://github.com/ASCS-eV/ontology-based-nl-search) application implements this flow. The ontology IS the search schema — every property becomes a searchable facet, every enum value becomes a filter option.
+
+### Data Creator
+
+> "I have an OpenDRIVE 1.8 file of the A9 near Munich — how do I make it findable?"
+
+The creator annotates their asset with JSON-LD metadata conforming to the ontology. The annotation captures what's important for discovery without duplicating the entire file content.
+
+**How it works:**
+
+1. The creator (or automated tooling like [sl-5-8-asset-tools](https://github.com/openMSL/sl-5-8-asset-tools)) produces a JSON-LD instance
+2. The instance declares `@type: hdmap:HdMap` and populates properties (format, content, quality, quantity)
+3. SHACL validation ensures the metadata is complete and values are correct
+4. The validated metadata is indexed in a knowledge graph for search
+
+### The Feedback Loop
+
+Both personas generate feedback that improves the ontology:
+
+- **Searcher can't find what they want** → missing property or enum value
+- **Creator can't describe their asset** → missing concept or inadequate granularity
+- **Search returns wrong results** → property semantics unclear or overlapping
+
+This gap-discovery process drives ontology evolution.
+
+## Metadata, Not Data Modeling
+
+A critical design principle: **these ontologies describe metadata ABOUT simulation assets, not the assets themselves**.
+
+```
+┌────────────────────────────────────────────────────┐
+│  SIMULATION ASSET (e.g., highway.xodr, 100MB)      │
+│                                                    │
+│  Contains: every road, lane, junction, signal,     │
+│  geometry point, elevation sample...               │
+│  Format: OpenDRIVE XSD schema (implicit ontology)  │
+└────────────────────────────────────────────────────┘
+                     │
+                     │ DESCRIBED BY (summarized, not duplicated)
+                     ▼
+┌────────────────────────────────────────────────────┐
+│  METADATA ANNOTATION (~2KB JSON-LD)                │
+│                                                    │
+│  "This file is an ASAM OpenDRIVE v1.8 map.        │
+│   It covers 45km of motorway with 12 junctions.   │
+│   Right-hand traffic. Lane types: driving,         │
+│   shoulder. Accuracy: ±0.1m 2D."                   │
+│                                                    │
+│  Format: ENVITED-X ontology (explicit, searchable) │
+└────────────────────────────────────────────────────┘
+```
+
+The ontology does NOT re-model OpenDRIVE's road geometry, signal semantics, or lane structure. Instead it captures the **discovery-relevant summary** of what's inside.
+
+## Relationship to Source Standards
+
+The ontologies relate to ASAM/ISO standards in five ways:
+
+| Relationship | Description | Example |
+|-------------|-------------|---------|
+| **Aligns** | Uses the same terminology and enum values | `hdmap:roadTypes` uses OpenDRIVE `e_roadType` values verbatim |
+| **Summarizes** | Counts or lists what's in the file | `numberJunctions: 12` (not each junction's structure) |
+| **Extends** | Adds metadata not present in the format itself | `accuracyLaneModel2d: 0.1` (quality info external to the file) |
+| **Complements** | Adds governance/provenance context | `hasManifest`, `hasResourceDescription` (Gaia-X layer) |
+| **Interconnects** | Links across simulation domains | `scenario` references `hdmap` + `environment-model` |
+
+## Design Principles
+
+1. **Search-first** — Every property should answer a plausible user query. If no one would search by it, it's low priority.
+
+2. **Standard-aligned** — Use the same terms as ASAM/ISO standards. Don't invent new names for existing concepts. Cite the normative source.
+
+3. **Version-aware** — Track format versions and enforce version-appropriate constraints. OpenDRIVE 1.4 has different valid values than 1.8.
+
+4. **Cross-domain** — Enable queries that span multiple asset types. "Find scenarios that use a specific HD map" requires linked metadata.
+
+5. **Fail-fast validation** — SHACL shapes ensure metadata is correct at creation time, not when someone tries to search and gets bad results.
+
+6. **Gap-discoverable** — When the search app can't answer a question, that's a signal to add a property. Document gaps explicitly.
+
+## The Property Test
+
+When considering adding a new ontology property, apply this test:
+
+> **"What natural language search query does this property enable?"**
+
+- ✅ `junctionTypes` → "Find maps with roundabouts" — clear search value
+- ✅ `geometryTypes` → "Find maps with spiral road segments" — useful for tooling
+- ❌ `numberOfGeometryPoints` → Nobody searches by vertex count — too low-level
+- ❌ `xmlSchemaVersion` → Internal technical detail, not a discovery criterion
+
+## Architecture Overview
+
+```
+ENVITED-X Ontology Stack
+═══════════════════════════════════════════════════════
+
+    ┌─────────────────────────────────────────────┐
+    │          Gaia-X Trust Framework              │  Governance
+    │  (gx:ServiceOffering, Compliance, Trust)     │  & Identity
+    └──────────────────────┬──────────────────────┘
+                           │
+    ┌──────────────────────▼──────────────────────┐
+    │         envited-x (base layer)              │  Shared Types
+    │  SimulationAsset, Manifest, ResourceDesc    │  & Wrappers
+    └──────────────────────┬──────────────────────┘
+                           │
+    ┌──────────┬───────────┼───────────┬──────────┐
+    │          │           │           │          │
+    ▼          ▼           ▼           ▼          ▼
+┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐
+│ hdmap  │ │scenario│ │osi-    │ │environ-│ │surface-│  Domain
+│        │ │        │ │trace   │ │ment-   │ │model   │  Specific
+│OpenDRIVE│ │OpenSCE-│ │OSI     │ │model   │ │OpenCRG │
+│Lanelet │ │NARIO   │ │        │ │OpenMAT │ │        │
+└────────┘ └────────┘ └────────┘ └────────┘ └────────┘
+
+    ┌──────────────────────────────────────────────┐
+    │       openlabel-v2 (cross-cutting)           │  ODD/Labeling
+    │  ISO 34503 taxonomy, weather, road users     │  (shared by
+    │  OpenODD modules, OpenLABEL types            │   multiple)
+    └──────────────────────────────────────────────┘
+```
+
+Each domain ontology:
+
+- Is a subclass of `envited-x:SimulationAsset`
+- Has a `DomainSpecification` with format, content, quality, quantity facets
+- Uses SHACL to validate enum values appropriate to the format version
+- Can reference other domains (e.g., scenario → hdmap)
+
+## Source Standards Reference
+
+The [asam-openx-standards](https://github.com/ASCS-eV/asam-openx-standards) submodule (at `submodules/asam-openx-standards/`) contains version-pinned markdown copies of all referenced ASAM standards. See its `AGENTS.md` for navigation guidance and `ENUMERATIONS.yaml` for machine-readable enum data.


### PR DESCRIPTION
## Summary

Adds clear purpose documentation explaining **why** the ontologies exist and **how** agents should use the ASAM standards references.

## Motivation

The README previously said only *'single source of truth for Gaia-X compliant ontologies'* — technically correct but explaining nothing about the discovery/search purpose. The [ontology-based-nl-search](https://github.com/ASCS-eV/ontology-based-nl-search) app proves the design but was never referenced in docs.

## Changes

### README.md (rewritten intro)
- Purpose-driven framing: *'Ontologies for discovering and describing simulation assets'*
- Mermaid architecture diagram (vertical flowchart)
- Three user personas table (Searcher, Creator, Developer)
- Links to NL search app and asset tools
- Updated Quick Links and What's in This Repository sections

### docs/concepts/purpose.md (NEW)
- Full conceptual framework: metadata layer vs data modeling
- Two personas with concrete examples
- Gap-discovery feedback loop
- Five relationship types to source standards (aligns/summarizes/extends/complements/interconnects)
- Design principles and the Property Test
- Architecture overview diagram

### .github/copilot-instructions.md (updated)
- New section: ASAM Standards Reference navigation guide
- Key files table for ontology work
- Citation patterns (SHACL, OWL, LinkML)
- Ontology purpose statement and property test

### submodules/asam-openx-standards (updated pointer)
- Now includes \AGENTS.md\: quick-reference for AI agents navigating standards
- Now includes \CROSS_REFERENCES.md\: concept equivalence table across standards
- Now includes \ENUMERATIONS.yaml\: machine-readable enum index with deprecation info

## Testing

- [x] No code changes — documentation only
- [x] Pre-commit hooks pass (mixed-line-ending fixed)
- [x] Submodule pointer verified

## Related

- Builds on PR #78 (ASAM OpenX standards submodule)
- References [ontology-based-nl-search](https://github.com/ASCS-eV/ontology-based-nl-search)
- References [sl-5-8-asset-tools](https://github.com/openMSL/sl-5-8-asset-tools)
