### PR TITLE
feat(openlabel): add structural LinkML schema for ASAM v1 JSON format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,14 @@ repos:
         types: [python]
         pass_filenames: true
 
+      - id: sync-tag-type-enum
+        name: Sync TagTypeEnum to structural schema
+        entry: python scripts/sync_tag_type_enum.py
+        language: system
+        pass_filenames: false
+        files: ^linkml/openlabel-v2/openlabel-v2\.yaml$
+        stages: [pre-commit]
+
       - id: generate-linkml
         name: Generate LinkML Artifacts
         entry: make generate
@@ -51,7 +59,7 @@ repos:
         entry: python -m src.tools.utils.registry_updater
         language: system
         pass_filenames: false
-        files: ^artifacts/.*\.(owl\.ttl|shacl\.ttl|context\.jsonld)$
+        files: ^artifacts/.*\.(owl\.ttl|shacl\.ttl|context\.jsonld|schema\.json)$
         stages: [pre-commit]
 
       - id: update-properties
@@ -59,7 +67,7 @@ repos:
         entry: python -m src.tools.utils.properties_updater
         language: system
         pass_filenames: false
-        files: ^artifacts/.*\.(owl\.ttl|shacl\.ttl|context\.jsonld)$
+        files: ^artifacts/.*\.(owl\.ttl|shacl\.ttl|context\.jsonld|schema\.json)$
         stages: [pre-commit]
 
       - id: update-readme
@@ -67,7 +75,7 @@ repos:
         entry: python -m src.tools.utils.readme_updater
         language: system
         pass_filenames: false
-        files: ^artifacts/.*\.(owl\.ttl|shacl\.ttl|context\.jsonld)$
+        files: ^artifacts/.*\.(owl\.ttl|shacl\.ttl|context\.jsonld|schema\.json)$
         stages: [pre-commit]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ endef
 GEN_OWL := $(VENV_BIN)/gen-owl
 GEN_SHACL := $(VENV_BIN)/gen-shacl
 GEN_JSONLD_CONTEXT := $(VENV_BIN)/gen-jsonld-context
+GEN_JSON_SCHEMA := $(VENV_BIN)/gen-json-schema
 
 # LinkML domains — add new domains here
 LINKML_DOMAINS := openlabel-v2
@@ -211,6 +212,10 @@ _generate_default:
 		"$(GEN_OWL)" --deterministic --normalize-prefixes --xsd-anyuri-as-iri --no-metadata --default-language en --ontology-uri-suffix "" linkml/$$domain/$$domain.yaml 2>/dev/null | tr -d '\r' | sed -e '$${' -e '/^$$/d' -e '}' > artifacts/$$domain/$$domain.owl.ttl; \
 		"$(GEN_SHACL)" --deterministic --normalize-prefixes --no-metadata --default-language en --message-template "{name} ({class}): {description} {comments}" linkml/$$domain/$$domain.yaml 2>/dev/null | tr -d '\r' | sed -e '$${' -e '/^$$/d' -e '}' > artifacts/$$domain/$$domain.shacl.ttl; \
 		"$(GEN_JSONLD_CONTEXT)" --deterministic --normalize-prefixes --no-metadata --exclude-external-imports --xsd-anyuri-as-iri linkml/$$domain/$$domain.yaml 2>/dev/null | tr -d '\r' | sed -e '$${' -e '/^$$/d' -e '}' > artifacts/$$domain/$$domain.context.jsonld; \
+		if [ -f linkml/$$domain/$$domain-schema.yaml ]; then \
+			echo "    Generating JSON Schema for $$domain..."; \
+			"$(GEN_JSON_SCHEMA)" linkml/$$domain/$$domain-schema.yaml 2>/dev/null | tr -d '\r' > artifacts/$$domain/$$domain.schema.json; \
+		fi; \
 	done
 	@echo "[OK] Artifacts generated"
 
@@ -408,7 +413,7 @@ _help_general:
 	@echo "  make format         - Format code with ruff"
 	@echo ""
 	@echo "LinkML:"
-	@echo "  make generate                     - Generate OWL/SHACL/context from all OMB LinkML schemas"
+	@echo "  make generate                     - Generate OWL/SHACL/context/JSON Schema from all OMB LinkML schemas"
 	@echo "  make generate DOMAIN=openlabel-v2 - Generate for a specific OMB domain"
 	@echo "  make generate gx                  - Build and sync Gaia-X artifacts from service-characteristics"
 	@echo "  make generate help                - Show generate subcommands"
@@ -434,7 +439,7 @@ _help_install:
 
 _help_generate:
 	@echo "Generate subcommands:"
-	@echo "  make generate                     - Generate OWL/SHACL/context from all OMB LinkML schemas"
+	@echo "  make generate                     - Generate OWL/SHACL/context/JSON Schema from all OMB LinkML schemas"
 	@echo "  make generate DOMAIN=openlabel-v2 - Generate for a specific OMB domain"
 	@echo "  make generate gx                  - Build and sync Gaia-X artifacts from service-characteristics"
 	@echo "  make generate gx GX_REF=25.12     - Check out a specific Gaia-X ref before generating"

--- a/artifacts/openlabel-v2/openlabel-v2.schema.json
+++ b/artifacts/openlabel-v2/openlabel-v2.schema.json
@@ -1,0 +1,824 @@
+{
+    "$defs": {
+        "Attributes": {
+            "additionalProperties": false,
+            "description": "Nested attributes for any data entry. Same structure as tag_data.",
+            "properties": {
+                "boolean": {
+                    "description": "Nested boolean attributes.",
+                    "items": {
+                        "$ref": "#/$defs/BooleanVal"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "num": {
+                    "description": "Nested numeric attributes.",
+                    "items": {
+                        "$ref": "#/$defs/NumVal"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "text": {
+                    "description": "Nested text attributes.",
+                    "items": {
+                        "$ref": "#/$defs/TextVal"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "vec": {
+                    "description": "Nested vector attributes.",
+                    "items": {
+                        "$ref": "#/$defs/VecVal"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                }
+            },
+            "title": "Attributes",
+            "type": "object"
+        },
+        "BooleanVal": {
+            "additionalProperties": false,
+            "description": "A boolean value entry in tag_data or attributes (spec 8.7.1).",
+            "properties": {
+                "attributes": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Attributes"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Nested attributes for this data entry."
+                },
+                "name": {
+                    "description": "Name of this data entry (used as index in data pointers).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "type": {
+                    "description": "How the value shall be interpreted (e.g., \"value\").",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "val": {
+                    "description": "The boolean value.",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "val"
+            ],
+            "title": "BooleanVal",
+            "type": "object"
+        },
+        "BoundaryModeEnum": {
+            "description": "Mode for interpreting the ontology tagging boundary (spec 8.2.2).",
+            "enum": [
+                "include",
+                "exclude"
+            ],
+            "title": "BoundaryModeEnum",
+            "type": "string"
+        },
+        "Metadata": {
+            "additionalProperties": false,
+            "description": "Metadata about the annotation file. The schema_version is mandatory.",
+            "properties": {
+                "annotator": {
+                    "description": "Name or identifier of the annotator.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "comment": {
+                    "description": "Free-text comment about the annotation.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "file_version": {
+                    "description": "Version of the annotation file.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "name": {
+                    "description": "Name of the annotation file.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "schema_version": {
+                    "description": "The version of the ASAM OpenLABEL schema this file conforms to.",
+                    "type": "string"
+                },
+                "tagged_file": {
+                    "description": "Path or URI to the raw data file that this annotation references.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "schema_version"
+            ],
+            "title": "Metadata",
+            "type": "object"
+        },
+        "NumTypeEnum": {
+            "description": "How a numeric value shall be interpreted in its context.",
+            "enum": [
+                "value",
+                "min",
+                "max"
+            ],
+            "title": "NumTypeEnum",
+            "type": "string"
+        },
+        "NumVal": {
+            "additionalProperties": false,
+            "description": "A numeric value entry in tag_data or attributes (spec 8.7.2).",
+            "properties": {
+                "attributes": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Attributes"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Nested attributes for this data entry."
+                },
+                "name": {
+                    "description": "Name of this data entry.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "type": {
+                    "$ref": "#/$defs/NumTypeEnum",
+                    "description": "How the number shall be interpreted: value, minimum, or maximum."
+                },
+                "val": {
+                    "description": "The numerical value.",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "val"
+            ],
+            "title": "NumVal",
+            "type": "object"
+        },
+        "OntologyEntry": {
+            "additionalProperties": false,
+            "description": "An ontology reference. Specifies the URI of the ontology and optional boundary controls for tagging subsets (spec 8.2.2).",
+            "properties": {
+                "boundary_list": {
+                    "description": "List of tag names that define the tagging boundary. Used with boundary_mode to specify which subset of ontology tags is relevant.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "boundary_mode": {
+                    "$ref": "#/$defs/BoundaryModeEnum",
+                    "description": "Whether boundary_list specifies inclusion or exclusion of tags."
+                },
+                "uid": {
+                    "description": "Unique identifier for this ontology entry (numeric UID or UUID).",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "URI of the ontology definition (RDF Turtle file URL).",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "uid",
+                "uri"
+            ],
+            "title": "OntologyEntry",
+            "type": "object"
+        },
+        "OntologyEntry__identifier_optional": {
+            "additionalProperties": false,
+            "description": "An ontology reference. Specifies the URI of the ontology and optional boundary controls for tagging subsets (spec 8.2.2).",
+            "properties": {
+                "boundary_list": {
+                    "description": "List of tag names that define the tagging boundary. Used with boundary_mode to specify which subset of ontology tags is relevant.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "boundary_mode": {
+                    "$ref": "#/$defs/BoundaryModeEnum",
+                    "description": "Whether boundary_list specifies inclusion or exclusion of tags."
+                },
+                "uid": {
+                    "description": "Unique identifier for this ontology entry (numeric UID or UUID).",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "URI of the ontology definition (RDF Turtle file URL).",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "uri"
+            ],
+            "title": "OntologyEntry",
+            "type": "object"
+        },
+        "OpenLabel": {
+            "additionalProperties": false,
+            "description": "The OpenLABEL root JSON object for scenario tagging. Contains metadata, ontology references, and tags. For scenario tagging, objects/actions/frames are not used (spec 8.1 - tags do not include spatiotemporal constructs).",
+            "properties": {
+                "metadata": {
+                    "$ref": "#/$defs/Metadata",
+                    "description": "Metadata about the annotation file (schema version, annotator, etc.)."
+                },
+                "ontologies": {
+                    "additionalProperties": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/$defs/OntologyEntry__identifier_optional"
+                            },
+                            {
+                                "description": "URI of the ontology definition (RDF Turtle file URL).",
+                                "format": "uri",
+                                "type": "string"
+                            }
+                        ]
+                    },
+                    "description": "Ontology references keyed by UID. Each entry specifies the URI of an ontology and optional tagging boundary controls.",
+                    "type": [
+                        "object",
+                        "null"
+                    ]
+                },
+                "tags": {
+                    "additionalProperties": {
+                        "$ref": "#/$defs/TagEntry__identifier_optional"
+                    },
+                    "description": "Tags keyed by UID. Each entry specifies the tag type (from an ontology) and optional tag_data with values.",
+                    "type": [
+                        "object",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "metadata"
+            ],
+            "title": "OpenLabel",
+            "type": "object"
+        },
+        "OpenLabelFile": {
+            "additionalProperties": false,
+            "description": "Root of an ASAM OpenLABEL JSON file. Contains a single \"openlabel\" key.",
+            "properties": {
+                "openlabel": {
+                    "$ref": "#/$defs/OpenLabel",
+                    "description": "The OpenLABEL root object containing all annotation data."
+                }
+            },
+            "required": [
+                "openlabel"
+            ],
+            "title": "OpenLabelFile",
+            "type": "object"
+        },
+        "ResourceUid": {
+            "additionalProperties": false,
+            "description": "References to external resources by UID.",
+            "properties": {
+                "uid": {
+                    "description": "Resource identifier.",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "URI of the external resource.",
+                    "format": "uri",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "uid"
+            ],
+            "title": "ResourceUid",
+            "type": "object"
+        },
+        "TagData": {
+            "additionalProperties": false,
+            "description": "Generic data associated with a tag. Contains arrays of typed values (boolean, numeric, text, vector). For scenario tagging, only non-geometric data types are used (spec 8.7).",
+            "properties": {
+                "boolean": {
+                    "description": "List of boolean values describing this tag.",
+                    "items": {
+                        "$ref": "#/$defs/BooleanVal"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "num": {
+                    "description": "List of numeric values describing this tag.",
+                    "items": {
+                        "$ref": "#/$defs/NumVal"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "text": {
+                    "description": "List of text values describing this tag.",
+                    "items": {
+                        "$ref": "#/$defs/TextVal"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "vec": {
+                    "description": "List of vector (array) values describing this tag.",
+                    "items": {
+                        "$ref": "#/$defs/VecVal"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                }
+            },
+            "title": "TagData",
+            "type": "object"
+        },
+        "TagEntry": {
+            "additionalProperties": false,
+            "description": "A single tag in an ASAM OpenLABEL file. References a tag type from an ontology and optionally includes tag_data with values.",
+            "properties": {
+                "ontology_uid": {
+                    "description": "UID of the ontology (from the ontologies section) where this tag type is defined.",
+                    "type": "string"
+                },
+                "resource_uid": {
+                    "description": "Reference to external resource identifiers.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "tag_data": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/TagData"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Optional data associated with this tag (values, ranges, text)."
+                },
+                "type": {
+                    "$ref": "#/$defs/TagTypeEnum",
+                    "description": "The type of tag, referencing a class or property name from the ontology. Constrained to valid values from the openlabel-v2 vocabulary."
+                },
+                "uid": {
+                    "description": "Unique identifier for this tag entry (numeric UID or UUID).",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "uid",
+                "type",
+                "ontology_uid"
+            ],
+            "title": "TagEntry",
+            "type": "object"
+        },
+        "TagEntry__identifier_optional": {
+            "additionalProperties": false,
+            "description": "A single tag in an ASAM OpenLABEL file. References a tag type from an ontology and optionally includes tag_data with values.",
+            "properties": {
+                "ontology_uid": {
+                    "description": "UID of the ontology (from the ontologies section) where this tag type is defined.",
+                    "type": "string"
+                },
+                "resource_uid": {
+                    "description": "Reference to external resource identifiers.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "tag_data": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/TagData"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Optional data associated with this tag (values, ranges, text)."
+                },
+                "type": {
+                    "$ref": "#/$defs/TagTypeEnum",
+                    "description": "The type of tag, referencing a class or property name from the ontology. Constrained to valid values from the openlabel-v2 vocabulary."
+                },
+                "uid": {
+                    "description": "Unique identifier for this tag entry (numeric UID or UUID).",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "type",
+                "ontology_uid"
+            ],
+            "title": "TagEntry",
+            "type": "object"
+        },
+        "TagTypeEnum": {
+            "description": "All valid values for the tag.type field in ASAM OpenLABEL v1 format files. Derived from the openlabel-v2 ontology vocabulary (classes, enums, slots). AUTO-GENERATED \u2014 do not edit manually.",
+            "enum": [
+                "Tag",
+                "AdminTag",
+                "Odd",
+                "Behaviour",
+                "RoadUser",
+                "licenseURI",
+                "ownerEmail",
+                "ownerName",
+                "ownerURL",
+                "scenarioCreatedDate",
+                "scenarioDefinition",
+                "scenarioDefinitionLanguageURI",
+                "scenarioDescription",
+                "scenarioName",
+                "scenarioParentReference",
+                "scenarioUniqueReference",
+                "scenarioVersion",
+                "scenarioVisualisationURL",
+                "DaySunElevation",
+                "HorizontalCurves",
+                "HorizontalStraights",
+                "IlluminationCloudiness",
+                "LaneSpecificationDimensions",
+                "LaneSpecificationLaneCount",
+                "LaneSpecificationMarking",
+                "LongitudinalDownSlope",
+                "LongitudinalLevelPlane",
+                "LongitudinalUpSlope",
+                "MotionAccelerate",
+                "MotionAway",
+                "MotionCross",
+                "MotionCutIn",
+                "MotionCutOut",
+                "MotionDecelerate",
+                "MotionDrive",
+                "MotionLaneChangeLeft",
+                "MotionLaneChangeRight",
+                "MotionOvertake",
+                "MotionReverse",
+                "MotionRun",
+                "MotionSlide",
+                "MotionStop",
+                "MotionTowards",
+                "MotionTurn",
+                "MotionTurnLeft",
+                "MotionTurnRight",
+                "MotionUTurn",
+                "MotionWalk",
+                "RoadUserAnimal",
+                "SubjectVehicleSpeed",
+                "TrafficAgentDensity",
+                "TrafficAgentType",
+                "TrafficFlowRate",
+                "TrafficSpecialVehicle",
+                "TrafficVolume",
+                "WeatherRain",
+                "WeatherSnow",
+                "WeatherWind",
+                "BehaviourCommunication",
+                "ConnectivityCommunication",
+                "ConnectivityPositioning",
+                "DaySunPosition",
+                "DrivableAreaEdge",
+                "DrivableAreaSurfaceCondition",
+                "DrivableAreaSurfaceFeature",
+                "DrivableAreaSurfaceType",
+                "DrivableAreaType",
+                "EnvironmentParticulates",
+                "GeometryTransverse",
+                "IlluminationArtificial",
+                "IlluminationLowLight",
+                "JunctionIntersection",
+                "JunctionRoundabout",
+                "LaneSpecificationTravelDirection",
+                "LaneSpecificationType",
+                "RainType",
+                "RoadUserHuman",
+                "RoadUserVehicle",
+                "SceneryFixedStructure",
+                "ScenerySpecialStructure",
+                "SceneryTemporaryStructure",
+                "SceneryZone",
+                "SignsInformation",
+                "SignsRegulatory",
+                "SignsWarning",
+                "CommunicationHeadlightFlash",
+                "CommunicationHorn",
+                "CommunicationSignalEmergency",
+                "CommunicationSignalHazard",
+                "CommunicationSignalLeft",
+                "CommunicationSignalRight",
+                "CommunicationSignalSlowing",
+                "CommunicationWave",
+                "CommunicationV2i",
+                "CommunicationV2v",
+                "V2iCellular",
+                "V2iSatellite",
+                "V2iWifi",
+                "V2vCellular",
+                "V2vSatellite",
+                "V2vWifi",
+                "PositioningGalileo",
+                "PositioningGlonass",
+                "PositioningGps",
+                "SunPositionBehind",
+                "SunPositionFront",
+                "SunPositionLeft",
+                "SunPositionRight",
+                "EdgeLineMarkers",
+                "EdgeNone",
+                "EdgeShoulderGrass",
+                "EdgeShoulderPavedOrGravel",
+                "EdgeSolidBarriers",
+                "EdgeTemporaryLineMarkers",
+                "SurfaceConditionContamination",
+                "SurfaceConditionFlooded",
+                "SurfaceConditionIcy",
+                "SurfaceConditionMirage",
+                "SurfaceConditionSnow",
+                "SurfaceConditionStandingWater",
+                "SurfaceConditionWet",
+                "SurfaceFeatureCrack",
+                "SurfaceFeaturePothole",
+                "SurfaceFeatureRut",
+                "SurfaceFeatureSwell",
+                "SurfaceTypeLoose",
+                "SurfaceTypeSegmented",
+                "SurfaceTypeUniform",
+                "MotorwayManaged",
+                "MotorwayUnmanaged",
+                "RoadTypeDistributor",
+                "RoadTypeMinor",
+                "RoadTypeMotorway",
+                "RoadTypeParking",
+                "RoadTypeRadial",
+                "RoadTypeShared",
+                "RoadTypeSlip",
+                "ParticulatesDust",
+                "ParticulatesMarine",
+                "ParticulatesPollution",
+                "ParticulatesVolcanic",
+                "ParticulatesWater",
+                "TransverseBarriers",
+                "TransverseDivided",
+                "TransverseLanesTogether",
+                "TransversePavements",
+                "TransverseUndivided",
+                "ArtificialStreetLighting",
+                "ArtificialVehicleLighting",
+                "LowLightAmbient",
+                "LowLightNight",
+                "IntersectionCrossroad",
+                "IntersectionGradeSeperated",
+                "IntersectionStaggered",
+                "IntersectionTJunction",
+                "IntersectionYJunction",
+                "RoundaboutCompactNosignal",
+                "RoundaboutCompactSignal",
+                "RoundaboutDoubleNosignal",
+                "RoundaboutDoubleSignal",
+                "RoundaboutLargeNosignal",
+                "RoundaboutLargeSignal",
+                "RoundaboutMiniNosignal",
+                "RoundaboutMiniSignal",
+                "RoundaboutNormalNosignal",
+                "RoundaboutNormalSignal",
+                "TravelDirectionLeft",
+                "TravelDirectionRight",
+                "LaneTypeBus",
+                "LaneTypeCycle",
+                "LaneTypeEmergency",
+                "LaneTypeSpecial",
+                "LaneTypeTraffic",
+                "LaneTypeTram",
+                "RainTypeConvective",
+                "RainTypeDynamic",
+                "RainTypeOrographic",
+                "HumanAnimalRider",
+                "HumanCyclist",
+                "HumanDriver",
+                "HumanMotorcyclist",
+                "HumanPassenger",
+                "HumanPedestrian",
+                "HumanWheelchairUser",
+                "VehicleAgricultural",
+                "VehicleBus",
+                "VehicleCar",
+                "VehicleConstruction",
+                "VehicleCycle",
+                "VehicleEmergency",
+                "VehicleMotorcycle",
+                "VehicleTrailer",
+                "VehicleTruck",
+                "VehicleVan",
+                "VehicleWheelchair",
+                "FixedStructureBuilding",
+                "FixedStructureStreetFurniture",
+                "FixedStructureStreetlight",
+                "FixedStructureVegetation",
+                "SpecialStructureAutoAccess",
+                "SpecialStructureBridge",
+                "SpecialStructurePedestrianCrossing",
+                "SpecialStructureRailCrossing",
+                "SpecialStructureTollPlaza",
+                "SpecialStructureTunnel",
+                "TemporaryStructureConstructionDetour",
+                "TemporaryStructureRefuseCollection",
+                "TemporaryStructureRoadSignage",
+                "TemporaryStructureRoadWorks",
+                "ZoneGeoFenced",
+                "ZoneInterference",
+                "ZoneRegion",
+                "ZoneSchool",
+                "ZoneTrafficManagement",
+                "InformationSignsUniformFullTime",
+                "InformationSignsUniformTemporary",
+                "InformationSignsVariableFullTime",
+                "InformationSignsVariableTemporary",
+                "RegulatorySignsUniformFullTime",
+                "RegulatorySignsUniformTemporary",
+                "RegulatorySignsVariableFullTime",
+                "RegulatorySignsVariableTemporary",
+                "WarningSignsUniform",
+                "WarningSignsUniformFullTime",
+                "WarningSignsUniformTemporary",
+                "WarningSignsVariableFullTime",
+                "WarningSignsVariableTemporary"
+            ],
+            "title": "TagTypeEnum",
+            "type": "string"
+        },
+        "TextVal": {
+            "additionalProperties": false,
+            "description": "A text value entry in tag_data or attributes (spec 8.7.3).",
+            "properties": {
+                "attributes": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Attributes"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Nested attributes for this data entry."
+                },
+                "name": {
+                    "description": "Name of this data entry.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "type": {
+                    "description": "How the text shall be interpreted (e.g., \"value\").",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "val": {
+                    "description": "The text value.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "val"
+            ],
+            "title": "TextVal",
+            "type": "object"
+        },
+        "VecTypeEnum": {
+            "description": "How a vector (array) value shall be interpreted.",
+            "enum": [
+                "range",
+                "set",
+                "values"
+            ],
+            "title": "VecTypeEnum",
+            "type": "string"
+        },
+        "VecVal": {
+            "additionalProperties": false,
+            "description": "A vector (array) value entry in tag_data or attributes (spec 8.7.4). Used for ranges, sets, and multi-valued data.",
+            "properties": {
+                "attributes": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Attributes"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Nested attributes for this data entry."
+                },
+                "name": {
+                    "description": "Name of this data entry.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "type": {
+                    "$ref": "#/$defs/VecTypeEnum",
+                    "description": "How the vector shall be interpreted: range, set, or values."
+                },
+                "val": {
+                    "description": "Array of values (numbers or strings). Interpretation depends on type.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "val"
+            ],
+            "title": "VecVal",
+            "type": "object"
+        }
+    },
+    "$id": "https://w3id.org/ascs-ev/envited-x/openlabel/schema/v1",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "additionalProperties": true,
+    "description": "Root of an ASAM OpenLABEL JSON file. Contains a single \"openlabel\" key.",
+    "metamodel_version": "1.11.0",
+    "properties": {
+        "openlabel": {
+            "$ref": "#/$defs/OpenLabel",
+            "description": "The OpenLABEL root object containing all annotation data."
+        }
+    },
+    "required": [
+        "openlabel"
+    ],
+    "title": "openlabel-v2-schema",
+    "type": "object",
+    "version": "1.0.0"
+}
+

--- a/linkml/openlabel-v2/SCHEMA_MODELING.md
+++ b/linkml/openlabel-v2/SCHEMA_MODELING.md
@@ -1,0 +1,222 @@
+# OpenLABEL v2 — Unified LinkML Modeling Strategy
+
+## Overview
+
+This directory contains **two complementary LinkML schemas** that together form
+the single source of truth for ASAM OpenLABEL scenario tagging:
+
+| Schema | Purpose | Generates |
+|--------|---------|-----------|
+| `openlabel-v2.yaml` | Semantic model (tag vocabulary) | OWL ontology, SHACL shapes, JSON-LD context |
+| `openlabel-v2-schema.yaml` | Structural model (file format) | JSON Schema for ASAM v1 format files |
+
+## Architecture
+
+```
+openlabel-v2.yaml (Semantic Model)
+├── 10 classes: Tag, AdminTag, Odd, Behaviour, RoadUser, QuantitativeValue, ...
+├── 113 typed slots: WeatherRain (boolean), weatherRainValue (decimal), ...
+├── 27 enums: DrivableAreaTypeEnum, JunctionIntersectionEnum, ...
+│   └── 142 permissible values
+└── Generates:
+    ├── openlabel-v2.owl.ttl       (OWL 2 ontology)
+    ├── openlabel-v2.shacl.ttl     (SHACL validation shapes)
+    └── openlabel-v2.context.jsonld (JSON-LD context with type coercion)
+
+openlabel-v2-schema.yaml (Structural Model)
+├── 12 classes: OpenLabelFile, OpenLabel, Metadata, TagEntry, TagData, ...
+├── TagTypeEnum: 227 valid tag.type values (derived from semantic model)
+├── BoundaryModeEnum, NumTypeEnum, VecTypeEnum
+└── Generates:
+    └── openlabel-v2.schema.json   (JSON Schema for ASAM v1 format)
+```
+
+## How They Work Together
+
+The **semantic model** defines WHAT tags exist and their validation rules.
+The **structural model** defines HOW those tags are serialized in ASAM v1 JSON files.
+
+The bridge between them is `TagTypeEnum` — it lists all 227 valid `tag.type` values
+derived from the semantic model's classes, slots, and enum values. When the
+vocabulary changes (e.g., adding a new tag), the `TagTypeEnum` is regenerated
+and the JSON Schema automatically reflects the update.
+
+```
+User changes openlabel-v2.yaml (add new tag)
+    │
+    ├── make generate → OWL/SHACL/context updated ✅
+    │
+    └── Regenerate TagTypeEnum → openlabel-v2-schema.yaml updated
+            │
+            └── gen-json-schema → JSON Schema updated ✅
+```
+
+## Functional Equivalence Proof
+
+The LinkML-generated JSON Schema was tested against the ASAM-authored JSON Schema
+using 9 test cases from the ASAM OpenLABEL v1.0.0 specification:
+
+| Test Case | ASAM Schema | LinkML Schema | Verdict |
+|-----------|-------------|---------------|---------|
+| Valid: minimal tagging (§8.6) | ✅ ACCEPT | ✅ ACCEPT | Equivalent |
+| Valid: full scenario (§8.8.1) | ✅ ACCEPT | ✅ ACCEPT | Equivalent |
+| Valid: boundary include (§8.2.2) | ✅ ACCEPT | ✅ ACCEPT | Equivalent |
+| Valid: numeric tag_data (§8.2.4) | ✅ ACCEPT | ✅ ACCEPT | Equivalent |
+| Invalid: missing metadata | ❌ REJECT | ❌ REJECT | Equivalent |
+| Invalid: missing tag.type | ❌ REJECT | ❌ REJECT | Equivalent |
+| Invalid: wrong tag.type value | ✅ ACCEPT | ❌ REJECT | **LinkML stricter** |
+| Invalid: wrong boundary_mode | ❌ REJECT | ❌ REJECT | Equivalent |
+| Invalid: num.val wrong type | ❌ REJECT | ❌ REJECT | Equivalent |
+
+**Result: 8/9 structurally equivalent. The one difference is that LinkML
+is STRICTER — it also validates vocabulary (tag.type values).**
+
+## Additional Gains from LinkML Modeling
+
+### 1. Vocabulary Validation (NEW — ASAM schema lacks this)
+
+The ASAM JSON Schema defines `tag.type` as an unconstrained `string`. Any value
+passes structural validation, even nonsense like `"CompletelyFakeTag"`.
+
+The LinkML-generated schema constrains `tag.type` to exactly 227 valid values
+derived from the ontology. Invalid vocabulary is caught at validation time:
+
+```
+ASAM:   {"type": "NonExistentTag", "ontology_uid": "0"} → ✅ VALID (!)
+LinkML: {"type": "NonExistentTag", "ontology_uid": "0"} → ❌ INVALID
+        "is not one of ['Tag', 'AdminTag', 'Odd', ...]"
+```
+
+### 2. Single Source of Truth (No Drift)
+
+| Artifact | Before (v1) | After (v2) |
+|----------|-------------|------------|
+| OWL ontology | Hand-maintained by ASAM | Generated from LinkML |
+| SHACL shapes | Hand-maintained by third party | Generated from LinkML |
+| JSON-LD context | Auto-generated from OWL+SHACL | Generated from LinkML |
+| JSON Schema | Hand-maintained by ASAM | Generated from LinkML |
+
+With both schemas in LinkML, **all four artifacts are generated from models**.
+A vocabulary change requires editing ONE file (`openlabel-v2.yaml`). All
+downstream artifacts update automatically. No manual synchronization needed.
+
+### 3. Enum Validation for Supporting Fields
+
+Beyond `tag.type`, the LinkML schema also validates:
+
+- `boundary_mode`: constrained to `["include", "exclude"]`
+- `num.type`: constrained to `["value", "min", "max"]`
+- `vec.type`: constrained to `["range", "set", "values"]`
+
+The ASAM schema has `boundary_mode` as an enum but leaves `num.type` and
+`vec.type` unconstrained. The LinkML schema enforces all of them.
+
+### 4. Required Field Validation (Equivalent)
+
+Both schemas enforce:
+- `metadata.schema_version` is required
+- `tag.type` is required
+- `tag.ontology_uid` is required
+- `ontology.uri` is required
+- `num.val`, `boolean.val`, `text.val`, `vec.val` are required
+
+### 5. Structural Typing (Equivalent)
+
+Both schemas validate:
+- `num.val` must be a number (not a string)
+- `boolean.val` must be a boolean
+- `vec.val` must be an array
+- `ontologies` and `tags` must be objects (dict-keyed)
+
+### 6. Documentation Co-location
+
+The LinkML schema includes `description` fields on every class and attribute,
+providing inline documentation that appears in the generated JSON Schema as
+`description` annotations. This makes the schema self-documenting.
+
+### 7. Cross-Validation with Semantic Artifacts
+
+When combined with the semantic model, users get **layered validation**:
+
+| Layer | Tool | What it validates |
+|-------|------|-------------------|
+| 1. Structure | JSON Schema (from schema model) | Keys, types, required fields |
+| 2. Vocabulary | JSON Schema TagTypeEnum | Valid tag.type values |
+| 3. Semantics | SHACL (from semantic model) | Enum values, cardinality, conditional rules |
+| 4. Reasoning | OWL (from semantic model) | Class consistency, property ranges |
+
+A single `@context` IRI enables the v2 JSON-LD path (layers 3-4).
+The JSON Schema path (layers 1-2) works without any context.
+
+## Synergy with Existing Ontology Model
+
+The `openlabel-v2.yaml` semantic model already provides:
+
+- **Closed SHACL shapes** — reject unknown properties
+- **Conditional constraints** — 18 boolean↔value rules (e.g., if weatherWindValue present, WeatherWind must be true)
+- **Type coercion via @vocab** — bare strings expand to IRIs during JSON-LD processing
+- **QuantitativeValue support** — values can be simple numbers or structured min/max ranges
+
+The structural schema (`openlabel-v2-schema.yaml`) complements this by validating
+the ASAM v1 file format — which uses a different (generic) representation of the
+same semantic content. Together, they support both:
+
+1. **v1 path**: Plain JSON → JSON Schema validation (structure + vocabulary)
+2. **v2 path**: JSON-LD → SHACL validation (structure + semantics + constraints)
+
+### Migration Support
+
+Users with existing ASAM v1 files can:
+1. Validate structure/vocabulary with the generated JSON Schema (immediate value)
+2. Optionally add `@context` to migrate to v2 format (full semantic validation)
+
+Both paths are supported by artifacts generated from the same LinkML source.
+
+## Usage
+
+```bash
+# Generate semantic artifacts (OWL, SHACL, context)
+make generate DOMAIN=openlabel-v2
+
+# Generate JSON Schema from structural model
+gen-json-schema linkml/openlabel-v2/openlabel-v2-schema.yaml > artifacts/openlabel-v2/openlabel-v2.schema.json
+
+# Regenerate TagTypeEnum after vocabulary changes
+python scripts/gen_tag_type_enum.py
+
+# Validate a v1 format file against the generated schema
+python -c "
+import json, jsonschema
+with open('artifacts/openlabel-v2/openlabel-v2.schema.json') as f:
+    schema = json.load(f)
+with open('my_tagging_file.json') as f:
+    instance = json.load(f)
+jsonschema.validate(instance, schema)
+print('Valid!')
+"
+```
+
+## Known Differences from ASAM Schema
+
+| Aspect | ASAM JSON Schema | LinkML-generated |
+|--------|-----------------|-----------------|
+| Dict key validation | `patternProperties: "^(0-9\|UUID)$"` | `additionalProperties` (any key) |
+| `tag.type` constraint | None (any string) | Enum with 227 values |
+| `tag_data` as string | Allowed via `oneOf` | Object only (string form not modeled) |
+| Multi-sensor definitions | 36 (objects, frames, geometry) | Not included (tagging only) |
+| Scope | All of OpenLABEL | Scenario tagging subset |
+
+The `patternProperties` difference is cosmetic — both accept numeric and UUID keys.
+LinkML's `additionalProperties` is slightly more permissive (accepts any key format)
+but validates the VALUE structure identically.
+
+## File Inventory
+
+```
+linkml/openlabel-v2/
+├── openlabel-v2.yaml           ← Semantic model (vocabulary + constraints)
+├── openlabel-v2-schema.yaml    ← Structural model (file format)
+├── GAP_ANALYSIS.md             ← Detailed v1↔v2 comparison
+├── IMPROVEMENTS.md             ← v2 improvements over v1
+└── SCHEMA_MODELING.md          ← This file
+```

--- a/linkml/openlabel-v2/openlabel-v2-schema.yaml
+++ b/linkml/openlabel-v2/openlabel-v2-schema.yaml
@@ -1,0 +1,866 @@
+# ASAM OpenLABEL Scenario Tagging File Format Schema
+# =============================================================================
+#
+# This LinkML schema models the STRUCTURAL format of ASAM OpenLABEL v1.0.0
+# scenario tagging JSON files. It generates a JSON Schema that validates the
+# file format (structure, keys, required fields) AND the tag vocabulary
+# (valid tag.type values derived from the openlabel-v2 ontology).
+#
+# Architecture:
+#   openlabel-v2.yaml         -> Semantic model (OWL, SHACL, JSON-LD context)
+#   openlabel-v2-schema.yaml  -> Structural model (JSON Schema for v1 format)
+#
+# The TagTypeEnum bridges both: it lists all valid tag.type values from the
+# ontology vocabulary. Changes to the ontology automatically flow into the
+# JSON Schema when this enum is regenerated.
+#
+# Usage:
+#   gen-json-schema linkml/openlabel-v2/openlabel-v2-schema.yaml
+#
+# =============================================================================
+
+id: https://w3id.org/ascs-ev/envited-x/openlabel/schema/v1
+name: openlabel-v2-schema
+title: ASAM OpenLABEL Scenario Tagging File Format Schema
+description: >-
+  Structural schema for ASAM OpenLABEL v1.0.0 scenario tagging JSON files.
+  Models the file format (openlabel root, metadata, ontologies, tags, tag_data)
+  and constrains tag.type values to the openlabel-v2 ontology vocabulary.
+version: "1.0.0"
+license: https://www.eclipse.org/legal/epl-2.0/
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+  openlabel_schema: https://w3id.org/ascs-ev/envited-x/openlabel/schema/v1/
+
+default_prefix: openlabel_schema
+default_range: string
+
+imports:
+  - linkml:types
+
+# =============================================================================
+# Classes
+# =============================================================================
+classes:
+
+  # ---------------------------------------------------------------------------
+  # Root wrapper: {"openlabel": {...}}
+  # ---------------------------------------------------------------------------
+  OpenLabelFile:
+    tree_root: true
+    description: >-
+      Root of an ASAM OpenLABEL JSON file. Contains a single "openlabel" key.
+    attributes:
+      openlabel:
+        range: OpenLabel
+        required: true
+        description: The OpenLABEL root object containing all annotation data.
+
+  # ---------------------------------------------------------------------------
+  # OpenLabel container (scenario tagging subset)
+  # ---------------------------------------------------------------------------
+  OpenLabel:
+    description: >-
+      The OpenLABEL root JSON object for scenario tagging. Contains metadata,
+      ontology references, and tags. For scenario tagging, objects/actions/frames
+      are not used (spec 8.1 - tags do not include spatiotemporal constructs).
+    attributes:
+      metadata:
+        range: Metadata
+        required: true
+        description: >-
+          Metadata about the annotation file (schema version, annotator, etc.).
+      ontologies:
+        range: OntologyEntry
+        multivalued: true
+        inlined: true
+        inlined_as_list: false
+        description: >-
+          Ontology references keyed by UID. Each entry specifies the URI
+          of an ontology and optional tagging boundary controls.
+      tags:
+        range: TagEntry
+        multivalued: true
+        inlined: true
+        inlined_as_list: false
+        description: >-
+          Tags keyed by UID. Each entry specifies the tag type (from an
+          ontology) and optional tag_data with values.
+
+  # ---------------------------------------------------------------------------
+  # Metadata
+  # ---------------------------------------------------------------------------
+  Metadata:
+    description: >-
+      Metadata about the annotation file. The schema_version is mandatory.
+    attributes:
+      schema_version:
+        range: string
+        required: true
+        description: >-
+          The version of the ASAM OpenLABEL schema this file conforms to.
+      tagged_file:
+        range: string
+        description: >-
+          Path or URI to the raw data file that this annotation references.
+      annotator:
+        range: string
+        description: Name or identifier of the annotator.
+      comment:
+        range: string
+        description: Free-text comment about the annotation.
+      name:
+        range: string
+        description: Name of the annotation file.
+      file_version:
+        range: string
+        description: Version of the annotation file.
+
+  # ---------------------------------------------------------------------------
+  # OntologyEntry
+  # ---------------------------------------------------------------------------
+  OntologyEntry:
+    description: >-
+      An ontology reference. Specifies the URI of the ontology and optional
+      boundary controls for tagging subsets (spec 8.2.2).
+    attributes:
+      uid:
+        identifier: true
+        range: string
+        required: true
+        description: >-
+          Unique identifier for this ontology entry (numeric UID or UUID).
+      uri:
+        range: uri
+        required: true
+        description: >-
+          URI of the ontology definition (RDF Turtle file URL).
+      boundary_list:
+        range: string
+        multivalued: true
+        description: >-
+          List of tag names that define the tagging boundary. Used with
+          boundary_mode to specify which subset of ontology tags is relevant.
+      boundary_mode:
+        range: BoundaryModeEnum
+        description: >-
+          Whether boundary_list specifies inclusion or exclusion of tags.
+
+  # ---------------------------------------------------------------------------
+  # TagEntry
+  # ---------------------------------------------------------------------------
+  TagEntry:
+    description: >-
+      A single tag in an ASAM OpenLABEL file. References a tag type from an
+      ontology and optionally includes tag_data with values.
+    attributes:
+      uid:
+        identifier: true
+        range: string
+        required: true
+        description: >-
+          Unique identifier for this tag entry (numeric UID or UUID).
+      type:
+        range: TagTypeEnum
+        required: true
+        description: >-
+          The type of tag, referencing a class or property name from the
+          ontology. Constrained to valid values from the openlabel-v2 vocabulary.
+      ontology_uid:
+        range: string
+        required: true
+        description: >-
+          UID of the ontology (from the ontologies section) where this tag
+          type is defined.
+      resource_uid:
+        range: ResourceUid
+        description: Reference to external resource identifiers.
+      tag_data:
+        range: TagData
+        description: >-
+          Optional data associated with this tag (values, ranges, text).
+
+  # ---------------------------------------------------------------------------
+  # TagData - generic data container (spec 8.7)
+  # ---------------------------------------------------------------------------
+  TagData:
+    description: >-
+      Generic data associated with a tag. Contains arrays of typed values
+      (boolean, numeric, text, vector). For scenario tagging, only non-geometric
+      data types are used (spec 8.7).
+    attributes:
+      boolean:
+        range: BooleanVal
+        multivalued: true
+        inlined_as_list: true
+        description: List of boolean values describing this tag.
+      num:
+        range: NumVal
+        multivalued: true
+        inlined_as_list: true
+        description: List of numeric values describing this tag.
+      text:
+        range: TextVal
+        multivalued: true
+        inlined_as_list: true
+        description: List of text values describing this tag.
+      vec:
+        range: VecVal
+        multivalued: true
+        inlined_as_list: true
+        description: List of vector (array) values describing this tag.
+
+  # ---------------------------------------------------------------------------
+  # Generic data types (boolean, num, text, vec) - spec 8.7.1-8.7.4
+  # ---------------------------------------------------------------------------
+  BooleanVal:
+    description: >-
+      A boolean value entry in tag_data or attributes (spec 8.7.1).
+    attributes:
+      name:
+        range: string
+        description: Name of this data entry (used as index in data pointers).
+      val:
+        range: boolean
+        required: true
+        description: The boolean value.
+      type:
+        range: string
+        description: How the value shall be interpreted (e.g., "value").
+      attributes:
+        range: Attributes
+        description: Nested attributes for this data entry.
+
+  NumVal:
+    description: >-
+      A numeric value entry in tag_data or attributes (spec 8.7.2).
+    attributes:
+      name:
+        range: string
+        description: Name of this data entry.
+      val:
+        range: float
+        required: true
+        description: The numerical value.
+      type:
+        range: NumTypeEnum
+        description: >-
+          How the number shall be interpreted: value, minimum, or maximum.
+      attributes:
+        range: Attributes
+        description: Nested attributes for this data entry.
+
+  TextVal:
+    description: >-
+      A text value entry in tag_data or attributes (spec 8.7.3).
+    attributes:
+      name:
+        range: string
+        description: Name of this data entry.
+      val:
+        range: string
+        required: true
+        description: The text value.
+      type:
+        range: string
+        description: How the text shall be interpreted (e.g., "value").
+      attributes:
+        range: Attributes
+        description: Nested attributes for this data entry.
+
+  VecVal:
+    description: >-
+      A vector (array) value entry in tag_data or attributes (spec 8.7.4).
+      Used for ranges, sets, and multi-valued data.
+    attributes:
+      name:
+        range: string
+        description: Name of this data entry.
+      val:
+        range: string
+        multivalued: true
+        required: true
+        description: >-
+          Array of values (numbers or strings). Interpretation depends on type.
+      type:
+        range: VecTypeEnum
+        description: >-
+          How the vector shall be interpreted: range, set, or values.
+      attributes:
+        range: Attributes
+        description: Nested attributes for this data entry.
+
+  # ---------------------------------------------------------------------------
+  # Attributes - recursive nested data container
+  # ---------------------------------------------------------------------------
+  Attributes:
+    description: >-
+      Nested attributes for any data entry. Same structure as tag_data.
+    attributes:
+      boolean:
+        range: BooleanVal
+        multivalued: true
+        inlined_as_list: true
+        description: Nested boolean attributes.
+      num:
+        range: NumVal
+        multivalued: true
+        inlined_as_list: true
+        description: Nested numeric attributes.
+      text:
+        range: TextVal
+        multivalued: true
+        inlined_as_list: true
+        description: Nested text attributes.
+      vec:
+        range: VecVal
+        multivalued: true
+        inlined_as_list: true
+        description: Nested vector attributes.
+
+  # ---------------------------------------------------------------------------
+  # ResourceUid - external resource references
+  # ---------------------------------------------------------------------------
+  ResourceUid:
+    description: >-
+      References to external resources by UID.
+    attributes:
+      uid:
+        identifier: true
+        range: string
+        description: Resource identifier.
+      uri:
+        range: uri
+        description: URI of the external resource.
+
+# =============================================================================
+# Enums
+# =============================================================================
+enums:
+
+  BoundaryModeEnum:
+    description: >-
+      Mode for interpreting the ontology tagging boundary (spec 8.2.2).
+    permissible_values:
+      include:
+        description: >-
+          Subset is the boundary tags plus their ascendants.
+      exclude:
+        description: >-
+          Subset is all tags minus boundary tags and their descendants.
+
+  NumTypeEnum:
+    description: >-
+      How a numeric value shall be interpreted in its context.
+    permissible_values:
+      value:
+        description: The number represents a single value.
+      min:
+        description: The number represents a minimum bound.
+      max:
+        description: The number represents a maximum bound.
+
+  VecTypeEnum:
+    description: >-
+      How a vector (array) value shall be interpreted.
+    permissible_values:
+      range:
+        description: Two-element array [min, max] defining a value range.
+      set:
+        description: Unordered collection of discrete values.
+      values:
+        description: Ordered list of values.
+
+
+  TagTypeEnum:
+    description: >-
+      All valid values for the tag.type field in ASAM OpenLABEL v1 format
+      files. Derived from the openlabel-v2 ontology vocabulary (classes,
+      enums, slots). AUTO-GENERATED — do not edit manually.
+    permissible_values:
+      # --- Structural class types ---
+      Tag:
+        description: Structural class type
+      AdminTag:
+        description: Structural class type
+      Odd:
+        description: Structural class type
+      Behaviour:
+        description: Structural class type
+      RoadUser:
+        description: Structural class type
+      # --- Administration tag properties ---
+      licenseURI:
+        description: Administration tag property
+      ownerEmail:
+        description: Administration tag property
+      ownerName:
+        description: Administration tag property
+      ownerURL:
+        description: Administration tag property
+      scenarioCreatedDate:
+        description: Administration tag property
+      scenarioDefinition:
+        description: Administration tag property
+      scenarioDefinitionLanguageURI:
+        description: Administration tag property
+      scenarioDescription:
+        description: Administration tag property
+      scenarioName:
+        description: Administration tag property
+      scenarioParentReference:
+        description: Administration tag property
+      scenarioUniqueReference:
+        description: Administration tag property
+      scenarioVersion:
+        description: Administration tag property
+      scenarioVisualisationURL:
+        description: Administration tag property
+      # --- Boolean flag tags (ODD/Behaviour) ---
+      DaySunElevation:
+        description: Boolean ODD/Behaviour flag
+      HorizontalCurves:
+        description: Boolean ODD/Behaviour flag
+      HorizontalStraights:
+        description: Boolean ODD/Behaviour flag
+      IlluminationCloudiness:
+        description: Boolean ODD/Behaviour flag
+      LaneSpecificationDimensions:
+        description: Boolean ODD/Behaviour flag
+      LaneSpecificationLaneCount:
+        description: Boolean ODD/Behaviour flag
+      LaneSpecificationMarking:
+        description: Boolean ODD/Behaviour flag
+      LongitudinalDownSlope:
+        description: Boolean ODD/Behaviour flag
+      LongitudinalLevelPlane:
+        description: Boolean ODD/Behaviour flag
+      LongitudinalUpSlope:
+        description: Boolean ODD/Behaviour flag
+      MotionAccelerate:
+        description: Boolean ODD/Behaviour flag
+      MotionAway:
+        description: Boolean ODD/Behaviour flag
+      MotionCross:
+        description: Boolean ODD/Behaviour flag
+      MotionCutIn:
+        description: Boolean ODD/Behaviour flag
+      MotionCutOut:
+        description: Boolean ODD/Behaviour flag
+      MotionDecelerate:
+        description: Boolean ODD/Behaviour flag
+      MotionDrive:
+        description: Boolean ODD/Behaviour flag
+      MotionLaneChangeLeft:
+        description: Boolean ODD/Behaviour flag
+      MotionLaneChangeRight:
+        description: Boolean ODD/Behaviour flag
+      MotionOvertake:
+        description: Boolean ODD/Behaviour flag
+      MotionReverse:
+        description: Boolean ODD/Behaviour flag
+      MotionRun:
+        description: Boolean ODD/Behaviour flag
+      MotionSlide:
+        description: Boolean ODD/Behaviour flag
+      MotionStop:
+        description: Boolean ODD/Behaviour flag
+      MotionTowards:
+        description: Boolean ODD/Behaviour flag
+      MotionTurn:
+        description: Boolean ODD/Behaviour flag
+      MotionTurnLeft:
+        description: Boolean ODD/Behaviour flag
+      MotionTurnRight:
+        description: Boolean ODD/Behaviour flag
+      MotionUTurn:
+        description: Boolean ODD/Behaviour flag
+      MotionWalk:
+        description: Boolean ODD/Behaviour flag
+      RoadUserAnimal:
+        description: Boolean ODD/Behaviour flag
+      SubjectVehicleSpeed:
+        description: Boolean ODD/Behaviour flag
+      TrafficAgentDensity:
+        description: Boolean ODD/Behaviour flag
+      TrafficAgentType:
+        description: Boolean ODD/Behaviour flag
+      TrafficFlowRate:
+        description: Boolean ODD/Behaviour flag
+      TrafficSpecialVehicle:
+        description: Boolean ODD/Behaviour flag
+      TrafficVolume:
+        description: Boolean ODD/Behaviour flag
+      WeatherRain:
+        description: Boolean ODD/Behaviour flag
+      WeatherSnow:
+        description: Boolean ODD/Behaviour flag
+      WeatherWind:
+        description: Boolean ODD/Behaviour flag
+      # --- Enum category tags (slot names with enum ranges) ---
+      BehaviourCommunication:
+        description: Enum category tag (takes values from BehaviourCommunicationEnum)
+      ConnectivityCommunication:
+        description: Enum category tag (takes values from ConnectivityCommunicationEnum)
+      ConnectivityPositioning:
+        description: Enum category tag (takes values from ConnectivityPositioningEnum)
+      DaySunPosition:
+        description: Enum category tag (takes values from DaySunPositionEnum)
+      DrivableAreaEdge:
+        description: Enum category tag (takes values from DrivableAreaEdgeEnum)
+      DrivableAreaSurfaceCondition:
+        description: Enum category tag (takes values from DrivableAreaSurfaceConditionEnum)
+      DrivableAreaSurfaceFeature:
+        description: Enum category tag (takes values from DrivableAreaSurfaceFeatureEnum)
+      DrivableAreaSurfaceType:
+        description: Enum category tag (takes values from DrivableAreaSurfaceTypeEnum)
+      DrivableAreaType:
+        description: Enum category tag (takes values from DrivableAreaTypeEnum)
+      EnvironmentParticulates:
+        description: Enum category tag (takes values from EnvironmentParticulatesEnum)
+      GeometryTransverse:
+        description: Enum category tag (takes values from GeometryTransverseEnum)
+      IlluminationArtificial:
+        description: Enum category tag (takes values from IlluminationArtificialEnum)
+      IlluminationLowLight:
+        description: Enum category tag (takes values from IlluminationLowLightEnum)
+      JunctionIntersection:
+        description: Enum category tag (takes values from JunctionIntersectionEnum)
+      JunctionRoundabout:
+        description: Enum category tag (takes values from JunctionRoundaboutEnum)
+      LaneSpecificationTravelDirection:
+        description: Enum category tag (takes values from LaneSpecificationTravelDirectionEnum)
+      LaneSpecificationType:
+        description: Enum category tag (takes values from LaneSpecificationTypeEnum)
+      RainType:
+        description: Enum category tag (takes values from RainTypeEnum)
+      RoadUserHuman:
+        description: Enum category tag (takes values from RoadUserHumanEnum)
+      RoadUserVehicle:
+        description: Enum category tag (takes values from RoadUserVehicleEnum)
+      SceneryFixedStructure:
+        description: Enum category tag (takes values from SceneryFixedStructureEnum)
+      ScenerySpecialStructure:
+        description: Enum category tag (takes values from ScenerySpecialStructureEnum)
+      SceneryTemporaryStructure:
+        description: Enum category tag (takes values from SceneryTemporaryStructureEnum)
+      SceneryZone:
+        description: Enum category tag (takes values from SceneryZoneEnum)
+      SignsInformation:
+        description: Enum category tag (takes values from SignsInformationEnum)
+      SignsRegulatory:
+        description: Enum category tag (takes values from SignsRegulatoryEnum)
+      SignsWarning:
+        description: Enum category tag (takes values from SignsWarningEnum)
+      # --- BehaviourCommunicationEnum ---
+      CommunicationHeadlightFlash:
+        description: "Flash headlight."
+      CommunicationHorn:
+        description: "Sound horn."
+      CommunicationSignalEmergency:
+        description: "Signal emergency."
+      CommunicationSignalHazard:
+        description: "Signal hazard."
+      CommunicationSignalLeft:
+        description: "Signal left."
+      CommunicationSignalRight:
+        description: "Signal right."
+      CommunicationSignalSlowing:
+        description: "Signal slowing."
+      CommunicationWave:
+        description: "Wave."
+      # --- ConnectivityCommunicationEnum ---
+      CommunicationV2i:
+        description: "Vehicle to infrastructure communication (V2I)."
+      CommunicationV2v:
+        description: "Vehicle to vehicle communication (V2V)."
+      V2iCellular:
+        description: "V2I via cellular network."
+      V2iSatellite:
+        description: "V2I via satellite."
+      V2iWifi:
+        description: "V2I via WiFi."
+      V2vCellular:
+        description: "V2V via cellular network."
+      V2vSatellite:
+        description: "V2V via satellite."
+      V2vWifi:
+        description: "V2V via WiFi."
+      # --- ConnectivityPositioningEnum ---
+      PositioningGalileo:
+        description: "Galileo."
+      PositioningGlonass:
+        description: "GLObal NAvigation Satellite System (GLONASS)."
+      PositioningGps:
+        description: "Global Positioning System (GPS)."
+      # --- DaySunPositionEnum ---
+      SunPositionBehind:
+        description: "Sun behind."
+      SunPositionFront:
+        description: "Sun in front."
+      SunPositionLeft:
+        description: "Sun on the left."
+      SunPositionRight:
+        description: "Sun on the right."
+      # --- DrivableAreaEdgeEnum ---
+      EdgeLineMarkers:
+        description: "Line markers."
+      EdgeNone:
+        description: "None."
+      EdgeShoulderGrass:
+        description: "Shoulder (grass)."
+      EdgeShoulderPavedOrGravel:
+        description: "Shoulder (paved or gravel)."
+      EdgeSolidBarriers:
+        description: "Solid barriers (e.g. grating, rails, curb, cones)."
+      EdgeTemporaryLineMarkers:
+        description: "Temporary line markers."
+      # --- DrivableAreaSurfaceConditionEnum ---
+      SurfaceConditionContamination:
+        description: "Surface contamination."
+      SurfaceConditionFlooded:
+        description: "Flooded roadways."
+      SurfaceConditionIcy:
+        description: "Icy."
+      SurfaceConditionMirage:
+        description: "Mirage effect on the drivable area surface."
+      SurfaceConditionSnow:
+        description: "Snow on drivable area."
+      SurfaceConditionStandingWater:
+        description: "Standing water."
+      SurfaceConditionWet:
+        description: "Wet road."
+      # --- DrivableAreaSurfaceFeatureEnum ---
+      SurfaceFeatureCrack:
+        description: "Cracks."
+      SurfaceFeaturePothole:
+        description: "Potholes."
+      SurfaceFeatureRut:
+        description: "Ruts."
+      SurfaceFeatureSwell:
+        description: "Swells."
+      # --- DrivableAreaSurfaceTypeEnum ---
+      SurfaceTypeLoose:
+        description: "Loose (e.g. gravel, earth, sand)."
+      SurfaceTypeSegmented:
+        description: "Segmented (e.g. concrete slabs, granite setts, cobblestones)."
+      SurfaceTypeUniform:
+        description: "Uniform (e.g. asphalt)."
+      # --- DrivableAreaTypeEnum ---
+      MotorwayManaged:
+        description: "Managed motorways."
+      MotorwayUnmanaged:
+        description: "Unmanaged motorways."
+      RoadTypeDistributor:
+        description: "Distributor roads."
+      RoadTypeMinor:
+        description: "Minor roads."
+      RoadTypeMotorway:
+        description: "Motorways."
+      RoadTypeParking:
+        description: "Parking."
+      RoadTypeRadial:
+        description: "Radial roads."
+      RoadTypeShared:
+        description: "Shared space."
+      RoadTypeSlip:
+        description: "Slip roads."
+      # --- EnvironmentParticulatesEnum ---
+      ParticulatesDust:
+        description: "Sand and dust."
+      ParticulatesMarine:
+        description: "Marine spray in coastal areas."
+      ParticulatesPollution:
+        description: "Smoke and pollution."
+      ParticulatesVolcanic:
+        description: "Volcanic ash."
+      ParticulatesWater:
+        description: "Non-precipitating water droplets or ice crystals (i.e. mist/fog)."
+      # --- GeometryTransverseEnum ---
+      TransverseBarriers:
+        description: "Barriers on edges."
+      TransverseDivided:
+        description: "Divided."
+      TransverseLanesTogether:
+        description: "Types of lanes together."
+      TransversePavements:
+        description: "Pavements."
+      TransverseUndivided:
+        description: "Undivided."
+      # --- IlluminationArtificialEnum ---
+      ArtificialStreetLighting:
+        description: "Streetlights."
+      ArtificialVehicleLighting:
+        description: "Oncoming vehicle lights."
+      # --- IlluminationLowLightEnum ---
+      LowLightAmbient:
+        description: "Low ambient lighting."
+      LowLightNight:
+        description: "Night."
+      # --- JunctionIntersectionEnum ---
+      IntersectionCrossroad:
+        description: "Crossroads."
+      IntersectionGradeSeperated:
+        description: "Grade separated."
+      IntersectionStaggered:
+        description: "Staggered."
+      IntersectionTJunction:
+        description: "T-Junctions."
+      IntersectionYJunction:
+        description: "Y-Junction."
+      # --- JunctionRoundaboutEnum ---
+      RoundaboutCompactNosignal:
+        description: "Compact non-signalised."
+      RoundaboutCompactSignal:
+        description: "Compact signalised."
+      RoundaboutDoubleNosignal:
+        description: "Double non-signalised."
+      RoundaboutDoubleSignal:
+        description: "Double signalised."
+      RoundaboutLargeNosignal:
+        description: "Large non-signalised."
+      RoundaboutLargeSignal:
+        description: "Large signalised."
+      RoundaboutMiniNosignal:
+        description: "Mini non-signalised."
+      RoundaboutMiniSignal:
+        description: "Mini signalised."
+      RoundaboutNormalNosignal:
+        description: "Normal non-signalised."
+      RoundaboutNormalSignal:
+        description: "Normal signalised."
+      # --- LaneSpecificationTravelDirectionEnum ---
+      TravelDirectionLeft:
+        description: "Left."
+      TravelDirectionRight:
+        description: "Right."
+      # --- LaneSpecificationTypeEnum ---
+      LaneTypeBus:
+        description: "Bus lane."
+      LaneTypeCycle:
+        description: "Cycle lane."
+      LaneTypeEmergency:
+        description: "Emergency lane."
+      LaneTypeSpecial:
+        description: "Special purpose lane."
+      LaneTypeTraffic:
+        description: "Traffic lane."
+      LaneTypeTram:
+        description: "Tram lane."
+      # --- RainTypeEnum ---
+      RainTypeConvective:
+        description: "Convective."
+      RainTypeDynamic:
+        description: "Dynamic."
+      RainTypeOrographic:
+        description: "Orographic."
+      # --- RoadUserHumanEnum ---
+      HumanAnimalRider:
+        description: "Animal rider (e.g. horse rider)."
+      HumanCyclist:
+        description: "Cyclist."
+      HumanDriver:
+        description: "Driver."
+      HumanMotorcyclist:
+        description: "Motorcyclist."
+      HumanPassenger:
+        description: "Passenger."
+      HumanPedestrian:
+        description: "Pedestrian."
+      HumanWheelchairUser:
+        description: "Wheelchair user."
+      # --- RoadUserVehicleEnum ---
+      VehicleAgricultural:
+        description: "Agricultural vehicle."
+      VehicleBus:
+        description: "Bus."
+      VehicleCar:
+        description: "Car."
+      VehicleConstruction:
+        description: "Construction vehicle."
+      VehicleCycle:
+        description: "Cycle."
+      VehicleEmergency:
+        description: "Emergency vehicle."
+      VehicleMotorcycle:
+        description: "Motorcycle."
+      VehicleTrailer:
+        description: "Trailer."
+      VehicleTruck:
+        description: "Truck."
+      VehicleVan:
+        description: "Van."
+      VehicleWheelchair:
+        description: "Wheelchair."
+      # --- SceneryFixedStructureEnum ---
+      FixedStructureBuilding:
+        description: "Buildings."
+      FixedStructureStreetFurniture:
+        description: "Street furniture (e.g. bollards)."
+      FixedStructureStreetlight:
+        description: "Street lights."
+      FixedStructureVegetation:
+        description: "Vegetation."
+      # --- ScenerySpecialStructureEnum ---
+      SpecialStructureAutoAccess:
+        description: "Automatic access control."
+      SpecialStructureBridge:
+        description: "Bridges."
+      SpecialStructurePedestrianCrossing:
+        description: "Pedestrian crossings."
+      SpecialStructureRailCrossing:
+        description: "Rail crossings."
+      SpecialStructureTollPlaza:
+        description: "Toll plaza."
+      SpecialStructureTunnel:
+        description: "Tunnels."
+      # --- SceneryTemporaryStructureEnum ---
+      TemporaryStructureConstructionDetour:
+        description: "Construction site detours."
+      TemporaryStructureRefuseCollection:
+        description: "Refuse collection."
+      TemporaryStructureRoadSignage:
+        description: "Road signage."
+      TemporaryStructureRoadWorks:
+        description: "Road works."
+      # --- SceneryZoneEnum ---
+      ZoneGeoFenced:
+        description: "GeoFenced areas."
+      ZoneInterference:
+        description: "Interference zones."
+      ZoneRegion:
+        description: "Regions or states."
+      ZoneSchool:
+        description: "School zones."
+      ZoneTrafficManagement:
+        description: "Traffic management zones."
+      # --- SignsInformationEnum ---
+      InformationSignsUniformFullTime:
+        description: "Uniform full-time."
+      InformationSignsUniformTemporary:
+        description: "Uniform temporary."
+      InformationSignsVariableFullTime:
+        description: "Variable full-time."
+      InformationSignsVariableTemporary:
+        description: "Variable temporary."
+      # --- SignsRegulatoryEnum ---
+      RegulatorySignsUniformFullTime:
+        description: "Uniform full-time."
+      RegulatorySignsUniformTemporary:
+        description: "Uniform temporary."
+      RegulatorySignsVariableFullTime:
+        description: "Variable full-time."
+      RegulatorySignsVariableTemporary:
+        description: "Variable temporary."
+      # --- SignsWarningEnum ---
+      WarningSignsUniform:
+        description: "Uniform."
+      WarningSignsUniformFullTime:
+        description: "Uniform full-time."
+      WarningSignsUniformTemporary:
+        description: "Uniform temporary."
+      WarningSignsVariableFullTime:
+        description: "Variable full-time."
+      WarningSignsVariableTemporary:
+        description: "Variable temporary."

--- a/scripts/convert_openlabel_v1_to_v2.py
+++ b/scripts/convert_openlabel_v1_to_v2.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Convert ASAM OpenLABEL v1 JSON files to JSON-LD with v2 context.
+
+Module purpose:
+    Transforms plain ASAM OpenLABEL scenario tagging JSON files (v1 format with
+    generic tag.type + tag_data containers) into JSON-LD documents that use the
+    openlabel-v2 ontology context for type coercion and SHACL validation.
+
+Dependencies:
+    core: (none — standalone script)
+    third-party: pyyaml
+
+Usage:
+    python scripts/convert_openlabel_v1_to_v2.py input.json
+    python scripts/convert_openlabel_v1_to_v2.py input.json -o output.jsonld
+    python scripts/convert_openlabel_v1_to_v2.py input.json --context-uri https://...
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+DEFAULT_CONTEXT_URI = "https://w3id.org/ascs-ev/envited-x/openlabel/v2/"
+DEFAULT_ONTOLOGY = Path("linkml/openlabel-v2/openlabel-v2.yaml")
+
+# Maps v1 tag.type → v2 class + slot
+# Built from the ontology model at runtime
+
+
+def load_tag_mapping(
+    ontology_path: Path,
+) -> dict[str, dict[str, str]]:
+    """Load the mapping from v1 tag.type values to v2 typed slots.
+
+    Returns:
+        Dict mapping tag.type string to {class, slot, range} info.
+    """
+    with open(ontology_path) as f:
+        model = yaml.safe_load(f)
+
+    slots = model.get("slots", {})
+    enums = model.get("enums", {})
+    classes = model.get("classes", {})
+    enum_names = set(enums.keys())
+
+    mapping: dict[str, dict[str, str]] = {}
+
+    # Build reverse index: which class owns which slot
+    slot_owners: dict[str, str] = {}
+    for cls_name, cls_def in classes.items():
+        for slot_name in cls_def.get("slots", []):
+            slot_owners[slot_name] = cls_name
+
+    # Boolean flag slots
+    for sname, sdef in slots.items():
+        if sdef.get("range") == "boolean":
+            owner = slot_owners.get(sname, "unknown")
+            mapping[sname] = {
+                "class": owner,
+                "slot": sname,
+                "range": "boolean",
+                "type": "flag",
+            }
+
+    # Enum-typed slots and their values
+    for sname, sdef in slots.items():
+        slot_range = sdef.get("range", "")
+        if slot_range in enum_names:
+            owner = slot_owners.get(sname, "unknown")
+            mapping[sname] = {
+                "class": owner,
+                "slot": sname,
+                "range": slot_range,
+                "type": "enum_slot",
+            }
+            # Each enum value is also a valid tag.type
+            pvs = enums[slot_range].get("permissible_values", {})
+            for pv_name in pvs:
+                mapping[pv_name] = {
+                    "class": owner,
+                    "slot": sname,
+                    "range": slot_range,
+                    "type": "enum_value",
+                    "value": pv_name,
+                }
+
+    # Admin slots (string-typed properties)
+    admin_slots = classes.get("AdminTag", {}).get("slots", [])
+    for sname in admin_slots:
+        if sname not in mapping:
+            sdef = slots.get(sname, {})
+            mapping[sname] = {
+                "class": "AdminTag",
+                "slot": sname,
+                "range": sdef.get("range", "string"),
+                "type": "admin",
+            }
+
+    return mapping
+
+
+def extract_tag_value(tag: dict, tag_mapping: dict[str, dict[str, str]]) -> str | bool | float | None:
+    """Extract the value from tag_data for a given tag.
+
+    For boolean flags: True (presence = true)
+    For enum values: the enum value string
+    For admin tags with tag_data.text: the text value
+    For numeric tags with tag_data.num: the numeric value
+    """
+    tag_type = tag.get("type", "")
+    info = tag_mapping.get(tag_type, {})
+    tag_data = tag.get("tag_data", {})
+
+    if info.get("type") == "flag":
+        return True
+
+    if info.get("type") == "enum_value":
+        return info.get("value", tag_type)
+
+    if info.get("type") == "enum_slot":
+        return True
+
+    if info.get("type") == "admin":
+        # Admin tags typically carry text values
+        texts = tag_data.get("text", [])
+        if texts and isinstance(texts, list) and len(texts) > 0:
+            return texts[0].get("val", "")
+        return ""
+
+    # For numeric values
+    nums = tag_data.get("num", [])
+    if nums and isinstance(nums, list) and len(nums) > 0:
+        return nums[0].get("val")
+
+    # For boolean values
+    bools = tag_data.get("boolean", [])
+    if bools and isinstance(bools, list) and len(bools) > 0:
+        return bools[0].get("val")
+
+    return True
+
+
+def convert_v1_to_v2(
+    v1_data: dict,
+    tag_mapping: dict[str, dict[str, str]],
+    context_uri: str = DEFAULT_CONTEXT_URI,
+) -> dict:
+    """Convert a v1 OpenLABEL JSON to v2 JSON-LD format.
+
+    Args:
+        v1_data: The parsed v1 JSON content.
+        tag_mapping: Mapping from tag.type to v2 slot info.
+        context_uri: The JSON-LD @context URI to inject.
+
+    Returns:
+        A v2 JSON-LD document with typed slots.
+    """
+    openlabel = v1_data.get("openlabel", v1_data)
+    tags = openlabel.get("tags", {})
+    metadata = openlabel.get("metadata", {})
+
+    # Group tags by their v2 class
+    class_slots: dict[str, dict[str, str | bool | float | None]] = {}
+    unmapped: list[dict] = []
+
+    for tag_uid, tag in tags.items():
+        tag_type = tag.get("type", "")
+        info = tag_mapping.get(tag_type)
+
+        if not info:
+            unmapped.append({"uid": tag_uid, "type": tag_type})
+            continue
+
+        cls = info["class"]
+        slot = info["slot"]
+        value = extract_tag_value(tag, tag_mapping)
+
+        if cls not in class_slots:
+            class_slots[cls] = {}
+
+        # For enum values, the slot is the enum category slot
+        if info["type"] == "enum_value":
+            class_slots[cls][slot] = value
+        else:
+            class_slots[cls][slot] = value
+
+    # Build the v2 JSON-LD document
+    result: dict = {
+        "@context": context_uri,
+        "@type": "Tag",
+    }
+
+    # Add metadata as comment if present
+    if metadata.get("tagged_file"):
+        result["@id"] = f"urn:openlabel:{metadata.get('tagged_file', 'unknown')}"
+
+    # Build class objects
+    for cls_name, slot_values in sorted(class_slots.items()):
+        if cls_name == "AdminTag":
+            result[cls_name] = {
+                "@type": cls_name,
+                **slot_values,
+            }
+        elif cls_name in ("Odd", "OddScenery", "OddEnvironment", "OddDynamicElements"):
+            if "Odd" not in result:
+                result["Odd"] = {"@type": "Odd"}
+            result["Odd"].update(slot_values)
+        elif cls_name == "Behaviour":
+            result[cls_name] = {
+                "@type": cls_name,
+                **slot_values,
+            }
+        elif cls_name == "RoadUser":
+            result[cls_name] = {
+                "@type": cls_name,
+                **slot_values,
+            }
+        else:
+            result[cls_name] = {
+                "@type": cls_name,
+                **slot_values,
+            }
+
+    # Report unmapped tags
+    if unmapped:
+        result["_unmapped_tags"] = unmapped
+
+    return result
+
+
+def main() -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Convert ASAM OpenLABEL v1 JSON to v2 JSON-LD format."
+    )
+    parser.add_argument("input", type=Path, help="Input v1 JSON file")
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        help="Output v2 JSON-LD file (default: stdout)",
+    )
+    parser.add_argument(
+        "--context-uri",
+        default=DEFAULT_CONTEXT_URI,
+        help=f"JSON-LD @context URI (default: {DEFAULT_CONTEXT_URI})",
+    )
+    parser.add_argument(
+        "--ontology",
+        type=Path,
+        default=DEFAULT_ONTOLOGY,
+        help=f"Path to ontology model YAML (default: {DEFAULT_ONTOLOGY})",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        default=True,
+        help="Pretty-print JSON output (default: True)",
+    )
+    args = parser.parse_args()
+
+    if not args.input.exists():
+        print(f"ERROR: Input file not found: {args.input}", file=sys.stderr)
+        return 1
+    if not args.ontology.exists():
+        print(f"ERROR: Ontology model not found: {args.ontology}", file=sys.stderr)
+        return 1
+
+    # Load input
+    with open(args.input) as f:
+        v1_data = json.load(f)
+
+    # Load mapping
+    tag_mapping = load_tag_mapping(args.ontology)
+
+    # Convert
+    v2_data = convert_v1_to_v2(v1_data, tag_mapping, args.context_uri)
+
+    # Output
+    indent = 2 if args.pretty else None
+    output_json = json.dumps(v2_data, indent=indent, ensure_ascii=False)
+
+    if args.output:
+        args.output.write_text(output_json + "\n", encoding="utf-8")
+        print(f"Converted {args.input} → {args.output}")
+    else:
+        print(output_json)
+
+    # Report unmapped tags
+    if "_unmapped_tags" in v2_data:
+        count = len(v2_data["_unmapped_tags"])
+        print(
+            f"\nWARNING: {count} tag(s) could not be mapped to v2 slots:",
+            file=sys.stderr,
+        )
+        for t in v2_data["_unmapped_tags"]:
+            print(f"  - {t['type']} (uid: {t['uid']})", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sync_tag_type_enum.py
+++ b/scripts/sync_tag_type_enum.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Synchronize TagTypeEnum in the structural schema from the ontology model.
+
+Module purpose:
+    Reads the openlabel-v2 semantic model (openlabel-v2.yaml) and regenerates
+    the TagTypeEnum section in the structural model (openlabel-v2-schema.yaml).
+    This keeps the JSON Schema vocabulary in sync with the OWL/SHACL ontology.
+
+Dependencies:
+    core: (none — standalone script)
+    third-party: pyyaml
+
+Usage:
+    python scripts/sync_tag_type_enum.py                       # default paths
+    python scripts/sync_tag_type_enum.py --check               # dry-run, exit 1 if out of sync
+    python scripts/sync_tag_type_enum.py --ontology X --schema Y  # custom paths
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+# Default paths relative to repository root
+DEFAULT_ONTOLOGY = Path("linkml/openlabel-v2/openlabel-v2.yaml")
+DEFAULT_SCHEMA = Path("linkml/openlabel-v2/openlabel-v2-schema.yaml")
+
+
+def extract_tag_types(ontology_path: Path) -> tuple[list[str], dict[str, str]]:
+    """Extract all valid tag.type values from the ontology model.
+
+    Returns:
+        Tuple of (yaml_lines, stats) where yaml_lines is the TagTypeEnum YAML
+        fragment and stats is a dict of category counts.
+    """
+    with open(ontology_path) as f:
+        model = yaml.safe_load(f)
+
+    enums = model.get("enums", {})
+    slots = model.get("slots", {})
+
+    # Admin slots
+    admin_slots = model["classes"].get("AdminTag", {}).get("slots", [])
+
+    # All enum permissible values (to detect overlaps with boolean flags)
+    all_enum_values: set[str] = set()
+    for edef in enums.values():
+        all_enum_values.update(edef.get("permissible_values", {}).keys())
+
+    # Enum-typed slots (slot names that take enum values — valid tag types in v1)
+    enum_names = set(enums.keys())
+    enum_slots = [
+        sname for sname, sdef in slots.items() if sdef.get("range") in enum_names
+    ]
+
+    # Boolean flags — exclude those already in enum values to avoid duplicate keys
+    bool_flags = [
+        sname
+        for sname, sdef in slots.items()
+        if sdef.get("range") == "boolean"
+        and sname not in all_enum_values
+        and sname not in set(enum_slots)
+    ]
+
+    # Build YAML lines
+    lines: list[str] = []
+    lines.append("  TagTypeEnum:")
+    lines.append("    description: >-")
+    lines.append(
+        "      All valid values for the tag.type field in ASAM OpenLABEL v1 format"
+    )
+    lines.append(
+        "      files. Derived from the openlabel-v2 ontology vocabulary (classes,"
+    )
+    lines.append("      enums, slots). AUTO-GENERATED — do not edit manually.")
+    lines.append("    permissible_values:")
+
+    # Structural classes
+    lines.append("      # --- Structural class types ---")
+    for c in ["Tag", "AdminTag", "Odd", "Behaviour", "RoadUser"]:
+        lines.append(f"      {c}:")
+        lines.append("        description: Structural class type")
+
+    # Admin properties
+    lines.append("      # --- Administration tag properties ---")
+    for s in sorted(admin_slots):
+        lines.append(f"      {s}:")
+        lines.append("        description: Administration tag property")
+
+    # Boolean flags
+    lines.append("      # --- Boolean flag tags (ODD/Behaviour) ---")
+    for s in sorted(bool_flags):
+        lines.append(f"      {s}:")
+        lines.append("        description: Boolean ODD/Behaviour flag")
+
+    # Enum-typed slot names
+    lines.append("      # --- Enum category tags (slot names with enum ranges) ---")
+    for s in sorted(enum_slots):
+        slot_range = slots[s].get("range", "")
+        lines.append(f"      {s}:")
+        lines.append(
+            f"        description: Enum category tag (takes values from {slot_range})"
+        )
+
+    # Enum values by family
+    for ename in sorted(enums.keys()):
+        pvs = enums[ename].get("permissible_values", {})
+        lines.append(f"      # --- {ename} ---")
+        for pv in sorted(pvs.keys()):
+            lines.append(f"      {pv}:")
+            desc = pvs[pv].get("description", "")
+            if desc:
+                desc_clean = desc.replace('"', '\\"')
+                lines.append(f'        description: "{desc_clean}"')
+
+    # Stats
+    all_types: set[str] = set()
+    all_types.update(["Tag", "AdminTag", "Odd", "Behaviour", "RoadUser"])
+    all_types.update(admin_slots)
+    all_types.update(bool_flags)
+    all_types.update(enum_slots)
+    for edef in enums.values():
+        all_types.update(edef.get("permissible_values", {}).keys())
+
+    stats = {
+        "total": str(len(all_types)),
+        "structural_classes": "5",
+        "admin_properties": str(len(admin_slots)),
+        "boolean_flags": str(len(bool_flags)),
+        "enum_category_slots": str(len(enum_slots)),
+        "enum_leaf_values": str(
+            sum(len(e.get("permissible_values", {})) for e in enums.values())
+        ),
+    }
+
+    return lines, stats
+
+
+def update_schema(schema_path: Path, enum_lines: list[str]) -> bool:
+    """Replace the TagTypeEnum section in the schema YAML.
+
+    Returns:
+        True if the file was changed, False if already up to date.
+    """
+    content = schema_path.read_text(encoding="utf-8")
+
+    # Find the TagTypeEnum block boundaries
+    marker_start = "  TagTypeEnum:"
+    start_idx = content.find(marker_start)
+    if start_idx == -1:
+        raise ValueError(f"Could not find '{marker_start}' in {schema_path}")
+
+    # Find the end of the TagTypeEnum block (next top-level enum or end of file)
+    lines = content[start_idx:].split("\n")
+    end_offset = 0
+    in_enum = False
+    for i, line in enumerate(lines):
+        if i == 0:
+            in_enum = True
+            continue
+        # A line at indentation level 2 (or less) that isn't empty marks the end
+        stripped = line.rstrip()
+        if stripped and not stripped.startswith(" " * 6) and not stripped.startswith(
+            "    "
+        ):
+            # This is at enum level or higher — we've left TagTypeEnum
+            end_offset = i
+            break
+        if (
+            in_enum
+            and stripped
+            and not stripped.startswith("#")
+            and len(stripped) > 0
+        ):
+            # Check if this is a new enum at level 2 (2 spaces)
+            if stripped.startswith("  ") and not stripped.startswith(
+                "    "
+            ):
+                if stripped != marker_start.strip():
+                    end_offset = i
+                    break
+
+    if end_offset == 0:
+        # TagTypeEnum goes to end of file
+        new_content = content[:start_idx] + "\n".join(enum_lines) + "\n"
+    else:
+        remaining = "\n".join(lines[end_offset:])
+        new_content = content[:start_idx] + "\n".join(enum_lines) + "\n" + remaining
+
+    if new_content == content:
+        return False
+
+    schema_path.write_text(new_content, encoding="utf-8")
+    return True
+
+
+def main() -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Sync TagTypeEnum from ontology model to structural schema."
+    )
+    parser.add_argument(
+        "--ontology",
+        type=Path,
+        default=DEFAULT_ONTOLOGY,
+        help=f"Path to ontology model YAML (default: {DEFAULT_ONTOLOGY})",
+    )
+    parser.add_argument(
+        "--schema",
+        type=Path,
+        default=DEFAULT_SCHEMA,
+        help=f"Path to structural schema YAML (default: {DEFAULT_SCHEMA})",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Dry run: exit 1 if enum is out of sync, 0 if up to date.",
+    )
+    args = parser.parse_args()
+
+    if not args.ontology.exists():
+        print(f"ERROR: Ontology model not found: {args.ontology}", file=sys.stderr)
+        return 1
+    if not args.schema.exists():
+        print(f"ERROR: Schema model not found: {args.schema}", file=sys.stderr)
+        return 1
+
+    enum_lines, stats = extract_tag_types(args.ontology)
+    print(
+        f"TagTypeEnum: {stats['total']} values "
+        f"({stats['structural_classes']} classes, "
+        f"{stats['admin_properties']} admin, "
+        f"{stats['boolean_flags']} boolean, "
+        f"{stats['enum_category_slots']} enum slots, "
+        f"{stats['enum_leaf_values']} enum values)"
+    )
+
+    if args.check:
+        # Read current content and compare
+        content = args.schema.read_text(encoding="utf-8")
+        expected_block = "\n".join(enum_lines)
+        if expected_block in content:
+            print("TagTypeEnum is up to date.")
+            return 0
+        else:
+            print("TagTypeEnum is OUT OF SYNC — run without --check to update.")
+            return 1
+
+    changed = update_schema(args.schema, enum_lines)
+    if changed:
+        print(f"Updated TagTypeEnum in {args.schema}")
+    else:
+        print("TagTypeEnum already up to date — no changes needed.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_openlabel_schema.py
+++ b/tests/unit/test_openlabel_schema.py
@@ -1,0 +1,487 @@
+#!/usr/bin/env python3
+"""Tests for the OpenLABEL v2 structural schema and related scripts.
+
+Tests cover:
+    1. JSON Schema generation from LinkML structural model
+    2. Schema validation of spec examples (functional equivalence)
+    3. TagTypeEnum sync script correctness
+    4. v1→v2 converter correctness
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+ROOT_DIR = Path(__file__).parent.parent.parent.resolve()
+SCHEMA_YAML = ROOT_DIR / "linkml" / "openlabel-v2" / "openlabel-v2-schema.yaml"
+ONTOLOGY_YAML = ROOT_DIR / "linkml" / "openlabel-v2" / "openlabel-v2.yaml"
+SYNC_SCRIPT = ROOT_DIR / "scripts" / "sync_tag_type_enum.py"
+CONVERT_SCRIPT = ROOT_DIR / "scripts" / "convert_openlabel_v1_to_v2.py"
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture(scope="module")
+def generated_schema() -> dict:
+    """Generate JSON Schema from the structural LinkML model."""
+    result = subprocess.run(
+        [sys.executable, "-m", "linkml.generators.jsonschemagen", str(SCHEMA_YAML)],
+        capture_output=True,
+        text=True,
+        cwd=str(ROOT_DIR),
+    )
+    assert result.returncode == 0, f"gen-json-schema failed: {result.stderr}"
+    return json.loads(result.stdout)
+
+
+# =============================================================================
+# Test instances (ASAM v1 format)
+# =============================================================================
+
+VALID_MINIMAL = {
+    "openlabel": {
+        "metadata": {"schema_version": "1.0.0"},
+        "ontologies": {
+            "0": {
+                "uri": "https://openlabel.asam.net/V1-0-0/ontologies/openlabel_ontology_scenario_tags.ttl"
+            }
+        },
+        "tags": {
+            "0": {"type": "RoadTypeMinor", "ontology_uid": "0"},
+            "1": {"type": "HorizontalStraights", "ontology_uid": "0"},
+        },
+    }
+}
+
+VALID_FULL_SCENARIO = {
+    "openlabel": {
+        "metadata": {
+            "schema_version": "1.0.0",
+            "tagged_file": "../resources/scenarios/scenario123.osc",
+        },
+        "ontologies": {
+            "0": {
+                "uri": "https://openlabel.asam.net/V1-0-0/ontologies/openlabel_ontology_scenario_tags.ttl",
+                "boundary_list": [
+                    "DrivableAreaSigns",
+                    "DrivableAreaEdge",
+                    "DrivableAreaSurface",
+                ],
+                "boundary_mode": "exclude",
+            }
+        },
+        "tags": {
+            "0": {"type": "RoadTypeMinor", "ontology_uid": "0"},
+            "1": {"type": "HorizontalStraights", "ontology_uid": "0"},
+            "3": {"type": "LaneTypeTraffic", "ontology_uid": "0"},
+            "4": {"type": "ZoneSchool", "ontology_uid": "0"},
+            "5": {"type": "IntersectionCrossroad", "ontology_uid": "0"},
+            "7": {
+                "type": "WeatherWind",
+                "ontology_uid": "0",
+                "tag_data": {"vec": [{"type": "range", "val": ["10", "25"]}]},
+            },
+            "11": {"type": "VehicleCar", "ontology_uid": "0"},
+            "13": {"type": "MotionDrive", "ontology_uid": "0"},
+            "15": {
+                "type": "scenarioUniqueReference",
+                "ontology_uid": "0",
+                "tag_data": {
+                    "text": [{"type": "value", "val": "c133241e-f325-11eb"}]
+                },
+            },
+        },
+    }
+}
+
+VALID_NUMERIC = {
+    "openlabel": {
+        "metadata": {"schema_version": "1.0.0"},
+        "ontologies": {
+            "0": {"uri": "https://openlabel.asam.net/V1-0-0/ontologies/openlabel.ttl"}
+        },
+        "tags": {
+            "0": {
+                "type": "WeatherRain",
+                "ontology_uid": "0",
+                "tag_data": {"num": [{"type": "value", "val": 3.1}]},
+            }
+        },
+    }
+}
+
+INVALID_NO_METADATA = {
+    "openlabel": {"tags": {"0": {"type": "WeatherRain", "ontology_uid": "0"}}}
+}
+
+INVALID_NO_TAG_TYPE = {
+    "openlabel": {
+        "metadata": {"schema_version": "1.0.0"},
+        "tags": {"0": {"ontology_uid": "0"}},
+    }
+}
+
+INVALID_WRONG_TAG_TYPE = {
+    "openlabel": {
+        "metadata": {"schema_version": "1.0.0"},
+        "ontologies": {"0": {"uri": "https://example.org/ont"}},
+        "tags": {"0": {"type": "CompletelyFakeTag", "ontology_uid": "0"}},
+    }
+}
+
+INVALID_WRONG_BOUNDARY_MODE = {
+    "openlabel": {
+        "metadata": {"schema_version": "1.0.0"},
+        "ontologies": {
+            "0": {"uri": "https://x.org/o", "boundary_mode": "something_invalid"}
+        },
+        "tags": {},
+    }
+}
+
+INVALID_NUM_VAL_STRING = {
+    "openlabel": {
+        "metadata": {"schema_version": "1.0.0"},
+        "tags": {
+            "0": {
+                "type": "WeatherRain",
+                "ontology_uid": "0",
+                "tag_data": {"num": [{"val": "not_a_number"}]},
+            }
+        },
+    }
+}
+
+
+# =============================================================================
+# Schema Generation Tests
+# =============================================================================
+
+
+class TestSchemaGeneration:
+    """Tests for JSON Schema generation from LinkML model."""
+
+    def test_schema_generates_successfully(self, generated_schema: dict) -> None:
+        """JSON Schema generation should succeed."""
+        assert "$defs" in generated_schema
+        assert "properties" in generated_schema
+
+    def test_schema_has_openlabel_root(self, generated_schema: dict) -> None:
+        """Schema should have OpenLabelFile as root with 'openlabel' property."""
+        assert "openlabel" in generated_schema["properties"]
+
+    def test_schema_has_required_defs(self, generated_schema: dict) -> None:
+        """Schema should contain all expected definition types."""
+        defs = generated_schema["$defs"]
+        expected = [
+            "Attributes",
+            "BooleanVal",
+            "Metadata",
+            "NumVal",
+            "OpenLabel",
+            "TagData",
+            "TextVal",
+            "VecVal",
+        ]
+        for name in expected:
+            assert name in defs, f"Missing definition: {name}"
+
+    def test_tag_type_enum_values(self, generated_schema: dict) -> None:
+        """TagEntry should constrain tag.type to enum values."""
+        # Find TagEntry definition (may have __identifier_optional suffix)
+        tag_defs = [
+            k for k in generated_schema["$defs"] if k.startswith("TagEntry")
+        ]
+        assert len(tag_defs) > 0, "No TagEntry definition found"
+        tag_def = generated_schema["$defs"][tag_defs[0]]
+        tag_type_prop = tag_def["properties"]["type"]
+
+        # The enum may be inline or referenced via $ref
+        if "enum" in tag_type_prop:
+            enum_values = tag_type_prop["enum"]
+        elif "$ref" in tag_type_prop:
+            ref = tag_type_prop["$ref"]
+            ref_name = ref.split("/")[-1]
+            assert ref_name in generated_schema["$defs"], (
+                f"Referenced enum {ref_name} not in $defs"
+            )
+            enum_def = generated_schema["$defs"][ref_name]
+            enum_values = enum_def.get("enum", [])
+        else:
+            pytest.fail("tag.type has no enum constraint (inline or via $ref)")
+
+        # Should contain known ontology values
+        assert "WeatherRain" in enum_values
+        assert "RoadTypeMinor" in enum_values
+        assert "VehicleCar" in enum_values
+        assert "scenarioName" in enum_values
+        assert len(enum_values) >= 200
+
+    def test_boundary_mode_enum(self, generated_schema: dict) -> None:
+        """OntologyEntry should constrain boundary_mode to enum values."""
+        ont_defs = [
+            k for k in generated_schema["$defs"] if k.startswith("OntologyEntry")
+        ]
+        assert len(ont_defs) > 0
+        ont_def = generated_schema["$defs"][ont_defs[0]]
+        bm = ont_def["properties"]["boundary_mode"]
+        # Should have enum constraint (may be in anyOf or directly)
+        if "enum" in bm:
+            assert "include" in bm["enum"]
+            assert "exclude" in bm["enum"]
+        elif "anyOf" in bm:
+            enum_found = False
+            for opt in bm["anyOf"]:
+                if "enum" in opt:
+                    assert "include" in opt["enum"]
+                    enum_found = True
+            assert enum_found
+
+
+# =============================================================================
+# Schema Validation Tests (Functional Equivalence)
+# =============================================================================
+
+
+class TestSchemaValidation:
+    """Tests that the generated schema validates ASAM v1 format files correctly."""
+
+    def test_valid_minimal(self, generated_schema: dict) -> None:
+        """Minimal valid tagging file should pass."""
+        jsonschema.validate(VALID_MINIMAL, generated_schema)
+
+    def test_valid_full_scenario(self, generated_schema: dict) -> None:
+        """Full scenario from spec §8.8.1 should pass."""
+        jsonschema.validate(VALID_FULL_SCENARIO, generated_schema)
+
+    def test_valid_numeric_tag_data(self, generated_schema: dict) -> None:
+        """Numeric tag_data should pass."""
+        jsonschema.validate(VALID_NUMERIC, generated_schema)
+
+    def test_invalid_missing_metadata(self, generated_schema: dict) -> None:
+        """Missing metadata should be rejected."""
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(INVALID_NO_METADATA, generated_schema)
+
+    def test_invalid_missing_tag_type(self, generated_schema: dict) -> None:
+        """Missing tag.type should be rejected."""
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(INVALID_NO_TAG_TYPE, generated_schema)
+
+    def test_invalid_wrong_tag_type_rejected(self, generated_schema: dict) -> None:
+        """Invalid tag.type value should be rejected (vocabulary constraint)."""
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(INVALID_WRONG_TAG_TYPE, generated_schema)
+
+    def test_invalid_boundary_mode_rejected(self, generated_schema: dict) -> None:
+        """Invalid boundary_mode should be rejected."""
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(INVALID_WRONG_BOUNDARY_MODE, generated_schema)
+
+    def test_invalid_num_val_string_rejected(self, generated_schema: dict) -> None:
+        """String value for num.val should be rejected."""
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(INVALID_NUM_VAL_STRING, generated_schema)
+
+
+# =============================================================================
+# TagTypeEnum Sync Script Tests
+# =============================================================================
+
+
+class TestSyncTagTypeEnum:
+    """Tests for the TagTypeEnum synchronization script."""
+
+    @pytest.mark.skipif(
+        not SYNC_SCRIPT.exists(), reason="sync script not found"
+    )
+    def test_check_mode_passes(self) -> None:
+        """Sync script --check should pass when enum is up to date."""
+        result = subprocess.run(
+            [sys.executable, str(SYNC_SCRIPT), "--check"],
+            capture_output=True,
+            text=True,
+            cwd=str(ROOT_DIR),
+        )
+        assert result.returncode == 0, (
+            f"TagTypeEnum is out of sync. "
+            f"Run: python scripts/sync_tag_type_enum.py\n{result.stdout}"
+        )
+
+    @pytest.mark.skipif(
+        not SYNC_SCRIPT.exists(), reason="sync script not found"
+    )
+    def test_enum_count_matches_ontology(self) -> None:
+        """TagTypeEnum should have the expected number of values."""
+        import yaml
+
+        with open(ONTOLOGY_YAML) as f:
+            model = yaml.safe_load(f)
+
+        enums = model.get("enums", {})
+        slots = model.get("slots", {})
+        enum_names = set(enums.keys())
+
+        all_enum_values: set[str] = set()
+        for edef in enums.values():
+            all_enum_values.update(edef.get("permissible_values", {}).keys())
+
+        enum_slots = {
+            sname
+            for sname, sdef in slots.items()
+            if sdef.get("range") in enum_names
+        }
+
+        bool_flags = {
+            sname
+            for sname, sdef in slots.items()
+            if sdef.get("range") == "boolean"
+            and sname not in all_enum_values
+            and sname not in enum_slots
+        }
+
+        admin_slots = set(
+            model["classes"].get("AdminTag", {}).get("slots", [])
+        )
+
+        expected_count = (
+            5  # structural classes
+            + len(admin_slots)
+            + len(bool_flags)
+            + len(enum_slots)
+            + len(all_enum_values)
+        )
+
+        # Verify the schema YAML has this count
+        with open(SCHEMA_YAML) as f:
+            schema = yaml.safe_load(f)
+        actual_count = len(
+            schema["enums"]["TagTypeEnum"]["permissible_values"]
+        )
+        assert actual_count == expected_count, (
+            f"TagTypeEnum has {actual_count} values, expected {expected_count}"
+        )
+
+
+# =============================================================================
+# v1→v2 Converter Tests
+# =============================================================================
+
+
+class TestV1ToV2Converter:
+    """Tests for the ASAM v1→v2 format converter."""
+
+    @pytest.mark.skipif(
+        not CONVERT_SCRIPT.exists(), reason="converter script not found"
+    )
+    def test_converter_produces_valid_jsonld(self, tmp_path: Path) -> None:
+        """Converter output should be valid JSON with @context."""
+        input_file = tmp_path / "input.json"
+        input_file.write_text(json.dumps(VALID_MINIMAL))
+
+        result = subprocess.run(
+            [sys.executable, str(CONVERT_SCRIPT), str(input_file)],
+            capture_output=True,
+            text=True,
+            cwd=str(ROOT_DIR),
+        )
+        assert result.returncode == 0, f"Converter failed: {result.stderr}"
+        output = json.loads(result.stdout)
+        assert "@context" in output
+        assert "@type" in output
+        assert output["@type"] == "Tag"
+
+    @pytest.mark.skipif(
+        not CONVERT_SCRIPT.exists(), reason="converter script not found"
+    )
+    def test_converter_maps_boolean_flags(self, tmp_path: Path) -> None:
+        """Boolean tag types should map to True values in v2."""
+        v1_data = {
+            "openlabel": {
+                "metadata": {"schema_version": "1.0.0"},
+                "ontologies": {"0": {"uri": "https://example.org/ont"}},
+                "tags": {
+                    "0": {"type": "WeatherRain", "ontology_uid": "0"},
+                    "1": {"type": "MotionDrive", "ontology_uid": "0"},
+                },
+            }
+        }
+        input_file = tmp_path / "input.json"
+        input_file.write_text(json.dumps(v1_data))
+
+        result = subprocess.run(
+            [sys.executable, str(CONVERT_SCRIPT), str(input_file)],
+            capture_output=True,
+            text=True,
+            cwd=str(ROOT_DIR),
+        )
+        output = json.loads(result.stdout)
+        assert output.get("Odd", {}).get("WeatherRain") is True
+        assert output.get("Behaviour", {}).get("MotionDrive") is True
+
+    @pytest.mark.skipif(
+        not CONVERT_SCRIPT.exists(), reason="converter script not found"
+    )
+    def test_converter_maps_enum_values(self, tmp_path: Path) -> None:
+        """Enum tag values should map to their slot with value."""
+        v1_data = {
+            "openlabel": {
+                "metadata": {"schema_version": "1.0.0"},
+                "ontologies": {"0": {"uri": "https://example.org/ont"}},
+                "tags": {
+                    "0": {"type": "RoadTypeMinor", "ontology_uid": "0"},
+                    "1": {"type": "VehicleCar", "ontology_uid": "0"},
+                },
+            }
+        }
+        input_file = tmp_path / "input.json"
+        input_file.write_text(json.dumps(v1_data))
+
+        result = subprocess.run(
+            [sys.executable, str(CONVERT_SCRIPT), str(input_file)],
+            capture_output=True,
+            text=True,
+            cwd=str(ROOT_DIR),
+        )
+        output = json.loads(result.stdout)
+        assert output.get("Odd", {}).get("DrivableAreaType") == "RoadTypeMinor"
+        assert output.get("RoadUser", {}).get("RoadUserVehicle") == "VehicleCar"
+
+    @pytest.mark.skipif(
+        not CONVERT_SCRIPT.exists(), reason="converter script not found"
+    )
+    def test_converter_maps_admin_tags(self, tmp_path: Path) -> None:
+        """Admin tags with text values should map correctly."""
+        v1_data = {
+            "openlabel": {
+                "metadata": {"schema_version": "1.0.0"},
+                "ontologies": {"0": {"uri": "https://example.org/ont"}},
+                "tags": {
+                    "0": {
+                        "type": "scenarioName",
+                        "ontology_uid": "0",
+                        "tag_data": {
+                            "text": [{"type": "value", "val": "My Scenario"}]
+                        },
+                    }
+                },
+            }
+        }
+        input_file = tmp_path / "input.json"
+        input_file.write_text(json.dumps(v1_data))
+
+        result = subprocess.run(
+            [sys.executable, str(CONVERT_SCRIPT), str(input_file)],
+            capture_output=True,
+            text=True,
+            cwd=str(ROOT_DIR),
+        )
+        output = json.loads(result.stdout)
+        assert output.get("AdminTag", {}).get("scenarioName") == "My Scenario"


### PR DESCRIPTION
# Description

Adds a **structural LinkML schema** (`openlabel-v2-schema.yaml`) that models the ASAM OpenLABEL v1.0.0 scenario tagging JSON file format. This generates a JSON Schema that validates both file structure AND tag vocabulary — something the original ASAM schema does not do (it accepts any string as `tag.type`).

## Architecture

Two complementary LinkML schemas form a single source of truth:

| Schema | Purpose | Generates |
|--------|---------|-----------|
| `openlabel-v2.yaml` | Semantic model (tag vocabulary) | OWL, SHACL, JSON-LD context |
| `openlabel-v2-schema.yaml` | Structural model (file format) | JSON Schema for v1 format |

The bridge between them is `TagTypeEnum` — 227 valid `tag.type` values derived from the ontology's classes, slots, and enum values. Changes to the ontology automatically flow into the JSON Schema when the enum is regenerated.

## Changes

### New files
- `linkml/openlabel-v2/openlabel-v2-schema.yaml` — Structural model (12 classes, 4 enums)
- `linkml/openlabel-v2/SCHEMA_MODELING.md` — Architecture documentation
- `artifacts/openlabel-v2/openlabel-v2.schema.json` — Generated JSON Schema artifact
- `scripts/sync_tag_type_enum.py` — CLI tool to sync TagTypeEnum from ontology
- `scripts/convert_openlabel_v1_to_v2.py` — v1 JSON to v2 JSON-LD converter
- `tests/unit/test_openlabel_schema.py` — 19 pytest tests

### Modified files
- `Makefile` — Added `gen-json-schema` target (auto-detects schema model)
- `.pre-commit-config.yaml` — Added `sync-tag-type-enum` hook, extended registry/properties/readme patterns

## Versioning & Compatibility

- [ ] **Patch**
- [x] **Minor** (New functionality that is backward-compatible)
- [ ] **Major**

## Type of change

- [x] New type (non-breaking change which adds a type)
- [ ] Change
- [ ] Breaking change

## How Has This Been Tested?

- 19 pytest tests covering:
  - JSON Schema generation from LinkML model
  - Validation of spec examples (minimal, full scenario, numeric data)
  - Rejection of invalid data (missing metadata, wrong type, bad enum)
  - Vocabulary constraint (fake tag types rejected)
  - TagTypeEnum sync correctness
  - v1-to-v2 converter (boolean flags, enum values, admin tags)
- Functional equivalence: same ASAM v1 JSON files validate against both ASAM and LinkML schemas
- LinkML schema is STRICTER: catches invalid `tag.type` values that ASAM schema accepts

```bash
pytest tests/unit/test_openlabel_schema.py -v  # 19/19 passed
```

## Checklist

- [x] My code follows the modelling guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes